### PR TITLE
T-4.6: replace live-wrong ARSO explain string (national/default view)

### DIFF
--- a/code/ali-je-vroce-era5/components/TodayCard.tsx
+++ b/code/ali-je-vroce-era5/components/TodayCard.tsx
@@ -46,6 +46,20 @@ function catDesc(catKey: string, r: TodayStatus): string {
     .replace("{record_years}", String(yearMax - yearMin + 1));
 }
 
+// National/default view = unweighted mean of the ERA5 stations (D-7,
+// "povprečje 18 postaj"). Count + elevation range are derived from meta rather
+// than hardcoded so the sentence cannot go stale if the station set changes —
+// the failure mode T-4.6 fixed (the old copy claimed ARSO data this page has
+// never carried). ERA5-Land climatology, same ±7-day window as the per-station
+// explain below.
+function nationalExplain(stations: SiteMeta["stations"], yearMin: number): string {
+  const era5 = stations.filter(s => s.source === "era5");
+  const elevs = era5.map(s => s.elevation);
+  const elMin = Math.min(...elevs);
+  const elMax = Math.max(...elevs);
+  return `Povprečje najvišjih dnevnih temperatur ${era5.length} slovenskih postaj (nadmorska višina ${elMin}–${elMax} m), razvrščeno glede na zapise ERA5-Land od leta ${yearMin} za isto ±7-dnevno okno.`;
+}
+
 function fmtDate(dateStr: string): string {
   const parts = dateStr.split("-");
   return `${parts[2]}.${parts[1]}.`;
@@ -191,7 +205,7 @@ export function TodayCard(props: Props) {
           <p class="today-explain">
             {r().loc
               ? r().loc === props.nationalLoc
-                ? `Povprečna najvišja temperatura vseh ARSO postaj v Sloveniji, razvrstena glede na percentilne zapise ARSO meritev (${r().year_min}–${r().year_max}).`
+                ? nationalExplain(props.meta.stations, r().year_min ?? 1950)
                 : isArsoLoc(r().loc!)
                   ? `Temperatura na ARSO postaji ${props.meta.stations.find(s => s.name === r().loc)?.label ?? r().loc!.replace("arso:", "")}, razvrstena glede na percentilne zapise ARSO meritev.`
                   : `Temperatura na postaji ${r().loc!.replace(/_/g, " ")}, razvrstena glede na zapise ERA5-Land od leta ${r().year_min} za isto ±7-dnevno okno.`

--- a/tests/fixtures/snapshot.json
+++ b/tests/fixtures/snapshot.json
@@ -31309,7 +31309,7 @@
           "percentile_label": "percentil",
           "samples": "20,520 vzorcev",
           "preliminary_badge": "ERA5T · preliminarno",
-          "explain": "Povprečna najvišja temperatura vseh ARSO postaj v Sloveniji, razvrstena glede na percentilne zapise ARSO meritev (1950–2026).",
+          "explain": "Povprečje najvišjih dnevnih temperatur 18 slovenskih postaj (nadmorska višina 10–2514 m), razvrščeno glede na zapise ERA5-Land od leta 1950 za isto ±7-dnevno okno.",
           "footer": "24.6 °C · 50. percentil · 20,520 vzorcev (1950–2026)",
           "unavailable_message": null
         },
@@ -40557,7 +40557,7 @@
           "percentile_label": "percentil",
           "samples": "20,520 vzorcev",
           "preliminary_badge": null,
-          "explain": "Povprečna najvišja temperatura vseh ARSO postaj v Sloveniji, razvrstena glede na percentilne zapise ARSO meritev (1950–2026).",
+          "explain": "Povprečje najvišjih dnevnih temperatur 18 slovenskih postaj (nadmorska višina 10–2514 m), razvrščeno glede na zapise ERA5-Land od leta 1950 za isto ±7-dnevno okno.",
           "footer": "28.0 °C · 88. percentil · 20,520 vzorcev (1950–2026)",
           "unavailable_message": null
         },


### PR DESCRIPTION
## T-4.6 (partial) — live-wrong ARSO explain string

**Decision:** D-7 (national = unweighted mean of 18 ERA5 stations)

Fixes the explain paragraph on the default/national view (`TodayCard.tsx`), which claimed the value came from ARSO measurements — but this page carries no ARSO data after the D-2 deletion. Flagged HIGH by the Phase 2 review.

New copy is ERA5-Land, D-7-consistent; count (18) and elevation range (10–2514 m) derived from `props.meta.stations`, not hardcoded, so it can't re-stale.

**Snapshot:** moves exactly `cases[0]`/`cases[3]` → `today_card.rendered.explain` (2 ins/2 del), re-recorded in-commit.

**Gates:** typecheck OK (8 allowlisted), test 32 passed, snapshot green, pytest 18 passed.

**Not in this PR (remaining T-4.6):** rename the national series to "povprečje 18 postaj" everywhere, make the station list/elevation visible, audit all station-count strings. Tracked as a follow-up.