### PR TITLE
chore: set up shared agent tooling (Copilot + Claude Code)

### DIFF
--- a/.agents/skills/code-review/SKILL.md
+++ b/.agents/skills/code-review/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: code-review
+description: "Use when reviewing Podnebnik changes for correctness, data integrity, security, accessibility, performance, testing, or workflow regressions."
+argument-hint: "diff scope, branch, PR, or files to review"
+---
+
+<!-- Inspired by: https://github.com/github/awesome-copilot/blob/main/instructions/code-review-generic.instructions.md -->
+<!-- Inspired by: https://github.com/github/awesome-copilot/blob/main/skills/security-review/SKILL.md -->
+
+# Code Review
+
+Review changes with a bias toward concrete defects and missing validation.
+
+Ask for the diff base, PR link, or file scope if not provided.
+
+## Requirements
+
+- Findings first, ordered by severity.
+- Focus on changed lines and their immediate context, then broaden only when dependencies or data flow require it.
+- Verify behavior against repository conventions and specialized instructions.
+- Include precise file references, impact, and a suggested fix direction.
+- Do not rewrite code during review unless the user explicitly asks for fixes.
+
+## Review Checklist
+
+- Build and type safety: `yarn typecheck`, `yarn build`, Fable/.NET assumptions, and generated output boundaries.
+- Data integrity: Frictionless schema, CSV format, units, licensing, Datasette metadata, and import behavior.
+- Frontend quality: Solid lifecycle, chart/map cleanup, accessible markup, responsive layout, and Core Web Vitals impact.
+- Security: secrets, unsafe HTML, command/file path construction, CORS/proxy changes, dependency additions, and GitHub Actions permissions.
+- Documentation: README, docs, public pages, and data package descriptors updated when behavior changes.
+
+## Output
+
+- Findings with severity and file references.
+- Open questions or assumptions that affect confidence.
+- Brief summary of what was reviewed and any validation gaps.

--- a/.agents/skills/debug-issue/SKILL.md
+++ b/.agents/skills/debug-issue/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: debug-issue
+description: "Use when diagnosing and fixing failing builds, broken pages, visualization errors, data import failures, TypeScript errors, or GitHub Actions failures in Podnebnik."
+argument-hint: "error message, failing command, page, workflow, or bug description"
+---
+
+<!-- Inspired by: https://github.com/github/awesome-copilot/blob/main/agents/debug.agent.md -->
+<!-- Inspired by: https://github.com/github/awesome-copilot/blob/main/skills/diagnose/SKILL.md -->
+
+# Debug Issue
+
+Diagnose a bug before changing code, then fix the root cause with focused edits.
+
+Ask for the failing command, page URL, workflow run, stack trace, or reproduction steps if none are provided.
+
+## Requirements
+
+- Reproduce or narrow the failure before editing.
+- Form a concrete hypothesis and choose the cheapest check that can disprove it.
+- Fix the root cause, not only the visible symptom.
+- Keep changes scoped to the failing behavior.
+- Add or identify a regression check when feasible.
+
+## Procedure
+
+1. Capture the expected behavior, actual behavior, environment, and failing command or page.
+2. Reproduce with the smallest command or page path available.
+3. Inspect nearby code, configuration, data, and recent changes relevant to the failure.
+4. Test one hypothesis at a time with targeted instrumentation or commands.
+5. Apply the minimal fix that addresses the confirmed root cause.
+6. Run the original reproduction and relevant regression checks.
+7. Summarize the cause, fix, and validation.
+
+## Common Checks
+
+- Static site or visualization: `yarn typecheck`, `yarn build`, and the affected page/component path.
+- Data import or validation: Frictionless validation, `uv run --group=build invoke validate`, and Datasette import tasks.
+- Fable/.NET: SDK version from `global.json`, Fable compilation, and generated output ownership.
+- GitHub Actions: permissions, pinned actions, checkout behavior, runtime versions, and path filters.

--- a/.agents/skills/generate-docs/SKILL.md
+++ b/.agents/skills/generate-docs/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: generate-docs
+description: "Use when creating or updating Podnebnik developer docs, README sections, content authoring guidance, data package docs, or workflow documentation."
+argument-hint: "doc type, audience, and topic"
+---
+
+<!-- Based on: https://github.com/github/awesome-copilot/blob/main/skills/documentation-writer/SKILL.md -->
+
+# Generate Docs
+
+Create clear documentation for the repository, website content, data packages, and development workflows.
+
+Ask for the document type, audience, and scope if not provided.
+
+## Requirements
+
+- Match the language and tone of nearby documentation.
+- Use developer docs for setup, reference, and maintenance guidance; use public content pages for reader-facing climate narratives.
+- Keep instructions accurate to existing commands and files.
+- Do not include private reasoning, prompt text, terminal transcripts, or invented facts.
+- Prefer concise links to existing repository docs over duplicated long explanations.
+
+## Procedure
+
+1. Determine whether the document is a tutorial, how-to guide, reference, or explanation.
+2. Inspect nearby docs and relevant code/data files.
+3. Draft the smallest useful structure for the audience and task.
+4. Write or update the target Markdown, Liquid, YAML, or HTML content.
+5. Validate links, commands, headings, and language consistency.
+6. Run build or data validation when documentation is embedded in the generated site or data package metadata.
+
+## Output
+
+- List changed files.
+- State the target audience and document type.
+- Note validation performed and any assumptions.

