### PR TITLE
Bump dotnet sdk from 6 to 8 LTS

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,7 @@
 
     // Features to add to the dev container. More info: https://containers.dev/features.
 	"features": {
-		"ghcr.io/devcontainers/features/dotnet:1": {"version": "6.0"},
+		"ghcr.io/devcontainers/features/dotnet:1": {"version": "8.0"},
 		"ghcr.io/devcontainers/features/node:1": {}
 	},
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Install dotnet
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: '6.0.x'
+          dotnet-version: '8.0.x'
 
       - name: Checkout repo
         uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Depending on whether you want to author data, text or visualizations, you will n
 To start developing you need to have the following requirements on:
 
 - `node` https://nodejs.org/en/
-- `.NET 6.0` https://dotnet.microsoft.com/en-us/download
+- `.NET 8.0` https://dotnet.microsoft.com/en-us/download
 - `python 3.11` https://www.python.org/
 - `pipenv` https://pipenv.pypa.io/
 

--- a/code/Components.fsproj
+++ b/code/Components.fsproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/deployment/Dockerfile.dev.base
+++ b/deployment/Dockerfile.dev.base
@@ -1,4 +1,4 @@
-FROM bitnami/dotnet-sdk:6-debian-11 as builder
+FROM bitnami/dotnet-sdk:8-debian-11 as builder
 ARG NODE_MAJOR=20
 
 WORKDIR /build

--- a/deployment/Dockerfile.website
+++ b/deployment/Dockerfile.website
@@ -1,4 +1,4 @@
-FROM bitnami/dotnet-sdk:6-debian-11 as builder
+FROM bitnami/dotnet-sdk:8-debian-11 as builder
 ARG NODE_MAJOR=20
 
 WORKDIR /build

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.100",
+    "version": "8.0.100",
     "rollForward": "latestMinor"
   }
 }


### PR DESCRIPTION
Skip v7, as 8 is LTS and hould be supported until 2026
https://dotnet.microsoft.com/en-us/download/dotnet
https://learn.microsoft.com/en-us/dotnet/standard/frameworks
https://hub.docker.com/r/bitnami/dotnet-sdk/tags

Closes #82 