### PR TITLE
Add local .venv to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 __pycache__/
 
 node_modules
+.venv
 
 .11ty-vite
 


### PR DESCRIPTION
I prefer to not pollute my home folder with project-specific stuff. This change makes sure the local virtual environment is also ignored.