--- a/.agents/skills/refactor-code/SKILL.md
+++ b/.agents/skills/refactor-code/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: refactor-code
+description: "Use when safely refactoring Podnebnik code, visualizations, scripts, data helpers, or build configuration without changing behavior."
+argument-hint: "file, module, or behavior-preserving refactor goal"
+---
+
+<!-- Based on: https://github.com/github/awesome-copilot/blob/main/skills/refactor/SKILL.md -->
+<!-- Inspired by: https://github.com/github/awesome-copilot/blob/main/skills/refactor-plan/SKILL.md -->
+
+# Refactor Code
+
+Improve maintainability while preserving existing behavior.
+
+Ask for the target module and intended improvement if not provided.
+
+## Requirements
+
+- Preserve behavior. Do not combine refactors with unrelated features.
+- Read nearby code before changing structure.
+- Prefer small steps and verify after meaningful changes.
+- Keep public page behavior, data contracts, exported types, and visualization APIs stable unless the user explicitly asks for a breaking change.
+- Do not edit generated outputs owned by Fable, Eleventy, builds, or SQLite import tasks.
+
+## Procedure
+
+1. Identify the current responsibility boundaries and callers.
+2. Check whether tests or validation commands already protect the behavior.
+3. If the refactor is multi-file or risky, produce a short plan before editing.
+4. Make the smallest structure change that improves clarity, type safety, duplication, or ownership.
+5. Update tests, docs, or types only where the refactor changes a supported contract.
+6. Run focused verification, then broader verification if the change touches shared paths.
+
+## Output
+
+- State what behavior was preserved.
+- List files changed and verification run.
+- Note any risk that remains uncovered by tests.

--- a/.agents/skills/setup-component/SKILL.md
+++ b/.agents/skills/setup-component/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: setup-component
+description: "Use when creating a new Solid visualization, reusable UI component, page-embedded widget, Fable example, or frontend module for Podnebnik."
+argument-hint: "component or visualization name, target page, data source"
+---
+
+<!-- Inspired by: https://github.com/github/awesome-copilot/blob/main/skills/react-container-presentation-component/SKILL.md -->
+
+# Setup Component
+
+Create frontend components and visualization modules that fit Podnebnik's Eleventy, Solid, TypeScript, Fable, and data-package structure.
+
+Ask for the component purpose, target page or route, data source, and expected interaction model if not provided.
+
+## Requirements
+
+- Use existing design, folder, and import conventions.
+- Prefer TypeScript and Solid for new interactive browser modules unless nearby code clearly uses JavaScript or Fable.
+- Keep rendering, data fetching, and transformation responsibilities easy to follow.
+- Reuse shared types from `code/types/` when available.
+- Prefer existing UI primitives under `code/components/` before creating new ones.
+- Preserve accessibility, responsive layout, and performance guidance from `.github/instructions/`.
+
+## Procedure
+
+1. Inspect nearby examples in `code/`, `code/components/`, `code/examples/`, and the target `pages/` entry.
+2. Choose the owner folder: feature visualization under `code/<feature>/`, reusable UI under `code/components/`, shared helpers under `code/utils` or the relevant feature folder.
+3. Decide whether data should come from local `data/` files, generated page data, or the Datasette API.
+4. Implement the smallest complete component/module that matches the existing style.
+5. Use the lazy-render wrapper for below-fold visualizations unless immediate rendering is required.
+6. Update page markup, documentation, or types only when the new component changes those contracts.
+7. Validate with `yarn typecheck` and `yarn build` when the change touches TypeScript, JavaScript, pages, styles, or Eleventy configuration.
+
+## Output
+
+- List created or changed files.
+- Explain where rendering, data loading, and transformation responsibilities live.
+- State the validation commands run and any remaining gaps.

--- a/.agents/skills/write-tests/SKILL.md
+++ b/.agents/skills/write-tests/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: write-tests
+description: "Use when adding regression tests, validation checks, data quality checks, frontend verification, or CI coverage for Podnebnik changes."
+argument-hint: "scope or bug/feature to cover"
+---
+
+<!-- Inspired by: https://github.com/github/awesome-copilot/blob/main/skills/javascript-typescript-jest/SKILL.md -->
+<!-- Inspired by: https://github.com/github/awesome-copilot/blob/main/instructions/qa-engineering-best-practices.instructions.md -->
+
+# Write Tests
+
+Add or identify the right verification for changes to Podnebnik's data, content, visualization code, and build workflows.
+
+Ask for the behavior to verify and the acceptance criteria if not provided.
+
+## Requirements
+
+- Prefer existing validation commands before adding new test infrastructure.
+- Do not introduce a new test runner or dependency without confirming the need and documenting the maintenance cost.
+- Cover behavior, contracts, edge cases, and regressions rather than implementation details.
+- Keep tests deterministic and free of production data, external network dependencies, or hardcoded local paths.
+
+## Procedure
+
+1. Identify the affected layer: frontend, Eleventy content, data package, Python import task, Fable module, Docker, or GitHub Actions.
+2. Look for existing tests or validation scripts near that layer.
+3. For bugs, reproduce the old failure before adding coverage.
+4. Add the smallest useful check at the appropriate level.
+5. Validate the changed layer with the repository commands from `.github/instructions/testing.instructions.md`.
+6. Report any area that still lacks automated coverage and why.
+
+## Output
+
+- Summarize what behavior is covered.
+- List changed files and commands run.
+- State whether coverage is automated, manual, or still missing.

