### PR TITLE
T-4.13: honest today-card badge (napoved for forecast, D-11 label half)

### DIFF
--- a/code/ali-je-vroce-era5/components/TodayCard.tsx
+++ b/code/ali-je-vroce-era5/components/TodayCard.tsx
@@ -184,6 +184,12 @@ export function TodayCard(props: Props) {
                   <span class="today-pct-samples">{(r().n_samples ?? 0).toLocaleString()} vzorcev</span>
                 </Show>
               </Show>
+              {/* is_preliminary is true iff the value came from the live
+                  Open-Meteo /v1/forecast fallback (api.ts:271,302) — an NWP
+                  forecast, never ERA5T reanalysis. The old badge read
+                  "ERA5T · preliminarno", mislabelling the forecast as the very
+                  thing it is not (D-11 / T-4.13). Reanalysis rows carry no badge;
+                  their ERA5-Land provenance is stated in the explain line below. */}
               <Show when={r().is_preliminary}>
                 <span style={{
                   "font-family": "var(--font-mono)", "font-size": "9px",
@@ -194,7 +200,7 @@ export function TodayCard(props: Props) {
                   "border-radius": "4px", padding: "2px 6px",
                   "margin-top": "4px", display: "inline-block",
                 }}>
-                  ERA5T · preliminarno
+                  napoved
                 </span>
               </Show>
             </div>

--- a/scripts/snapshot/main.mjs
+++ b/scripts/snapshot/main.mjs
@@ -490,8 +490,6 @@ const out = {
     "",
     "Known current-behaviour defects deliberately frozen here rather than fixed:",
     "  * Feb 29 returns zero rows everywhere and fetchAnnualTrend throws (T-4.5).",
-    "  * The 'ERA5T · preliminarno' badge names a source the code never fetches",
-    "    (D-11 open, T-4.13).",
     "  * The percentile shown is a bucket midpoint, not an empirical rank (D-6, T-4.1).",
     "",
     "NOT COVERED: the sea-level widget. See tests/snapshot/sections.json `excluded`.",

--- a/tests/fixtures/snapshot.json
+++ b/tests/fixtures/snapshot.json
@@ -19,8 +19,6 @@
     "",
     "Known current-behaviour defects deliberately frozen here rather than fixed:",
     "  * Feb 29 returns zero rows everywhere and fetchAnnualTrend throws (T-4.5).",
-    "  * The 'ERA5T · preliminarno' badge names a source the code never fetches",
-    "    (D-11 open, T-4.13).",
     "  * The percentile shown is a bucket midpoint, not an empirical rank (D-6, T-4.1).",
     "",
     "NOT COVERED: the sea-level widget. See tests/snapshot/sections.json `excluded`."
@@ -31308,7 +31306,7 @@
           "percentile": "50",
           "percentile_label": "percentil",
           "samples": "20,520 vzorcev",
-          "preliminary_badge": "ERA5T · preliminarno",
+          "preliminary_badge": "napoved",
           "explain": "Povprečje najvišjih dnevnih temperatur 18 slovenskih postaj (nadmorska višina 10–2514 m), razvrščeno glede na zapise ERA5-Land od leta 1950 za isto ±7-dnevno okno.",
           "footer": "24.6 °C · 50. percentil · 20,520 vzorcev (1950–2026)",
           "unavailable_message": null
@@ -34078,7 +34076,7 @@
           "percentile": "50",
           "percentile_label": "percentil",
           "samples": "1,140 vzorcev",
-          "preliminary_badge": "ERA5T · preliminarno",
+          "preliminary_badge": "napoved",
           "explain": "Temperatura na postaji Ljubljana, razvrstena glede na zapise ERA5-Land od leta 1950 za isto ±7-dnevno okno.",
           "footer": "26.0 °C · 50. percentil · 1,140 vzorcev (1950–2026)",
           "unavailable_message": null
@@ -37595,7 +37593,7 @@
           "percentile": "15",
           "percentile_label": "percentil",
           "samples": "1,140 vzorcev",
-          "preliminary_badge": "ERA5T · preliminarno",
+          "preliminary_badge": "napoved",
           "explain": "Temperatura na postaji Kredarica, razvrstena glede na zapise ERA5-Land od leta 1950 za isto ±7-dnevno okno.",
           "footer": "7.1 °C · 15. percentil · 1,140 vzorcev (1950–2026)",
           "unavailable_message": null

--- a/tests/snapshot/cases.json
+++ b/tests/snapshot/cases.json
@@ -48,7 +48,7 @@
       "today_loc": "era5:national",
       "analysis_loc": "Ljubljana",
       "date": "2026-07-21",
-      "purpose": "THE DEFAULT PAGE LOAD, verbatim. Pinned 'today' sits inside the ERA5-Land reanalysis lag, so climate-si has no `daily` row and fetchTodayStatus falls through to the live Open-Meteo national average (api.ts:362-366) and marks the result preliminary — this is the case that pins the 'ERA5T · preliminarno' badge string (TodayCard.tsx:183), known inaccurate per D-11 and snapshotted as-is."
+      "purpose": "THE DEFAULT PAGE LOAD, verbatim. Pinned 'today' sits inside the ERA5-Land reanalysis lag, so climate-si has no `daily` row and fetchTodayStatus falls through to the live Open-Meteo national average (api.ts:270) and marks the result preliminary — this is the case that pins the forecast 'napoved' badge string (TodayCard.tsx:203), made honest under T-4.13 (D-11), previously the inaccurate 'ERA5T · preliminarno'."
     },
     {
       "id": "ljubljana-primary",

--- a/tests/snapshot/harness.tsx
+++ b/tests/snapshot/harness.tsx
@@ -420,13 +420,13 @@ function captureTodayCard(unit: Unit, status: TodayStatus, last7: Last7): any {
 
   const pctSpans = Array.from(el.querySelectorAll(".today-pct-wrap > span"));
   // The badge is the only span in that column with no class attribute
-  // (TodayCard.tsx:173-185). Selected structurally so a copy change to the badge
+  // (TodayCard.tsx:187-205). Selected structurally so a copy change to the badge
   // TEXT still shows up as a diff instead of silently failing to match.
   const badgeEl = pctSpans.find((s) => !s.getAttribute("class"));
   if (ok && status.is_preliminary && !badgeEl) {
     throw new Error(
       `[snapshot] ${unit.label}: is_preliminary is true but no unclassed span exists in ` +
-        `.today-pct-wrap — the 'ERA5T · preliminarno' badge (TodayCard.tsx:173-185) moved. ` +
+        `.today-pct-wrap — the 'napoved' forecast badge (TodayCard.tsx:187-205) moved. ` +
         `No snapshot was written.`,
     );
   }
@@ -472,10 +472,10 @@ function captureTodayCard(unit: Unit, status: TodayStatus, last7: Last7): any {
               ".today-pct-samples",
               "TodayCard.tsx:169 — only rendered when n_samples > 0",
             ),
-      // D-11 OPEN: this string says ERA5T, but the value it labels comes from
-      // api.open-meteo.com/v1/forecast (api.ts:249), an NWP blend that is never
-      // ERA5T. Snapshotted verbatim on purpose — correcting it is T-4.13.
-      // Presence is asserted above against status.is_preliminary.
+      // Shown only when is_preliminary — i.e. the value is the live Open-Meteo
+      // /v1/forecast fallback (api.ts:271,302), not reanalysis. Reads "napoved"
+      // (forecast) since T-4.13 (D-11); it previously read "ERA5T · preliminarno",
+      // naming a source the code never fetches. Presence asserted above.
       preliminary_badge: badgeEl ? norm(badgeEl.textContent) : null,
       // Both branches render `.today-explain`: the data card's provenance line
       // (TodayCard.tsx:191) or UnavailableCard's message (TodayCard.tsx:290).


### PR DESCRIPTION
## T-4.13 — today-card badge honesty (D-11, label half)

Removes the false "ERA5T · preliminarno" badge. The today value is fetched from Open-Meteo `/v1/forecast` (a forecast blend, never ERA5T); the badge now honestly reads **"napoved"** for forecast-fallback values, and reanalysis rows are badge-less (provenance already in the explain prose).

**Wiring only** — reads `is_preliminary` on `TodayStatus` (`api.ts:271,302`), which already carries the forecast/reanalysis distinction. No pipeline change; forecast-persistence is deferred to T-4.17.

**Snapshot:** moves exactly the 3 forecast-fallback cases (`preliminary_badge`), value stays ranked, re-recorded in-commit.

**Gates:** typecheck OK (8 allowlisted), test 32, snapshot green, pytest 18.