### PR TITLE
Bump python from 3.11.x to 3.12

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.12-slim
 
 RUN apt-get update && \
     apt-get install -y fish git pipenv

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
 {
 	"name": "Podnebnik",
 
-    "image": "python:3.11-slim",
+    "image": "python:3.12-slim",
 
     // Features to add to the dev container. More info: https://containers.dev/features.
 	"features": {

--- a/Pipfile
+++ b/Pipfile
@@ -17,4 +17,4 @@ frictionless = "*"
 colorama = "*"
 
 [requires]
-python_version = "3.11"
+python_version = "3.12"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -5,7 +5,7 @@
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.11"
+            "python_version": "3.12"
         },
         "sources": [
             {

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ To start developing you need to have the following requirements on:
 - `node` https://nodejs.org/en/ with `corepack` enabled
 - `yarn` https://yarnpkg.com
 - `.NET 8.0` https://dotnet.microsoft.com/en-us/download
-- `python 3.11` https://www.python.org/
+- `python 3.12` https://www.python.org/
 - `pipenv` https://pipenv.pypa.io/
 
 We suggest uou use [pyenv](https://github.com/pyenv/pyenv) to install and manage the python version(s) on your system. Once you have `pyenv` installed, the `pipenv` will automatically use it to install the correct python version.

--- a/data/temperature/sources/Pipfile
+++ b/data/temperature/sources/Pipfile
@@ -15,4 +15,4 @@ scipy = "==1.10.0"
 netcdf4 = "*"
 
 [requires]
-python_version = "3.11"
+python_version = "3.12"

--- a/data/temperature/sources/Pipfile.lock
+++ b/data/temperature/sources/Pipfile.lock
@@ -5,7 +5,7 @@
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.11"
+            "python_version": "3.12"
         },
         "sources": [
             {

--- a/deployment/Dockerfile.datasette
+++ b/deployment/Dockerfile.datasette
@@ -1,4 +1,4 @@
-FROM python:3.11-slim-bullseye AS builder
+FROM python:3.12-slim-bullseye AS builder
 
 WORKDIR /build
 
@@ -15,7 +15,7 @@ COPY tasks.py /build/
 RUN invoke create-databases
 
 # -----------------------------------------------------------------------------
-FROM python:3.11.0-slim-bullseye
+FROM python:3.12-slim-bullseye
 
 WORKDIR /datasette
 RUN pip install --no-cache datasette==0.64.0


### PR DESCRIPTION
https://devguide.python.org/versions/

motivated by #201, #153, #176...

It was tried before in https://github.com/podnebnik/website/pull/62, but had to be reverted in https://github.com/podnebnik/website/commit/924356a817a0abf1459fbe1064eac6a434fc16d9 because datasette failed to build then, which is not a problem anymore now (checked in CI since https://github.com/podnebnik/website/commit/ac8ad8020b19c8649f0596712f789fd93cd01805).

Closes #201 