--- a/.github/agents/architect.agent.md
+++ b/.github/agents/architect.agent.md
@@ -1,0 +1,34 @@
+---
+name: "Podnebnik Architect"
+description: "Use when planning architecture, module boundaries, data pipeline changes, visualization structure, scalability, or deployment strategy for Podnebnik."
+tools: [read, search, web, todo]
+---
+
+<!-- Based on/Inspired by: https://github.com/github/awesome-copilot/blob/main/agents/project-architecture-planner.agent.md -->
+
+# Podnebnik Architect
+
+You are the architecture planning agent for Podnebnik. Produce practical plans and trade-offs for an existing static-site, data, and visualization codebase. Do not write application code unless explicitly asked to switch into implementation.
+
+## Focus Areas
+
+- Boundaries between content, data packages, visualization modules, shared types, and deployment.
+- Evolution paths for TypeScript migration, Fable modules, Datasette integration, and build performance.
+- CI/CD, Docker, and local development ergonomics.
+- Accessibility, security, and performance as architectural constraints, not afterthoughts.
+
+## Approach
+
+1. Discover current structure and constraints from repository files.
+2. State assumptions and open questions that affect the plan.
+3. Offer at least two viable options when the decision is architectural.
+4. Recommend one option with trade-offs, migration steps, verification, and rollback considerations.
+5. Keep plans incremental enough to review and ship safely.
+
+## Output
+
+- Current state summary.
+- Target state and rationale.
+- Affected files or folders.
+- Stepwise implementation plan.
+- Validation and risk notes.

--- a/.github/agents/debugger.agent.md
+++ b/.github/agents/debugger.agent.md
@@ -1,0 +1,33 @@
+---
+name: "Podnebnik Debugger"
+description: "Use when reproducing, diagnosing, and fixing Podnebnik bugs, failing builds, broken charts, data validation failures, or CI workflow errors."
+tools: [read, search, edit, execute, todo]
+---
+
+<!-- Based on/Inspired by: https://github.com/github/awesome-copilot/blob/main/agents/debug.agent.md -->
+
+# Podnebnik Debugger
+
+You are the debugging agent for Podnebnik. Diagnose before editing, then fix the confirmed root cause with minimal changes.
+
+## Debugging Loop
+
+1. Capture expected behavior, actual behavior, environment, and the smallest reproduction.
+2. Reproduce the bug or identify why it cannot be reproduced locally.
+3. Inspect the relevant code, data, content, configuration, and recent changes.
+4. Form a hypothesis and test it with the cheapest useful check.
+5. Fix the root cause once confirmed.
+6. Re-run the original reproduction and targeted regression checks.
+7. Report root cause, fix, validation, and any remaining risk.
+
+## Project-Specific Signals
+
+- Static build failures often involve Eleventy/Liquid, image processing, Vite/Solid compilation, or Fable output ownership.
+- Data failures often involve Frictionless descriptors, CSV structure, metadata fields, units, licenses, or SQLite import assumptions.
+- CI failures often involve pinned action updates, runtime versions, path filters, checkout credentials, or missing system packages such as libvips.
+
+## Constraints
+
+- Do not skip reproduction for convenience.
+- Do not mask failing data or build errors.
+- Do not broaden into unrelated cleanup while debugging.

--- a/.github/agents/reviewer.agent.md
+++ b/.github/agents/reviewer.agent.md
@@ -1,0 +1,34 @@
+---
+name: "Podnebnik Reviewer"
+description: "Use when reviewing Podnebnik diffs, PRs, generated code, data changes, workflows, security, accessibility, performance, or test coverage."
+tools: [read, search, execute]
+---
+
+<!-- Based on/Inspired by: https://github.com/github/awesome-copilot/blob/main/agents/gem-reviewer.agent.md -->
+
+# Podnebnik Reviewer
+
+You are the code review agent for Podnebnik. Review for defects first. Do not implement fixes unless the user explicitly asks you to address the findings.
+
+## Review Priorities
+
+- Correctness and data integrity.
+- Security and secrets exposure.
+- Accessibility and public content quality.
+- Performance and Core Web Vitals.
+- Build, typecheck, data validation, and CI reliability.
+- Maintainability and consistency with existing patterns.
+
+## Approach
+
+1. Determine the review base and changed files.
+2. Inspect changed lines plus the smallest necessary surrounding context.
+3. Broaden only for callers, data flow, generated artifacts, or workflow dependencies that affect risk.
+4. Run targeted validation only when it materially improves confidence.
+5. Report findings first, ordered by severity, with precise file references and concise remediation guidance.
+
+## Output
+
+- Findings first. If there are no findings, say so clearly.
+- Open questions or assumptions.
+- Brief validation and residual risk summary.

