### PR TITLE
Fixed dockerfile syntax warnings

### DIFF
--- a/deployment/Dockerfile.datasette
+++ b/deployment/Dockerfile.datasette
@@ -23,4 +23,4 @@ COPY --from=builder /build/var/sqlite /datasette/sqlite
 
 EXPOSE 8001
 # TODO: remove custom setting when no longer needed
-CMD datasette serve --host 0.0.0.0 --port 8001 --cors --inspect-file sqlite/inspect-data.json --metadata sqlite/metadata.json ./sqlite/*.db  --setting max_returned_rows 150000
+CMD ["datasette", "serve", "--host", "0.0.0.0", "--port", "8001", "--cors", "--inspect-file", "sqlite/inspect-data.json", "--metadata", "sqlite/metadata.json", "./sqlite/*.db", "--setting", "max_returned_rows", "150000"]

--- a/deployment/Dockerfile.datasette
+++ b/deployment/Dockerfile.datasette
@@ -1,4 +1,4 @@
-FROM python:3.11-slim-bullseye as builder
+FROM python:3.11-slim-bullseye AS builder
 
 WORKDIR /build
 

--- a/deployment/Dockerfile.dev.base
+++ b/deployment/Dockerfile.dev.base
@@ -1,4 +1,4 @@
-FROM bitnami/dotnet-sdk:8-debian-12 as builder
+FROM bitnami/dotnet-sdk:8-debian-12 AS builder
 ARG NODE_MAJOR=20
 
 WORKDIR /build

--- a/deployment/Dockerfile.dev.website
+++ b/deployment/Dockerfile.dev.website
@@ -1,4 +1,4 @@
-FROM podnebnik/base:1.0 as builder
+FROM podnebnik/base:1.0 AS builder
 
 COPY . /build
 

--- a/deployment/Dockerfile.website
+++ b/deployment/Dockerfile.website
@@ -1,4 +1,4 @@
-FROM bitnami/dotnet-sdk:8-debian-12 as builder
+FROM bitnami/dotnet-sdk:8-debian-12 AS builder
 ARG NODE_MAJOR=20
 
 WORKDIR /build


### PR DESCRIPTION
Noticed warnings in #201:

>The 'as' keyword should match the case of the 'from' keyword
FromAsCasing: 'as' and 'FROM' keywords' casing do not match
More info: https://docs.docker.com/go/dockerfile/rule/from-as-casing/

and 
>JSON arguments recommended for ENTRYPOINT/CMD to prevent unintended behavior related to OS signals
JSONArgsRecommended: JSON arguments recommended for CMD to prevent unintended behavior related to OS signals
More info: https://docs.docker.com/go/dockerfile/rule/json-args-recommended/

