### PR TITLE
T-4.15 + T-4.16: remove dead regression controls + rename ArsoTropicalData

### DIFF
--- a/code/ali-je-vroce-era5/api.ts
+++ b/code/ali-je-vroce-era5/api.ts
@@ -491,7 +491,7 @@ async function buildRegressionResult(
 // ── Tropical days / nights ───────────────────────────────────────────────────
 
 // Matches TropStation from TropicalChart.tsx so TropHighchart can be reused directly
-export interface ArsoTropicalData {
+export interface Era5TropicalData {
   years:         number[];
   counts:        number[];
   nonzero_count: number;
@@ -517,7 +517,7 @@ export async function fetchEra5Tropical(
   kind:      "days" | "nights",
   threshold: number,
   streak:    number = 1,
-): Promise<ArsoTropicalData | null> {
+): Promise<Era5TropicalData | null> {
   if (loc === ERA5_NATIONAL) return null;
   let rows: Array<{ years_json: string; counts_json: string; nonzero_count: number; trend_json: string }>;
   try {
@@ -533,8 +533,8 @@ export async function fetchEra5Tropical(
   if (!r) return null;
   const years  = JSON.parse(r.years_json)  as number[];
   const counts = JSON.parse(r.counts_json) as number[];
-  const t = JSON.parse(r.trend_json) as ArsoTropicalData["trend"] | Record<string, never>;
-  const trend = (t && (t as any).model_used) ? (t as ArsoTropicalData["trend"]) : {
+  const t = JSON.parse(r.trend_json) as Era5TropicalData["trend"] | Record<string, never>;
+  const trend = (t && (t as any).model_used) ? (t as Era5TropicalData["trend"]) : {
     model_used: false as const, rate_per_year: 0, days_per_decade: 0, p_value: 1,
     x_line: [], y_line: [], ci_low: [], ci_high: [],
     fit_year_max: years[years.length - 1] ?? 0, aic: 0, alpha: 0,

--- a/code/ali-je-vroce-era5/components/RegressionPanel.tsx
+++ b/code/ali-je-vroce-era5/components/RegressionPanel.tsx
@@ -38,8 +38,6 @@ function createStore(props: ProviderProps) {
   const [selLocs,  setSelLocs]  = createSignal<string[]>([defaultLoc()]);
   const [selVar,   setSelVar]   = createSignal("temperature_max");
   const [doy,      setDoy]      = createSignal(props.defaultDoy);
-  const [corr,     setCorr]     = createSignal(false);
-  const [useOls,   setUseOls]   = createSignal(false);
   const [locOpen,  setLocOpen]  = createSignal(false);
 
   createEffect(() => {
@@ -51,8 +49,11 @@ function createStore(props: ProviderProps) {
     locs:   selLocs(),
     var:    selVar(),
     doy:    doy(),
-    corr:   corr() ? "corr" : "raw",
-    method: useOls() ? "ols" : "theilsen",
+    // Retained to satisfy RegressionParams; fetchRegression ignores both (the
+    // annual_trend table is always Theil-Sen + TFPW MK with elevation correction
+    // baked in). The toolbar controls that once varied them were dead — see T-4.15.
+    corr:   "raw",
+    method: "theilsen",
   }));
   const [regData] = createResource(params, fetchRegression);
 
@@ -101,7 +102,6 @@ function createStore(props: ProviderProps) {
     meta: props.meta,
     selLocs, setSelLocs, selVar, setSelVar,
     doy, setDoy,
-    corr, setCorr, useOls, setUseOls,
     locOpen, setLocOpen,
     regData, calData,
     isPrecip, stats0, trend10, trendColor, totalChange,
@@ -179,33 +179,15 @@ export function RegToolbar() {
         </div>
       </div>
 
-      {/* Method */}
-      <div style={pillGroupStyle}>
-        <span style={pgkStyle}>Method</span>
-        <div style={{ display: "flex", gap: "2px" }}>
-          <button
-            style={{ ...pillStyle, background: !s.useOls() ? "var(--color-card)" : "transparent", "border-color": !s.useOls() ? "var(--color-rule-2)" : "transparent", color: !s.useOls() ? "var(--color-ink)" : "var(--color-ink-soft)" }}
-            onClick={() => s.setUseOls(false)}
-          >Theil-Sen + MK</button>
-          <button
-            style={{ ...pillStyle, background: s.useOls() ? "var(--color-card)" : "transparent", "border-color": s.useOls() ? "var(--color-rule-2)" : "transparent", color: s.useOls() ? "var(--color-ink)" : "var(--color-ink-soft)" }}
-            onClick={() => s.setUseOls(true)}
-          >OLS</button>
-        </div>
-      </div>
-
-      {/* Elevation correction */}
-      <Show when={!s.isPrecip()}>
-        <div style={pillGroupStyle}>
-          <span style={pgkStyle}>Elevation corr.</span>
-          <label style={{ position: "relative", width: "28px", height: "16px", "flex-shrink": "0", display: "inline-block" }}>
-            <input type="checkbox" checked={s.corr()} onChange={(e) => s.setCorr(e.currentTarget.checked)} style={{ position: "absolute", opacity: "0", width: "0", height: "0" }} />
-            <div style={{ position: "absolute", inset: "0", background: s.corr() ? "var(--color-accent)" : "var(--color-ink-faint)", "border-radius": "999px", cursor: "pointer", transition: "background 0.2s" }}>
-              <div style={{ position: "absolute", width: "12px", height: "12px", "border-radius": "50%", background: "#fff", top: "2px", left: s.corr() ? "14px" : "2px", transition: "left 0.2s" }} />
-            </div>
-          </label>
-        </div>
-      </Show>
+      {/* NB: former "Method" (Theil-Sen/OLS) and "Elevation corr." toolbar controls
+          were removed in T-4.15 — they were dead. Their signals fed
+          RegressionParams.corr/method, but fetchRegression reads the precomputed
+          annual_trend table and ignores both; the values never reached a request or
+          computation. The controls also carried false labels: the data is always
+          Theil-Sen + TFPW MK with elevation correction baked in (D-5), so "OLS" and
+          the toggle promised a switch that never happened. The genuine method/colour
+          readouts (stats.method footer, precip-vs-temp trend colour) are sourced
+          elsewhere and are untouched. */}
 
       <div class="reg-doy-spacer" />
 

--- a/scripts/snapshot/main.mjs
+++ b/scripts/snapshot/main.mjs
@@ -269,8 +269,10 @@ function assertMirroredCopy() {
  */
 const DEFAULT_SOURCES = [
   { key: "variable", file: PANEL_SRC, cite: "RegressionPanel.tsx:39", from: /const \[selVar,\s*setSelVar\]\s*=\s*createSignal\("([^"]+)"\)/, cast: String },
-  { key: "method", file: PANEL_SRC, cite: "RegressionPanel.tsx:42 (useOls)", from: /const \[useOls,\s*setUseOls\]\s*=\s*createSignal\((true|false)\)/, cast: (v) => (v === "true" ? "ols" : "theilsen") },
-  { key: "elevation_correction", file: PANEL_SRC, cite: "RegressionPanel.tsx:41 (corr)", from: /const \[corr,\s*setCorr\]\s*=\s*createSignal\((true|false)\)/, cast: (v) => (v === "true" ? "corr" : "raw") },
+  // "method" and "elevation_correction" removed with their toolbar controls in T-4.15:
+  // both were dead (fetchRegression ignores RegressionParams.corr/method), the harness
+  // read neither, and the values are now fixed literals in the params memo — there is no
+  // control default left to guard.
   { key: "tropical_days_threshold", file: PAGE_SRC, cite: "AliJeVroceERA5.tsx:212", from: /const \[daysThr,\s*setDaysThr\]\s*=\s*createSignal\((\d+)\)/, cast: Number },
   { key: "tropical_nights_threshold", file: PAGE_SRC, cite: "AliJeVroceERA5.tsx:213", from: /const \[nightsThr,\s*setNightsThr\]\s*=\s*createSignal\((\d+)\)/, cast: Number },
   { key: "tropical_streak", file: PAGE_SRC, cite: "AliJeVroceERA5.tsx:214", from: /const \[streak,\s*setStreak\]\s*=\s*createSignal\((\d+)\)/, cast: Number },

--- a/tests/fixtures/snapshot.json
+++ b/tests/fixtures/snapshot.json
@@ -33621,8 +33621,6 @@
           "toolbar": [
             "LocationLjubljana",
             "VariableMax temperature (°C)Min temperature (°C)Mean temperature (°C)Precipitation (mm)ET₀ (mm)",
-            "MethodTheil-Sen + MKOLS",
-            "Elevation corr.",
             "Day21 Jul◀▶"
           ],
           "day_label": "21 Jul",
@@ -37138,8 +37136,6 @@
           "toolbar": [
             "LocationLjubljana",
             "VariableMax temperature (°C)Min temperature (°C)Mean temperature (°C)Precipitation (mm)ET₀ (mm)",
-            "MethodTheil-Sen + MKOLS",
-            "Elevation corr.",
             "Day21 Jul◀▶"
           ],
           "day_label": "21 Jul",
@@ -40655,8 +40651,6 @@
           "toolbar": [
             "LocationKredarica",
             "VariableMax temperature (°C)Min temperature (°C)Mean temperature (°C)Precipitation (mm)ET₀ (mm)",
-            "MethodTheil-Sen + MKOLS",
-            "Elevation corr.",
             "Day21 Jul◀▶"
           ],
           "day_label": "21 Jul",
@@ -43981,8 +43975,6 @@
           "toolbar": [
             "LocationLjubljana",
             "VariableMax temperature (°C)Min temperature (°C)Mean temperature (°C)Precipitation (mm)ET₀ (mm)",
-            "MethodTheil-Sen + MKOLS",
-            "Elevation corr.",
             "Day15 Jul◀▶"
           ],
           "day_label": "15 Jul",
@@ -47498,8 +47490,6 @@
           "toolbar": [
             "LocationLjubljana",
             "VariableMax temperature (°C)Min temperature (°C)Mean temperature (°C)Precipitation (mm)ET₀ (mm)",
-            "MethodTheil-Sen + MKOLS",
-            "Elevation corr.",
             "Day15 Jul◀▶"
           ],
           "day_label": "15 Jul",
@@ -51015,8 +51005,6 @@
           "toolbar": [
             "LocationKredarica",
             "VariableMax temperature (°C)Min temperature (°C)Mean temperature (°C)Precipitation (mm)ET₀ (mm)",
-            "MethodTheil-Sen + MKOLS",
-            "Elevation corr.",
             "Day15 Jul◀▶"
           ],
           "day_label": "15 Jul",
@@ -51851,8 +51839,6 @@
           "toolbar": [
             "LocationLjubljana",
             "VariableMax temperature (°C)Min temperature (°C)Mean temperature (°C)Precipitation (mm)ET₀ (mm)",
-            "MethodTheil-Sen + MKOLS",
-            "Elevation corr.",
             "Day28 Feb◀▶"
           ],
           "day_label": "28 Feb",
@@ -52687,8 +52673,6 @@
           "toolbar": [
             "LocationKredarica",
             "VariableMax temperature (°C)Min temperature (°C)Mean temperature (°C)Precipitation (mm)ET₀ (mm)",
-            "MethodTheil-Sen + MKOLS",
-            "Elevation corr.",
             "Day28 Feb◀▶"
           ],
           "day_label": "28 Feb",
@@ -53474,8 +53458,6 @@
           "toolbar": [
             "LocationLjubljana",
             "VariableMax temperature (°C)Min temperature (°C)Mean temperature (°C)Precipitation (mm)ET₀ (mm)",
-            "MethodTheil-Sen + MKOLS",
-            "Elevation corr.",
             "Day28 Feb◀▶"
           ],
           "day_label": "28 Feb",
@@ -56973,8 +56955,6 @@
           "toolbar": [
             "LocationLjubljana",
             "VariableMax temperature (°C)Min temperature (°C)Mean temperature (°C)Precipitation (mm)ET₀ (mm)",
-            "MethodTheil-Sen + MKOLS",
-            "Elevation corr.",
             "Day1 Mar◀▶"
           ],
           "day_label": "1 Mar",
@@ -60490,8 +60470,6 @@
           "toolbar": [
             "LocationLjubljana",
             "VariableMax temperature (°C)Min temperature (°C)Mean temperature (°C)Precipitation (mm)ET₀ (mm)",
-            "MethodTheil-Sen + MKOLS",
-            "Elevation corr.",
             "Day28 Feb◀▶"
           ],
           "day_label": "28 Feb",
@@ -64007,8 +63985,6 @@
           "toolbar": [
             "LocationLjubljana",
             "VariableMax temperature (°C)Min temperature (°C)Mean temperature (°C)Precipitation (mm)ET₀ (mm)",
-            "MethodTheil-Sen + MKOLS",
-            "Elevation corr.",
             "Day1 Mar◀▶"
           ],
           "day_label": "1 Mar",
@@ -67524,8 +67500,6 @@
           "toolbar": [
             "LocationLjubljana",
             "VariableMax temperature (°C)Min temperature (°C)Mean temperature (°C)Precipitation (mm)ET₀ (mm)",
-            "MethodTheil-Sen + MKOLS",
-            "Elevation corr.",
             "Day1 Jan◀▶"
           ],
           "day_label": "1 Jan",
@@ -71033,8 +71007,6 @@
           "toolbar": [
             "LocationLjubljana",
             "VariableMax temperature (°C)Min temperature (°C)Mean temperature (°C)Precipitation (mm)ET₀ (mm)",
-            "MethodTheil-Sen + MKOLS",
-            "Elevation corr.",
             "Day31 Dec◀▶"
           ],
           "day_label": "31 Dec",
@@ -74542,8 +74514,6 @@
           "toolbar": [
             "LocationLjubljana",
             "VariableMax temperature (°C)Min temperature (°C)Mean temperature (°C)Precipitation (mm)ET₀ (mm)",
-            "MethodTheil-Sen + MKOLS",
-            "Elevation corr.",
             "Day3 Aug◀▶"
           ],
           "day_label": "3 Aug",
@@ -78051,8 +78021,6 @@
           "toolbar": [
             "LocationKredarica",
             "VariableMax temperature (°C)Min temperature (°C)Mean temperature (°C)Precipitation (mm)ET₀ (mm)",
-            "MethodTheil-Sen + MKOLS",
-            "Elevation corr.",
             "Day3 Aug◀▶"
           ],
           "day_label": "3 Aug",
@@ -81568,8 +81536,6 @@
           "toolbar": [
             "LocationLjubljana",
             "VariableMax temperature (°C)Min temperature (°C)Mean temperature (°C)Precipitation (mm)ET₀ (mm)",
-            "MethodTheil-Sen + MKOLS",
-            "Elevation corr.",
             "Day7 Feb◀▶"
           ],
           "day_label": "7 Feb",
@@ -85098,8 +85064,6 @@
           "toolbar": [
             "LocationKredarica",
             "VariableMax temperature (°C)Min temperature (°C)Mean temperature (°C)Precipitation (mm)ET₀ (mm)",
-            "MethodTheil-Sen + MKOLS",
-            "Elevation corr.",
             "Day7 Jan◀▶"
           ],
           "day_label": "7 Jan",

--- a/tests/snapshot/cases.json
+++ b/tests/snapshot/cases.json
@@ -35,8 +35,6 @@
       "date (AliJeVroceERA5.tsx:53 dateToDoy, passed to RegressionPanel.tsx:39)."
     ],
     "variable": "temperature_max",
-    "method": "theilsen",
-    "elevation_correction": "raw",
     "tropical_days_threshold": 30,
     "tropical_nights_threshold": 20,
     "tropical_streak": 1


### PR DESCRIPTION
## T-4.16 — type rename
`ArsoTropicalData` → `Era5TropicalData` (ARSO-era holdover for what's actually an ERA5 fetch). 4 refs in api.ts, no external importers. No render change, snapshot unmoved.

## T-4.15 — remove dead regression toolbar controls
Both `corr` ("Elevation corr.") and `method` ("Theil-Sen/OLS") controls were dead AND had **false labels**: the corr toggle promised to switch the D-5 lapse correction (always baked in); the OLS pill changed nothing (footer reads a hardcoded method). Removed the controls + signals + orphaned defaults.

**Live consumers left untouched** — footer `stats.method` and trend colouring read table/selVar sources, not the removed signals. Verified: `grep -v .toolbar` on the snapshot diff was empty (60 moved leaves all in toolbar text).

**Remaining dead traces** (interface fields, HeroCards call site) deferred to T-4.19 (entangled with T-2.7).

**Gates:** typecheck OK (8 allowlisted), test 38, snapshot green, pytest 18.