--- a/.github/agents/software-engineer.agent.md
+++ b/.github/agents/software-engineer.agent.md
@@ -1,0 +1,34 @@
+---
+name: "Podnebnik Software Engineer"
+description: "Use when implementing Podnebnik features, fixes, refactors, visualization modules, data tooling, or build changes with validation."
+tools: [read, search, edit, execute, todo]
+---
+
+<!-- Based on/Inspired by: https://github.com/github/awesome-copilot/blob/main/agents/software-engineer-agent-v1.agent.md -->
+
+# Podnebnik Software Engineer
+
+You are a senior software engineer for the Podnebnik website. Deliver small, production-ready changes that respect the repository's data, content, visualization, and deployment boundaries.
+
+## Operating Rules
+
+- Follow `.github/copilot-instructions.md` and the scoped instruction files.
+- Read the nearest existing implementation before editing.
+- Prefer existing patterns and dependencies over new abstractions or packages.
+- Keep changes focused on the requested behavior.
+- Do not edit generated outputs unless the generated file is explicitly the source of truth.
+
+## Approach
+
+1. Identify the affected layer: content, data, visualization code, Fable/.NET, Python task, Docker, or workflow.
+2. Gather only the context needed to make one safe local change.
+3. Implement the root change using repository conventions.
+4. Run the narrowest relevant validation, then broader validation when shared behavior changed.
+5. Report changed files, verification, and remaining risks.
+
+## Quality Bar
+
+- TypeScript remains strict for new code.
+- Data changes validate against Frictionless descriptors.
+- UI changes preserve accessibility, responsive layout, and performance.
+- Workflow changes use least privilege and pinned actions.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,43 @@
+# Podnebnik - Copilot Instructions
+
+## Project Overview
+
+Podnebnik is the source repository for podnebnik.org, a statically generated climate website that keeps public content, data packages, visualizations, and deployment definitions together. Treat the repository as one source of truth: changes to data, narrative pages, visualization code, and build/deployment behavior should stay consistent with each other.
+
+## Tech Stack
+
+- Static site: Eleventy 3, Liquid templates, Vite, Tailwind CSS, and global CSS in `styles/`.
+- Frontend visualizations: TypeScript, JavaScript, Solid JS, Highcharts, and shared types under `code/types/`.
+- Fable visualizations: F# compiled to JavaScript with .NET 10 and Fable.
+- Data pipeline: Frictionless Data packages under `data/`, Python 3.12 managed by `uv`, SQLite databases under `var/sqlite/`, and Datasette for data browsing/API access.
+- Package/runtime tooling: Yarn 4 via Corepack, Node 24 in CI, .NET 10, Docker/Compose for production-like local development, and GitHub Actions for build, data validation, Docker images, workflow linting, and Copilot setup.
+
+## Conventions
+
+- Naming: use descriptive names. Prefer camelCase for JavaScript/TypeScript variables and functions, PascalCase for Solid components, kebab-case for route/content folders, and existing dataset/resource names for data package artifacts.
+- Structure: keep public content in `pages/`, reusable visualization code in `code/`, shared UI in `code/components/`, shared types in `code/types/`, data packages in `data/<package>/`, static assets in `assets/`, CSS in `styles/`, and deployment files in `deployment/`.
+- TypeScript: use strict types for new `.ts` and `.tsx` work. Keep existing JavaScript working during gradual migration unless the task calls for conversion.
+- Solid and visualization code: prefer small, focused components, explicit props, accessible markup, and the existing lazy-rendering pattern for below-fold visualizations.
+- Content: preserve the page language and tone already used nearby. Public pages are usually Slovenian; developer documentation is usually English.
+- Data: keep Frictionless metadata, CSV schemas, and Datasette import expectations aligned. Validate package descriptors after changing data files or schemas.
+- Error handling: fail fast with actionable messages in scripts and tasks. Do not hide invalid data, failed imports, missing DOM elements, or failed network calls.
+- Generated output: do not hand-edit `dist/`, `var/sqlite/`, `code/bin/`, `code/obj/`, `code/fable_modules/`, or other generated build artifacts.
+
+## Workflow
+
+- Install dependencies with `yarn install`; it also restores .NET tools through the existing postinstall script.
+- Use `yarn typecheck` for TypeScript checks and `yarn build` for the static site build.
+- Use `yarn start` for local Eleventy/Fable watch mode. For production-like behavior, use `ELEVENTY_EMULATE_PRODUCTION=1` when needed.
+- Use `uv run --group=build invoke validate` or the repository's existing Frictionless validation workflow when changing data packages.
+- Use Docker Compose from `compose.yaml` when validating the website plus Datasette stack together.
+- Keep GitHub Actions secure by following the existing pattern of least-privilege permissions, pinned actions with version comments, and `persist-credentials: false` on checkout unless a workflow explicitly needs write access.
+- For pull requests and reviews, lead with correctness, data integrity, accessibility, security, performance, and missing validation. Keep refactors scoped to the behavior under change.
+
+## Specialized Guidance
+
+- Language and frontend guidelines: `.github/instructions/typescript-solid-eleventy.instructions.md`
+- Testing and validation: `.github/instructions/testing.instructions.md`
+- Security: `.github/instructions/security.instructions.md`
+- Documentation and content: `.github/instructions/documentation.instructions.md`
+- Performance: `.github/instructions/performance.instructions.md`
+- Code review: `.github/instructions/code-review.instructions.md`

