### PR TITLE
T-4.6: rename national series to povprečje N postaj (D-7, rename half)

### DIFF
--- a/code/ali-je-vroce-era5/AliJeVroceERA5.tsx
+++ b/code/ali-je-vroce-era5/AliJeVroceERA5.tsx
@@ -108,7 +108,7 @@ function Dashboard(props: { meta: SiteMeta }) {
 
           {/* National (pooled) or per-station annual trend with projection */}
           <Show when={todayData()?.available}>
-            <TodayTrendChart date={date()} loc={loc()} />
+            <TodayTrendChart date={date()} loc={loc()} stationCount={era5Stations.length} />
           </Show>
         </div>
       </section>
@@ -131,7 +131,7 @@ function Dashboard(props: { meta: SiteMeta }) {
             <div style={{ ...panelHStyle, background: "var(--color-card)" }}>
               <div>
                 <div style={panelTitleStyle}>
-                  {mapLoc() ? mapLoc()!.replace(/_/g, " ") : "Slovenija — vse postaje"}
+                  {mapLoc() ? mapLoc()!.replace(/_/g, " ") : `Slovenija — vseh ${era5Stations.length} postaj`}
                 </div>
                 <div style={{ ...panelSubStyle, "margin-top": "3px" }}>
                   {era5Stations.length} postaj · ERA5

--- a/code/ali-je-vroce-era5/components/TodayCard.tsx
+++ b/code/ali-je-vroce-era5/components/TodayCard.tsx
@@ -127,7 +127,7 @@ export function TodayCard(props: Props) {
           value={r().loc === props.nationalLoc ? (props.nationalLoc ?? "") : r().loc ?? ""}
           onChange={(e) => props.onLocChange(e.currentTarget.value)}
         >
-          <option value={props.nationalLoc ?? ""}>Slovenija</option>
+          <option value={props.nationalLoc ?? ""}>Slovenija — povprečje {props.meta.stations.filter(s => s.source === "era5").length} postaj</option>
           <Show when={props.meta.stations.some(s => s.source === "arso")}>
             <optgroup label="ARSO postaje">
               <For each={props.meta.stations.filter(s => s.source === "arso")}>

--- a/code/ali-je-vroce-era5/components/TodayTrendChart.tsx
+++ b/code/ali-je-vroce-era5/components/TodayTrendChart.tsx
@@ -131,6 +131,10 @@ function TrendHighchart(props: ChartProps) {
 interface Props {
   date: string;
   loc:  string | null;
+  // era5 station count (D-7 "povprečje N postaj") — the national trend explain
+  // names it rather than the bare "vseh postaj". Derived from meta.stations by the
+  // caller so it can't go stale; only read on the national branch (props.loc null).
+  stationCount: number;
 }
 
 export function TodayTrendChart(props: Props) {
@@ -166,7 +170,7 @@ export function TodayTrendChart(props: Props) {
               </div>
               <TrendHighchart trend={d()} />
               <p class="today-explain" style={{ padding: "4px 0 2px" }}>
-                Vsaka pika je 90. percentil {props.loc ? `lapsno popravljene dnevne najvišje temperature na postaji ${props.loc.replace(/_/g, " ")}` : "nacionalne povprečne dnevne najvišje temperature vseh postaj"} v ±30-dnevnem oknu okoli tega datuma za vsako leto od {d().yearMin}. Trend Theil-Sen je {trendStr()} °C/desetletje ({sig()}). Po tem tempu projekcija kaže {proj2050()} °C do leta 2050. Zasenčeni pas je 95% interval zaupanja za nagib.
+                Vsaka pika je 90. percentil {props.loc ? `lapsno popravljene dnevne najvišje temperature na postaji ${props.loc.replace(/_/g, " ")}` : `nacionalne povprečne dnevne najvišje temperature vseh ${props.stationCount} postaj`} v ±30-dnevnem oknu okoli tega datuma za vsako leto od {d().yearMin}. Trend Theil-Sen je {trendStr()} °C/desetletje ({sig()}). Po tem tempu projekcija kaže {proj2050()} °C do leta 2050. Zasenčeni pas je 95% interval zaupanja za nagib.
               </p>
               <div class="today-foot">
                 Theil-Sen + TFPW MK: {trendStr()} °C/desetletje · {sig()} · τ = {d().tau.toFixed(3)} · 95% CI · {d().nYears} let

--- a/scripts/snapshot/main.mjs
+++ b/scripts/snapshot/main.mjs
@@ -204,9 +204,9 @@ const MIRRORED = [
   },
   {
     file: PAGE_SRC,
-    cite: "AliJeVroceERA5.tsx:140",
+    cite: "AliJeVroceERA5.tsx:134",
     mirror: "harness.tsx MapPanelHeader — title",
-    fragment: '{mapLoc() ? mapLoc()!.replace(/_/g, " ") : "Slovenija — vse postaje"}',
+    fragment: '{mapLoc() ? mapLoc()!.replace(/_/g, " ") : `Slovenija — vseh ${era5Stations.length} postaj`}',
   },
   {
     file: PAGE_SRC,

--- a/tests/fixtures/snapshot.json
+++ b/tests/fixtures/snapshot.json
@@ -499,7 +499,7 @@
       ],
       "panel_header": {
         "_note": "Raw JSX in AliJeVroceERA5.tsx:137-145, owned by no component and therefore invisible to the section-set assertion. Mirrored by MapPanelHeader in harness.tsx and checked against the source by main.mjs assertMirroredCopy. `station_count` is the same figure the _size=50 cap would truncate (T-5.2).",
-        "title": "Slovenija — vse postaje",
+        "title": "Slovenija — vseh 18 postaj",
         "station_count": "18 postaj · ERA5"
       }
     },

--- a/tests/snapshot/harness.tsx
+++ b/tests/snapshot/harness.tsx
@@ -617,7 +617,7 @@ function MapPanelHeader(props: { mapLoc: string | null; stationCount: number }) 
   return (
     <div>
       <div class="mirror-panel-title">
-        {props.mapLoc ? props.mapLoc.replace(/_/g, " ") : "Slovenija — vse postaje"}
+        {props.mapLoc ? props.mapLoc.replace(/_/g, " ") : `Slovenija — vseh ${props.stationCount} postaj`}
       </div>
       <div class="mirror-panel-sub">{props.stationCount} postaj · ERA5</div>
     </div>
@@ -989,7 +989,7 @@ export async function run(): Promise<RunResult> {
       // loc is the TODAY-card station, not the analysis one (AliJeVroceERA5.tsx:117).
       const trendUnit = await mount(
         `${label}.today_trend`,
-        () => <TodayTrendChart date={c.date} loc={c.today_loc} />,
+        () => <TodayTrendChart date={c.date} loc={c.today_loc} stationCount={era5Stations.length} />,
         1,
       );
       const tr = read(trendUnit);


### PR DESCRIPTION
## T-4.6 — national-series rename (D-7, remaining half)

Closes the rename/audit half of T-4.6 (the wrong-ARSO-string half shipped in `95d2d32`).

**Audit clean:** no hardcoded 18/17, no "Kredarica excluded"; counts already derive from `meta.stations`. Visibility already satisfied (station map + elevation legend + dropdown).

**Rename (Targeted/Option 1):** the three NAME-labels carry the derived count — selector "Slovenija — povprečje N postaj", map title "Slovenija — vseh N postaj", trend explain "…vseh N postaj". Geographic chart titles ("v Sloveniji") left as-is; method disclosed in the adjacent explain.

**Snapshot:** one leaf moved (`station_map.panel_header.title`, text only). Note: L1/L6/L7 are in a harness blind spot (tracked as T-4.18) — verified by source + typecheck.

**Gates:** typecheck OK (8 allowlisted), test 38, snapshot green, pytest 18.