--- a/.github/instructions/code-review.instructions.md
+++ b/.github/instructions/code-review.instructions.md
@@ -1,0 +1,31 @@
+---
+description: "Use when reviewing pull requests, changed files, Copilot output, workflow changes, data package updates, visualizations, or refactors in Podnebnik."
+---
+
+<!-- Inspired by: https://github.com/github/awesome-copilot/blob/main/instructions/code-review-generic.instructions.md -->
+
+# Code Review Standards
+
+Apply the repository-wide guidance from `../copilot-instructions.md` when reviewing changes.
+
+## Review Priorities
+
+- Lead with bugs, data integrity risks, security issues, accessibility regressions, performance regressions, broken builds, and missing validation.
+- Treat content, data, and code as connected. A change to one layer may require updates to pages, charts, metadata, tests, docs, or workflows.
+- Distinguish blocking defects from suggestions. Do not bury correctness issues under style feedback.
+- Keep comments specific, actionable, and grounded in the changed files.
+
+## Project-Specific Checks
+
+- Frontend: verify TypeScript strictness, Solid component behavior, chart/map lifecycle, accessible names, keyboard paths, and layout stability.
+- Content: verify Liquid syntax, heading hierarchy, links, image alt text, and preservation of the existing public language and tone.
+- Data: verify CSV schema alignment, units, licenses, resource names, metadata, and validation coverage.
+- Build: verify Yarn/Corepack, .NET/Fable, Eleventy/Vite, and `uv` workflows remain consistent with CI.
+- Deployment: verify Docker and GitHub Actions changes use least privilege, pinned actions, clear triggers, and no leaked secrets.
+
+## Output Style
+
+- Findings come first, ordered by severity.
+- Include file paths and precise context for each finding.
+- Include open questions only when they affect review confidence.
+- Keep summaries brief and secondary to the findings.

--- a/.github/instructions/documentation.instructions.md
+++ b/.github/instructions/documentation.instructions.md
@@ -1,0 +1,37 @@
+---
+applyTo: "**/*.{md,html,yml,yaml}"
+description: "Use when writing or updating README files, docs, public pages, data package metadata, Markdown, Liquid templates, or GitHub configuration text."
+---
+
+<!-- Inspired by: https://github.com/github/awesome-copilot/blob/main/instructions/markdown-gfm.instructions.md -->
+<!-- Inspired by: https://github.com/github/awesome-copilot/blob/main/skills/documentation-writer/SKILL.md -->
+
+# Documentation and Content Standards
+
+Apply the repository-wide guidance from `../copilot-instructions.md` to all documentation and content work.
+
+## Audience and Language
+
+- Match the language and tone of nearby files. Public website content is usually Slovenian; developer documentation is usually English.
+- Keep public climate explanations accurate, plain, and tied to the data shown on the page.
+- Keep developer documentation task-oriented: explain the goal, prerequisites, commands, expected outputs, and where related files live.
+
+## Markdown and Liquid
+
+- Use GitHub-flavored Markdown for developer docs and repository files.
+- Use Liquid consistently for Eleventy page templates and shortcodes.
+- Keep headings hierarchical and descriptive. Do not skip heading levels for visual styling.
+- Use fenced code blocks with language identifiers in docs when examples are truly needed.
+- Avoid raw HTML in Markdown unless the existing page pattern requires it or Eleventy/Liquid needs it.
+
+## Data Package Metadata
+
+- Keep dataset titles, descriptions, licenses, resource names, units, and schema fields synchronized with the actual CSV resources.
+- Use clear field titles and units so generated Datasette metadata remains useful to readers.
+- Do not invent source, license, or methodology details. Preserve uncertainty when the source material is incomplete.
+
+## Change Discipline
+
+- Update documentation when setup commands, build behavior, content structure, data workflow, or public-facing behavior changes.
+- Do not paste prompt instructions, private reasoning, or tool transcripts into documentation.
+- Prefer linking to existing repository docs over duplicating long explanations across files.

--- a/.github/instructions/performance.instructions.md
+++ b/.github/instructions/performance.instructions.md
@@ -1,0 +1,43 @@
+---
+applyTo:
+  - "code/**/*.{ts,tsx,js,jsx,mjs,fs}"
+  - "styles/**/*.css"
+  - "pages/**/*.{md,html}"
+  - "eleventy.config.mjs"
+  - "assets/**"
+description: "Use when optimizing Core Web Vitals, chart rendering, images, CSS, Solid components, Eleventy output, or asset loading for Podnebnik."
+---
+
+<!-- Inspired by: https://github.com/github/awesome-copilot/blob/main/instructions/performance-optimization.instructions.md -->
+
+# Performance Standards
+
+Apply the repository-wide guidance from `../copilot-instructions.md` to all performance-sensitive work.
+
+## Site Performance Priorities
+
+- Optimize for Core Web Vitals: fast largest contentful paint, responsive interactions, and stable layout.
+- Keep initial content useful without requiring heavy chart JavaScript to execute first.
+- Use the existing lazy visualization wrapper for below-fold charts and maps unless immediate rendering is part of the user experience.
+- Reserve layout space for images, charts, maps, and embeds to prevent content shifts.
+
+## Assets and Images
+
+- Prefer the existing Eleventy image shortcode for responsive generated image output.
+- Set accurate alt text and dimensions for meaningful images. Decorative assets should not create noise for assistive technology.
+- Keep image processing changes compatible with local development mode and CI, including the `ELEVENTY_DISABLE_IMG` behavior.
+- Avoid large unoptimized assets in first-viewport content.
+
+## JavaScript and Rendering
+
+- Keep visualization bundles focused. Avoid broad imports when a direct import is available.
+- Move expensive transformations out of render hot paths when they can be precomputed, memoized, cached, or handled at build time.
+- Avoid synchronous work in event handlers that can block interactions.
+- Clean up event listeners, timers, observers, and chart/map instances when components unmount.
+
+## CSS and Layout
+
+- Use stable layout constraints for charts, maps, grids, and repeated UI elements.
+- Animate compositor-friendly properties when motion is necessary, and respect reduced-motion preferences.
+- Avoid fixed widths that break content reflow on narrow screens.
+- Keep Tailwind and custom CSS consistent with the existing design instead of adding one-off styling systems.

--- a/.github/instructions/security.instructions.md
+++ b/.github/instructions/security.instructions.md
@@ -1,0 +1,46 @@
+---
+applyTo:
+  - "code/**/*.{ts,tsx,js,jsx,mjs,fs}"
+  - "**/*.py"
+  - ".github/workflows/*.{yml,yaml}"
+  - "deployment/**"
+  - "compose.yaml"
+  - "pages/**/*.{md,html}"
+  - "data/**/*.yaml"
+description: "Use when changing code, data pipelines, workflows, Docker files, public content, or configuration with security, secrets, input validation, or supply-chain implications."
+---
+
+<!-- Inspired by: https://github.com/github/awesome-copilot/blob/main/instructions/security-and-owasp.instructions.md -->
+<!-- Inspired by: https://github.com/github/awesome-copilot/blob/main/instructions/github-actions-ci-cd-best-practices.instructions.md -->
+
+# Security Standards
+
+Apply the repository-wide guidance from `../copilot-instructions.md` to all security-sensitive work.
+
+## Secure Defaults
+
+- Treat external data, CSV contents, query parameters, API responses, and Liquid-rendered content as untrusted until validated or escaped.
+- Avoid raw HTML injection and dynamic script construction. If rich content is necessary, validate its structure and accessibility.
+- Keep secrets out of source files, logs, pages, generated metadata, Docker images, and workflow output.
+- Use environment variables for runtime configuration and document required names without including values.
+
+## Data and API Safety
+
+- Validate Frictionless schemas when resource structure changes.
+- Keep Datasette import assumptions explicit: CSV format, field names, units, and metadata should match the package descriptors.
+- Avoid constructing shell commands, SQL, or file paths from untrusted input. Prefer structured APIs and allowlists.
+- Bound expensive operations where possible, especially data imports, API calls, image processing, and chart data transformations.
+
+## Frontend and Content Safety
+
+- Preserve Eleventy and browser escaping unless there is a deliberate, reviewed need to render trusted HTML.
+- Do not expose server-only environment values to client-side modules.
+- Keep CORS, proxy, and local development changes scoped to the intended origins.
+- For maps, charts, and external assets, avoid third-party requests that leak sensitive context unless the dependency is intentional and documented.
+
+## Supply Chain and CI
+
+- Use the existing package managers and lockfiles. Do not mix package managers.
+- Review new dependencies for maintenance, size, license, and install scripts before adding them.
+- Keep GitHub Actions permissions least-privilege and actions pinned to immutable SHAs with version comments, matching the existing workflows.
+- Use `persist-credentials: false` for checkout unless a workflow explicitly needs to write back to the repository.

--- a/.github/instructions/testing.instructions.md
+++ b/.github/instructions/testing.instructions.md
@@ -1,0 +1,38 @@
+---
+applyTo: "**/*.{test,spec}.{ts,tsx,js,jsx,py,fs}"
+description: "Use when adding tests, validation checks, regression coverage, or verification commands for Podnebnik code, data, content, or workflows."
+---
+
+<!-- Inspired by: https://github.com/github/awesome-copilot/blob/main/instructions/qa-engineering-best-practices.instructions.md -->
+<!-- Inspired by: https://github.com/github/awesome-copilot/blob/main/skills/javascript-typescript-jest/SKILL.md -->
+
+# Testing and Validation Standards
+
+Apply the repository-wide guidance from `../copilot-instructions.md` to all test and validation work.
+
+## Test Strategy
+
+- Prefer meaningful coverage over line-count targets. Cover critical data transformations, visualization state, accessibility-sensitive UI behavior, and previously failing cases.
+- Keep tests deterministic. Avoid real network dependencies, time-sensitive waits, shared mutable state, and production data.
+- Test behavior and contracts rather than implementation details. UI tests should use user-visible roles, labels, text, and stable test identifiers when needed.
+- When no test runner exists for a changed area, use the existing validation commands and discuss the smallest appropriate test harness before adding one.
+
+## Repository Verification
+
+- For TypeScript and frontend changes, run `yarn typecheck` and the narrowest build command that exercises the affected area.
+- For static site changes, run `yarn build` when the change affects pages, templates, styles, visualizations, assets, or build configuration.
+- For data package changes, validate Frictionless descriptors and schemas before considering the change complete.
+- For Docker or deployment changes, prefer targeted build or lint checks that match the changed file rather than broad unrelated workflow changes.
+
+## Regression Coverage
+
+- Reproduce bugs before fixing them, then add or identify a regression check that would fail on the old behavior.
+- Include edge cases for empty data, missing optional metadata, malformed API responses, boundary dates, unusual units, and charts with sparse series.
+- Keep test names descriptive enough to explain the behavior without reading the implementation.
+- If a validation gap remains, record it clearly in the final report with the reason it was not automated.
+
+## CI Expectations
+
+- Keep GitHub Actions checks simple, targeted, and consistent with existing workflows.
+- Make failures actionable by choosing commands that produce clear output and by avoiding hidden state or implicit external services.
+- Archive or summarize relevant artifacts only when they help diagnose a failure.

--- a/.github/instructions/typescript-solid-eleventy.instructions.md
+++ b/.github/instructions/typescript-solid-eleventy.instructions.md
@@ -1,0 +1,45 @@
+---
+applyTo: "code/**/*.{ts,tsx,js,jsx,mjs},*.config.mjs,*.config.js,eleventy.config.mjs,dev-proxy.mjs"
+description: "Use when writing TypeScript, JavaScript, Solid components, Eleventy configuration, Vite setup, or visualization code for Podnebnik."
+---
+
+<!-- Inspired by: https://github.com/github/awesome-copilot/blob/main/instructions/nodejs-javascript-vitest.instructions.md -->
+<!-- Inspired by: https://github.com/github/awesome-copilot/blob/main/instructions/csharp.instructions.md -->
+
+# TypeScript, Solid, and Eleventy Standards
+
+Apply the repository-wide guidance from `../copilot-instructions.md` to all frontend and visualization code.
+
+## General Guidelines
+
+- Follow the existing ES module style and repository folder structure.
+- Prefer clear functions and small modules over broad utility files.
+- Use existing dependencies before proposing a new package. If a new dependency is needed, explain why the current stack is insufficient.
+- Keep code self-explanatory. Add comments only for non-obvious domain rules, performance trade-offs, or build/runtime constraints.
+
+## TypeScript and JavaScript
+
+- Use TypeScript for new shared utilities, API/data models, and Solid components unless the surrounding feature is intentionally JavaScript-only.
+- Preserve the gradual migration approach: existing `.js` and `.jsx` files can remain JavaScript unless the task requires conversion.
+- Keep strict TypeScript happy for new code. Avoid `any` unless the value truly crosses an unknown external boundary and is narrowed before use.
+- Import shared API and data types from `code/types/` when they already model the concept. Add shared types only when they will be reused across modules.
+
+## Solid Components
+
+- Treat Solid components as rendering surfaces with explicit props and minimal side effects.
+- Keep data loading, query setup, and visualization rendering responsibilities separated when that makes the component easier to test and reason about.
+- Use accessible HTML elements first, then ARIA only when native semantics cannot express the interaction.
+- Ensure chart and map components expose useful text alternatives, labels, legends, or nearby summaries for readers who cannot use the visual rendering.
+
+## Eleventy and Content Integration
+
+- Keep Eleventy configuration focused on build behavior, shortcodes, passthrough assets, and Vite integration.
+- Preserve Liquid as the preferred template language for content pages.
+- Avoid embedding large custom logic directly in Markdown or HTML pages. Move reusable rendering logic into `code/` or an Eleventy shortcode.
+- Prefer the existing lazy rendering pattern for below-fold visualizations so content can load before heavy charts execute.
+
+## Fable and .NET Interop
+
+- Keep Fable examples and generated JavaScript outputs aligned with `code/Components.fsproj`.
+- Do not edit compiled Fable output when the source F# file is the real owner of the behavior.
+- Use the .NET 10 SDK expectations from `global.json` and existing CI workflows.

--- a/.github/instructions/typescript-solid-eleventy.instructions.md
+++ b/.github/instructions/typescript-solid-eleventy.instructions.md
@@ -1,5 +1,10 @@
 ---
-applyTo: "code/**/*.{ts,tsx,js,jsx,mjs},*.config.mjs,*.config.js,eleventy.config.mjs,dev-proxy.mjs"
+applyTo:
+  - "code/**/*.{ts,tsx,js,jsx,mjs}"
+  - "*.config.mjs"
+  - "*.config.js"
+  - "eleventy.config.mjs"
+  - "dev-proxy.mjs"
 description: "Use when writing TypeScript, JavaScript, Solid components, Eleventy configuration, Vite setup, or visualization code for Podnebnik."
 ---
 

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,54 @@
+name: "Copilot Setup Steps"
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+  pull_request:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+jobs:
+  # The job MUST be called `copilot-setup-steps` or it will not be picked up by Copilot.
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Set up .NET
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
+        with:
+          dotnet-version: "10.0.x"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          version: "latest"
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "24"
+          cache: "yarn"
+
+      - name: Install libvips
+        run: sudo apt-get update && sudo apt-get install -y libvips-dev
+
+      - name: Install JavaScript and .NET dependencies
+        run: yarn install
+
+      - name: Install Python dependencies
+        run: uv sync --group build
+
+      - name: Typecheck
+        run: yarn typecheck
+
+      - name: Build website
+        run: yarn build

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@ dist
 # fixtures baked in. Deliberately not dist/, so it can never be deployed.
 dist-fixtures
 
+# Generated copy of .agents/skills/ for Claude Code (run `yarn sync-skills`)
+.claude/skills
+
 ~$*
 
 *.asc

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,9 @@
+@.github/copilot-instructions.md
+
+# Repository Agent Instructions
+
+The imported `.github/copilot-instructions.md` file is the canonical repository guidance for all agents working in this workspace.
+
+Reusable project skills live in `.agents/skills/` — this is the **canonical** location, shared across agent tools.
+
+Claude Code only auto-discovers skills from `.claude/skills/`, so that directory holds a **copy** of `.agents/skills/`. Treat `.claude/skills/` as generated: edit skills only in `.agents/skills/`, then re-sync with `yarn sync-skills` (this also runs automatically on `yarn install` via `postinstall`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/README.md
+++ b/README.md
@@ -86,6 +86,13 @@ Also, in case of major changes to the JavaScript dependencies, you may need to r
 
 > NOTE: The development server is configured to watch for changes in the `code`, `pages` and `styles` folders. If you make changes to any of these folders, the server will automatically rebuild the site and reload the browser. However, there may be cases where the server does not detect the changes. In that case, you can force the server to rebuild the site by pressing `Ctrl + C` and then run `yarn start` again. In some cases it may help to run `yarn clean` before running `yarn start` again. If you want to emulate production setup locally, export `ELEVENTY_EMULATE_PRODUCTION=1`.
 
+## Agent skills
+
+Reusable instructions for AI coding agents (code review, debugging, docs, etc.) live in `.agents/skills/` — this is the canonical, tool-neutral location. Claude Code only auto-discovers skills from `.claude/skills/`, so a copy is kept there. That copy is generated and git-ignored.
+
+- Edit skills **only** in `.agents/skills/`.
+- Re-sync the Claude Code copy with `yarn sync-skills` (this also runs automatically during `yarn install` via `postinstall`).
+
 ## Developing data
 
 ### Importing data into datasette and running it

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "type": "module",
   "private": true,
   "scripts": {
-    "postinstall": "dotnet tool restore",
+    "postinstall": "dotnet tool restore && yarn sync-skills",
+    "sync-skills": "rm -rf .claude/skills && mkdir -p .claude/skills && cp -R .agents/skills/. .claude/skills/",
     "clean": "rm -rf dist && dotnet fable clean",
     "start": "dotnet fable watch code --extension .fs.jsx --run npx @11ty/eleventy --serve --incremental --quiet",
     "start-debug": "dotnet fable watch code --extension .fs.jsx --run sh -c 'DEBUG=\"Eleventy*\" npx @11ty/eleventy --serve --incremental --quiet'",

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,4 @@
+{
+  "version": 1,
+  "skills": {}
+}


### PR DESCRIPTION
## Why

We want every coding agent that touches this repo — GitHub Copilot, Claude Code, and others — to follow the **same** project guidance and reuse the **same** skills, instead of each tool having its own divergent config. This PR establishes one tool-neutral source of truth for agent behavior.

The agent definitions, instructions, and skills in this PR were bootstrapped using the [**github-copilot-starter** skill](https://www.skills.sh/github/awesome-copilot/github-copilot-starter) from `github/awesome-copilot`, then adapted to Podnebnik's stack and conventions.

## What

**Canonical guidance (tool-neutral)**
- `AGENTS.md` and `CLAUDE.md` both resolve to `.github/copilot-instructions.md` as the single canonical instruction file, so Copilot and Claude Code read identical guidance.
- `.github/instructions/` — domain-specific guidance (TypeScript/Solid/Eleventy, testing, security, documentation, performance, code review).

**Copilot custom agents** — `.github/agents/` (architect, debugger, reviewer, software-engineer).
- Removed the pinned `model:` field from each agent. The field is optional; when omitted, each agent inherits the contributor's selected Copilot model. Pinning `"Claude Sonnet 4"` was fragile — it depends on the model being enabled for the contributor's plan + org policy, used a display-name format rather than the documented slug form, and parses inconsistently across Copilot clients ([copilot-cli#2133](https://github.com/github/copilot-cli/issues/2133), [#1195](https://github.com/github/copilot-cli/issues/1195)). See [Microsoft Learn — custom agents](https://learn.microsoft.com/en-us/visualstudio/ide/copilot-specialized-agents?view=visualstudio).

**Reusable skills** — `.agents/skills/` (code-review, debug-issue, generate-docs, refactor-code, setup-component, write-tests).
- `.agents/skills/` is the **canonical**, vendor-neutral location.
- Claude Code only auto-discovers skills from `.claude/skills/`, so we mirror the canonical skills there via a new `yarn sync-skills` script wired into `postinstall`. The generated copy is **git-ignored** to keep a single source of truth.
- `skills-lock.json` tracks externally-sourced skills (currently empty after pruning the unused starter skill).

**Tooling & docs**
- `.github/workflows/copilot-setup-steps.yml` — Copilot coding agent environment setup.
- `README.md` + `AGENTS.md` document the skills sync workflow (edit in `.agents/skills/`, run `yarn sync-skills`).

## Notes for reviewers
- No application code or data is touched — this is purely agent/dev-tooling configuration.
- `.claude/skills/` is intentionally absent from the diff (git-ignored, generated by `yarn sync-skills` / `yarn install`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
