### PR TITLE
T-4.18: capture select state in snapshot harness (+ correct the blind-spot finding)

### DIFF
--- a/tests/fixtures/snapshot.json
+++ b/tests/fixtures/snapshot.json
@@ -31856,6 +31856,30 @@
         },
         "rendered": {
           "date_badge": "21.07.",
+          "loc_select": {
+            "selected": "era5:national",
+            "options": [
+              "Slovenija — povprečje 18 postaj",
+              "Ljubljana",
+              "Maribor",
+              "Celje",
+              "Kranj",
+              "Koper",
+              "Novo Mesto",
+              "Murska Sobota",
+              "Nova Gorica",
+              "Postojna",
+              "Ptuj",
+              "Velenje",
+              "Trbovlje",
+              "Tolmin",
+              "Kocevje",
+              "Ilirska Bistrica",
+              "Domzale",
+              "Ratece",
+              "Kredarica"
+            ]
+          },
           "category_label": "Normalno",
           "category_color": "rgb(231, 217, 184)",
           "description": "Točno takšno, kot 21.07 v Slovenija ponavadi je.",
@@ -33623,6 +33647,16 @@
             "VariableMax temperature (°C)Min temperature (°C)Mean temperature (°C)Precipitation (mm)ET₀ (mm)",
             "Day21 Jul◀▶"
           ],
+          "variable_select": {
+            "selected": "temperature_max",
+            "options": [
+              "Max temperature (°C)",
+              "Min temperature (°C)",
+              "Mean temperature (°C)",
+              "Precipitation (mm)",
+              "ET₀ (mm)"
+            ]
+          },
           "day_label": "21 Jul",
           "title": "Max temperature · 21 Jul",
           "subtitle": "Ljubljana",
@@ -35180,6 +35214,30 @@
         },
         "rendered": {
           "date_badge": "21.07.",
+          "loc_select": {
+            "selected": "Ljubljana",
+            "options": [
+              "Slovenija — povprečje 18 postaj",
+              "Ljubljana",
+              "Maribor",
+              "Celje",
+              "Kranj",
+              "Koper",
+              "Novo Mesto",
+              "Murska Sobota",
+              "Nova Gorica",
+              "Postojna",
+              "Ptuj",
+              "Velenje",
+              "Trbovlje",
+              "Tolmin",
+              "Kocevje",
+              "Ilirska Bistrica",
+              "Domzale",
+              "Ratece",
+              "Kredarica"
+            ]
+          },
           "category_label": "Normalno",
           "category_color": "rgb(231, 217, 184)",
           "description": "Točno takšno, kot 21.07 v Slovenija ponavadi je.",
@@ -37138,6 +37196,16 @@
             "VariableMax temperature (°C)Min temperature (°C)Mean temperature (°C)Precipitation (mm)ET₀ (mm)",
             "Day21 Jul◀▶"
           ],
+          "variable_select": {
+            "selected": "temperature_max",
+            "options": [
+              "Max temperature (°C)",
+              "Min temperature (°C)",
+              "Mean temperature (°C)",
+              "Precipitation (mm)",
+              "ET₀ (mm)"
+            ]
+          },
           "day_label": "21 Jul",
           "title": "Max temperature · 21 Jul",
           "subtitle": "Ljubljana",
@@ -38695,6 +38763,30 @@
         },
         "rendered": {
           "date_badge": "21.07.",
+          "loc_select": {
+            "selected": "Kredarica",
+            "options": [
+              "Slovenija — povprečje 18 postaj",
+              "Ljubljana",
+              "Maribor",
+              "Celje",
+              "Kranj",
+              "Koper",
+              "Novo Mesto",
+              "Murska Sobota",
+              "Nova Gorica",
+              "Postojna",
+              "Ptuj",
+              "Velenje",
+              "Trbovlje",
+              "Tolmin",
+              "Kocevje",
+              "Ilirska Bistrica",
+              "Domzale",
+              "Ratece",
+              "Kredarica"
+            ]
+          },
           "category_label": "Hladno",
           "category_color": "rgb(108, 143, 182)",
           "description": "Hladneje od večine izmerjenih 21.07.",
@@ -40653,6 +40745,16 @@
             "VariableMax temperature (°C)Min temperature (°C)Mean temperature (°C)Precipitation (mm)ET₀ (mm)",
             "Day21 Jul◀▶"
           ],
+          "variable_select": {
+            "selected": "temperature_max",
+            "options": [
+              "Max temperature (°C)",
+              "Min temperature (°C)",
+              "Mean temperature (°C)",
+              "Precipitation (mm)",
+              "ET₀ (mm)"
+            ]
+          },
           "day_label": "21 Jul",
           "title": "Max temperature · 21 Jul",
           "subtitle": "Kredarica",
@@ -42210,6 +42312,30 @@
         },
         "rendered": {
           "date_badge": "15.07.",
+          "loc_select": {
+            "selected": "era5:national",
+            "options": [
+              "Slovenija — povprečje 18 postaj",
+              "Ljubljana",
+              "Maribor",
+              "Celje",
+              "Kranj",
+              "Koper",
+              "Novo Mesto",
+              "Murska Sobota",
+              "Nova Gorica",
+              "Postojna",
+              "Ptuj",
+              "Velenje",
+              "Trbovlje",
+              "Tolmin",
+              "Kocevje",
+              "Ilirska Bistrica",
+              "Domzale",
+              "Ratece",
+              "Kredarica"
+            ]
+          },
           "category_label": "Vroče",
           "category_color": "rgb(194, 90, 44)",
           "description": "Med najtoplejšimi 15.07 v naših zapisih.",
@@ -43977,6 +44103,16 @@
             "VariableMax temperature (°C)Min temperature (°C)Mean temperature (°C)Precipitation (mm)ET₀ (mm)",
             "Day15 Jul◀▶"
           ],
+          "variable_select": {
+            "selected": "temperature_max",
+            "options": [
+              "Max temperature (°C)",
+              "Min temperature (°C)",
+              "Mean temperature (°C)",
+              "Precipitation (mm)",
+              "ET₀ (mm)"
+            ]
+          },
           "day_label": "15 Jul",
           "title": "Max temperature · 15 Jul",
           "subtitle": "Ljubljana",
@@ -45534,6 +45670,30 @@
         },
         "rendered": {
           "date_badge": "15.07.",
+          "loc_select": {
+            "selected": "Ljubljana",
+            "options": [
+              "Slovenija — povprečje 18 postaj",
+              "Ljubljana",
+              "Maribor",
+              "Celje",
+              "Kranj",
+              "Koper",
+              "Novo Mesto",
+              "Murska Sobota",
+              "Nova Gorica",
+              "Postojna",
+              "Ptuj",
+              "Velenje",
+              "Trbovlje",
+              "Tolmin",
+              "Kocevje",
+              "Ilirska Bistrica",
+              "Domzale",
+              "Ratece",
+              "Kredarica"
+            ]
+          },
           "category_label": "Vroče",
           "category_color": "rgb(194, 90, 44)",
           "description": "Med najtoplejšimi 15.07 v naših zapisih.",
@@ -47492,6 +47652,16 @@
             "VariableMax temperature (°C)Min temperature (°C)Mean temperature (°C)Precipitation (mm)ET₀ (mm)",
             "Day15 Jul◀▶"
           ],
+          "variable_select": {
+            "selected": "temperature_max",
+            "options": [
+              "Max temperature (°C)",
+              "Min temperature (°C)",
+              "Mean temperature (°C)",
+              "Precipitation (mm)",
+              "ET₀ (mm)"
+            ]
+          },
           "day_label": "15 Jul",
           "title": "Max temperature · 15 Jul",
           "subtitle": "Ljubljana",
@@ -49049,6 +49219,30 @@
         },
         "rendered": {
           "date_badge": "15.07.",
+          "loc_select": {
+            "selected": "Kredarica",
+            "options": [
+              "Slovenija — povprečje 18 postaj",
+              "Ljubljana",
+              "Maribor",
+              "Celje",
+              "Kranj",
+              "Koper",
+              "Novo Mesto",
+              "Murska Sobota",
+              "Nova Gorica",
+              "Postojna",
+              "Ptuj",
+              "Velenje",
+              "Trbovlje",
+              "Tolmin",
+              "Kocevje",
+              "Ilirska Bistrica",
+              "Domzale",
+              "Ratece",
+              "Kredarica"
+            ]
+          },
           "category_label": "Vroče",
           "category_color": "rgb(194, 90, 44)",
           "description": "Med najtoplejšimi 15.07 v naših zapisih.",
@@ -51007,6 +51201,16 @@
             "VariableMax temperature (°C)Min temperature (°C)Mean temperature (°C)Precipitation (mm)ET₀ (mm)",
             "Day15 Jul◀▶"
           ],
+          "variable_select": {
+            "selected": "temperature_max",
+            "options": [
+              "Max temperature (°C)",
+              "Min temperature (°C)",
+              "Mean temperature (°C)",
+              "Precipitation (mm)",
+              "ET₀ (mm)"
+            ]
+          },
           "day_label": "15 Jul",
           "title": "Max temperature · 15 Jul",
           "subtitle": "Kredarica",
@@ -51756,6 +51960,30 @@
         },
         "rendered": {
           "date_badge": "29.02.",
+          "loc_select": {
+            "selected": "",
+            "options": [
+              "Slovenija — povprečje 18 postaj",
+              "Ljubljana",
+              "Maribor",
+              "Celje",
+              "Kranj",
+              "Koper",
+              "Novo Mesto",
+              "Murska Sobota",
+              "Nova Gorica",
+              "Postojna",
+              "Ptuj",
+              "Velenje",
+              "Trbovlje",
+              "Tolmin",
+              "Kocevje",
+              "Ilirska Bistrica",
+              "Domzale",
+              "Ratece",
+              "Kredarica"
+            ]
+          },
           "category_label": null,
           "category_color": null,
           "description": null,
@@ -51841,6 +52069,16 @@
             "VariableMax temperature (°C)Min temperature (°C)Mean temperature (°C)Precipitation (mm)ET₀ (mm)",
             "Day28 Feb◀▶"
           ],
+          "variable_select": {
+            "selected": "temperature_max",
+            "options": [
+              "Max temperature (°C)",
+              "Min temperature (°C)",
+              "Mean temperature (°C)",
+              "Precipitation (mm)",
+              "ET₀ (mm)"
+            ]
+          },
           "day_label": "28 Feb",
           "title": "Max temperature · 28 Feb",
           "subtitle": "Ljubljana",
@@ -52590,6 +52828,30 @@
         },
         "rendered": {
           "date_badge": "29.02.",
+          "loc_select": {
+            "selected": "",
+            "options": [
+              "Slovenija — povprečje 18 postaj",
+              "Ljubljana",
+              "Maribor",
+              "Celje",
+              "Kranj",
+              "Koper",
+              "Novo Mesto",
+              "Murska Sobota",
+              "Nova Gorica",
+              "Postojna",
+              "Ptuj",
+              "Velenje",
+              "Trbovlje",
+              "Tolmin",
+              "Kocevje",
+              "Ilirska Bistrica",
+              "Domzale",
+              "Ratece",
+              "Kredarica"
+            ]
+          },
           "category_label": null,
           "category_color": null,
           "description": null,
@@ -52675,6 +52937,16 @@
             "VariableMax temperature (°C)Min temperature (°C)Mean temperature (°C)Precipitation (mm)ET₀ (mm)",
             "Day28 Feb◀▶"
           ],
+          "variable_select": {
+            "selected": "temperature_max",
+            "options": [
+              "Max temperature (°C)",
+              "Min temperature (°C)",
+              "Mean temperature (°C)",
+              "Precipitation (mm)",
+              "ET₀ (mm)"
+            ]
+          },
           "day_label": "28 Feb",
           "title": "Max temperature · 28 Feb",
           "subtitle": "Kredarica",
@@ -53424,6 +53696,30 @@
         },
         "rendered": {
           "date_badge": "29.02.",
+          "loc_select": {
+            "selected": "",
+            "options": [
+              "Slovenija — povprečje 18 postaj",
+              "Ljubljana",
+              "Maribor",
+              "Celje",
+              "Kranj",
+              "Koper",
+              "Novo Mesto",
+              "Murska Sobota",
+              "Nova Gorica",
+              "Postojna",
+              "Ptuj",
+              "Velenje",
+              "Trbovlje",
+              "Tolmin",
+              "Kocevje",
+              "Ilirska Bistrica",
+              "Domzale",
+              "Ratece",
+              "Kredarica"
+            ]
+          },
           "category_label": null,
           "category_color": null,
           "description": null,
@@ -53460,6 +53756,16 @@
             "VariableMax temperature (°C)Min temperature (°C)Mean temperature (°C)Precipitation (mm)ET₀ (mm)",
             "Day28 Feb◀▶"
           ],
+          "variable_select": {
+            "selected": "temperature_max",
+            "options": [
+              "Max temperature (°C)",
+              "Min temperature (°C)",
+              "Mean temperature (°C)",
+              "Precipitation (mm)",
+              "ET₀ (mm)"
+            ]
+          },
           "day_label": "28 Feb",
           "title": "Max temperature · 28 Feb",
           "subtitle": "Ljubljana",
@@ -55017,6 +55323,30 @@
         },
         "rendered": {
           "date_badge": "01.03.",
+          "loc_select": {
+            "selected": "Ljubljana",
+            "options": [
+              "Slovenija — povprečje 18 postaj",
+              "Ljubljana",
+              "Maribor",
+              "Celje",
+              "Kranj",
+              "Koper",
+              "Novo Mesto",
+              "Murska Sobota",
+              "Nova Gorica",
+              "Postojna",
+              "Ptuj",
+              "Velenje",
+              "Trbovlje",
+              "Tolmin",
+              "Kocevje",
+              "Ilirska Bistrica",
+              "Domzale",
+              "Ratece",
+              "Kredarica"
+            ]
+          },
           "category_label": "Normalno",
           "category_color": "rgb(231, 217, 184)",
           "description": "Točno takšno, kot 01.03 v Slovenija ponavadi je.",
@@ -56957,6 +57287,16 @@
             "VariableMax temperature (°C)Min temperature (°C)Mean temperature (°C)Precipitation (mm)ET₀ (mm)",
             "Day1 Mar◀▶"
           ],
+          "variable_select": {
+            "selected": "temperature_max",
+            "options": [
+              "Max temperature (°C)",
+              "Min temperature (°C)",
+              "Mean temperature (°C)",
+              "Precipitation (mm)",
+              "ET₀ (mm)"
+            ]
+          },
           "day_label": "1 Mar",
           "title": "Max temperature · 1 Mar",
           "subtitle": "Ljubljana",
@@ -58514,6 +58854,30 @@
         },
         "rendered": {
           "date_badge": "28.02.",
+          "loc_select": {
+            "selected": "Ljubljana",
+            "options": [
+              "Slovenija — povprečje 18 postaj",
+              "Ljubljana",
+              "Maribor",
+              "Celje",
+              "Kranj",
+              "Koper",
+              "Novo Mesto",
+              "Murska Sobota",
+              "Nova Gorica",
+              "Postojna",
+              "Ptuj",
+              "Velenje",
+              "Trbovlje",
+              "Tolmin",
+              "Kocevje",
+              "Ilirska Bistrica",
+              "Domzale",
+              "Ratece",
+              "Kredarica"
+            ]
+          },
           "category_label": "Normalno",
           "category_color": "rgb(231, 217, 184)",
           "description": "Točno takšno, kot 28.02 v Slovenija ponavadi je.",
@@ -60472,6 +60836,16 @@
             "VariableMax temperature (°C)Min temperature (°C)Mean temperature (°C)Precipitation (mm)ET₀ (mm)",
             "Day28 Feb◀▶"
           ],
+          "variable_select": {
+            "selected": "temperature_max",
+            "options": [
+              "Max temperature (°C)",
+              "Min temperature (°C)",
+              "Mean temperature (°C)",
+              "Precipitation (mm)",
+              "ET₀ (mm)"
+            ]
+          },
           "day_label": "28 Feb",
           "title": "Max temperature · 28 Feb",
           "subtitle": "Ljubljana",
@@ -62029,6 +62403,30 @@
         },
         "rendered": {
           "date_badge": "01.03.",
+          "loc_select": {
+            "selected": "Ljubljana",
+            "options": [
+              "Slovenija — povprečje 18 postaj",
+              "Ljubljana",
+              "Maribor",
+              "Celje",
+              "Kranj",
+              "Koper",
+              "Novo Mesto",
+              "Murska Sobota",
+              "Nova Gorica",
+              "Postojna",
+              "Ptuj",
+              "Velenje",
+              "Trbovlje",
+              "Tolmin",
+              "Kocevje",
+              "Ilirska Bistrica",
+              "Domzale",
+              "Ratece",
+              "Kredarica"
+            ]
+          },
           "category_label": "Normalno",
           "category_color": "rgb(231, 217, 184)",
           "description": "Točno takšno, kot 01.03 v Slovenija ponavadi je.",
@@ -63987,6 +64385,16 @@
             "VariableMax temperature (°C)Min temperature (°C)Mean temperature (°C)Precipitation (mm)ET₀ (mm)",
             "Day1 Mar◀▶"
           ],
+          "variable_select": {
+            "selected": "temperature_max",
+            "options": [
+              "Max temperature (°C)",
+              "Min temperature (°C)",
+              "Mean temperature (°C)",
+              "Precipitation (mm)",
+              "ET₀ (mm)"
+            ]
+          },
           "day_label": "1 Mar",
           "title": "Max temperature · 1 Mar",
           "subtitle": "Ljubljana",
@@ -65544,6 +65952,30 @@
         },
         "rendered": {
           "date_badge": "01.01.",
+          "loc_select": {
+            "selected": "Ljubljana",
+            "options": [
+              "Slovenija — povprečje 18 postaj",
+              "Ljubljana",
+              "Maribor",
+              "Celje",
+              "Kranj",
+              "Koper",
+              "Novo Mesto",
+              "Murska Sobota",
+              "Nova Gorica",
+              "Postojna",
+              "Ptuj",
+              "Velenje",
+              "Trbovlje",
+              "Tolmin",
+              "Kocevje",
+              "Ilirska Bistrica",
+              "Domzale",
+              "Ratece",
+              "Kredarica"
+            ]
+          },
           "category_label": "Vroče",
           "category_color": "rgb(194, 90, 44)",
           "description": "Med najtoplejšimi 01.01 v naših zapisih.",
@@ -67502,6 +67934,16 @@
             "VariableMax temperature (°C)Min temperature (°C)Mean temperature (°C)Precipitation (mm)ET₀ (mm)",
             "Day1 Jan◀▶"
           ],
+          "variable_select": {
+            "selected": "temperature_max",
+            "options": [
+              "Max temperature (°C)",
+              "Min temperature (°C)",
+              "Mean temperature (°C)",
+              "Precipitation (mm)",
+              "ET₀ (mm)"
+            ]
+          },
           "day_label": "1 Jan",
           "title": "Max temperature · 1 Jan",
           "subtitle": "Ljubljana",
@@ -69059,6 +69501,30 @@
         },
         "rendered": {
           "date_badge": "31.12.",
+          "loc_select": {
+            "selected": "Ljubljana",
+            "options": [
+              "Slovenija — povprečje 18 postaj",
+              "Ljubljana",
+              "Maribor",
+              "Celje",
+              "Kranj",
+              "Koper",
+              "Novo Mesto",
+              "Murska Sobota",
+              "Nova Gorica",
+              "Postojna",
+              "Ptuj",
+              "Velenje",
+              "Trbovlje",
+              "Tolmin",
+              "Kocevje",
+              "Ilirska Bistrica",
+              "Domzale",
+              "Ratece",
+              "Kredarica"
+            ]
+          },
           "category_label": "Normalno",
           "category_color": "rgb(231, 217, 184)",
           "description": "Točno takšno, kot 31.12 v Slovenija ponavadi je.",
@@ -71009,6 +71475,16 @@
             "VariableMax temperature (°C)Min temperature (°C)Mean temperature (°C)Precipitation (mm)ET₀ (mm)",
             "Day31 Dec◀▶"
           ],
+          "variable_select": {
+            "selected": "temperature_max",
+            "options": [
+              "Max temperature (°C)",
+              "Min temperature (°C)",
+              "Mean temperature (°C)",
+              "Precipitation (mm)",
+              "ET₀ (mm)"
+            ]
+          },
           "day_label": "31 Dec",
           "title": "Max temperature · 31 Dec",
           "subtitle": "Ljubljana",
@@ -72566,6 +73042,30 @@
         },
         "rendered": {
           "date_badge": "03.08.",
+          "loc_select": {
+            "selected": "Ljubljana",
+            "options": [
+              "Slovenija — povprečje 18 postaj",
+              "Ljubljana",
+              "Maribor",
+              "Celje",
+              "Kranj",
+              "Koper",
+              "Novo Mesto",
+              "Murska Sobota",
+              "Nova Gorica",
+              "Postojna",
+              "Ptuj",
+              "Velenje",
+              "Trbovlje",
+              "Tolmin",
+              "Kocevje",
+              "Ilirska Bistrica",
+              "Domzale",
+              "Ratece",
+              "Kredarica"
+            ]
+          },
           "category_label": "Peklensko",
           "category_color": "rgb(150, 44, 26)",
           "description": "Izjemna vročina — vrh 5 % vseh 03.08 od 1950.",
@@ -74516,6 +75016,16 @@
             "VariableMax temperature (°C)Min temperature (°C)Mean temperature (°C)Precipitation (mm)ET₀ (mm)",
             "Day3 Aug◀▶"
           ],
+          "variable_select": {
+            "selected": "temperature_max",
+            "options": [
+              "Max temperature (°C)",
+              "Min temperature (°C)",
+              "Mean temperature (°C)",
+              "Precipitation (mm)",
+              "ET₀ (mm)"
+            ]
+          },
           "day_label": "3 Aug",
           "title": "Max temperature · 3 Aug",
           "subtitle": "Ljubljana",
@@ -76073,6 +76583,30 @@
         },
         "rendered": {
           "date_badge": "03.08.",
+          "loc_select": {
+            "selected": "Kredarica",
+            "options": [
+              "Slovenija — povprečje 18 postaj",
+              "Ljubljana",
+              "Maribor",
+              "Celje",
+              "Kranj",
+              "Koper",
+              "Novo Mesto",
+              "Murska Sobota",
+              "Nova Gorica",
+              "Postojna",
+              "Ptuj",
+              "Velenje",
+              "Trbovlje",
+              "Tolmin",
+              "Kocevje",
+              "Ilirska Bistrica",
+              "Domzale",
+              "Ratece",
+              "Kredarica"
+            ]
+          },
           "category_label": "Peklensko",
           "category_color": "rgb(150, 44, 26)",
           "description": "Izjemna vročina — vrh 5 % vseh 03.08 od 1950.",
@@ -78023,6 +78557,16 @@
             "VariableMax temperature (°C)Min temperature (°C)Mean temperature (°C)Precipitation (mm)ET₀ (mm)",
             "Day3 Aug◀▶"
           ],
+          "variable_select": {
+            "selected": "temperature_max",
+            "options": [
+              "Max temperature (°C)",
+              "Min temperature (°C)",
+              "Mean temperature (°C)",
+              "Precipitation (mm)",
+              "ET₀ (mm)"
+            ]
+          },
           "day_label": "3 Aug",
           "title": "Max temperature · 3 Aug",
           "subtitle": "Kredarica",
@@ -79580,6 +80124,30 @@
         },
         "rendered": {
           "date_badge": "07.02.",
+          "loc_select": {
+            "selected": "Ljubljana",
+            "options": [
+              "Slovenija — povprečje 18 postaj",
+              "Ljubljana",
+              "Maribor",
+              "Celje",
+              "Kranj",
+              "Koper",
+              "Novo Mesto",
+              "Murska Sobota",
+              "Nova Gorica",
+              "Postojna",
+              "Ptuj",
+              "Velenje",
+              "Trbovlje",
+              "Tolmin",
+              "Kocevje",
+              "Ilirska Bistrica",
+              "Domzale",
+              "Ratece",
+              "Kredarica"
+            ]
+          },
           "category_label": "Zmrzujoče",
           "category_color": "rgb(58, 90, 138)",
           "description": "Med najhladnejšimi 07.02 v naših 77 letih zapisov.",
@@ -81538,6 +82106,16 @@
             "VariableMax temperature (°C)Min temperature (°C)Mean temperature (°C)Precipitation (mm)ET₀ (mm)",
             "Day7 Feb◀▶"
           ],
+          "variable_select": {
+            "selected": "temperature_max",
+            "options": [
+              "Max temperature (°C)",
+              "Min temperature (°C)",
+              "Mean temperature (°C)",
+              "Precipitation (mm)",
+              "ET₀ (mm)"
+            ]
+          },
           "day_label": "7 Feb",
           "title": "Max temperature · 7 Feb",
           "subtitle": "Ljubljana",
@@ -83108,6 +83686,30 @@
         },
         "rendered": {
           "date_badge": "07.01.",
+          "loc_select": {
+            "selected": "Kredarica",
+            "options": [
+              "Slovenija — povprečje 18 postaj",
+              "Ljubljana",
+              "Maribor",
+              "Celje",
+              "Kranj",
+              "Koper",
+              "Novo Mesto",
+              "Murska Sobota",
+              "Nova Gorica",
+              "Postojna",
+              "Ptuj",
+              "Velenje",
+              "Trbovlje",
+              "Tolmin",
+              "Kocevje",
+              "Ilirska Bistrica",
+              "Domzale",
+              "Ratece",
+              "Kredarica"
+            ]
+          },
           "category_label": "Zmrzujoče",
           "category_color": "rgb(58, 90, 138)",
           "description": "Med najhladnejšimi 07.01 v naših 77 letih zapisov.",
@@ -85066,6 +85668,16 @@
             "VariableMax temperature (°C)Min temperature (°C)Mean temperature (°C)Precipitation (mm)ET₀ (mm)",
             "Day7 Jan◀▶"
           ],
+          "variable_select": {
+            "selected": "temperature_max",
+            "options": [
+              "Max temperature (°C)",
+              "Min temperature (°C)",
+              "Mean temperature (°C)",
+              "Precipitation (mm)",
+              "ET₀ (mm)"
+            ]
+          },
           "day_label": "7 Jan",
           "title": "Max temperature · 7 Jan",
           "subtitle": "Kredarica",

--- a/tests/snapshot/harness.tsx
+++ b/tests/snapshot/harness.tsx
@@ -223,6 +223,15 @@ async function mount(
   }
   assertNoMisses(`${label} (re-check)`);
 
+  // T-4.18: Solid sets <select>.value as a PROPERTY, and cloneNode(true) does not
+  // copy it (jsdom's clone reports the first option, verified), so the frozen clone
+  // cannot tell which option is selected. Materialize the LIVE selection into an
+  // attribute — attributes do survive the clone — so Reader.select() can read it
+  // back after teardown. Harmless on units with no <select>.
+  for (const sel of Array.from(el.querySelectorAll("select"))) {
+    sel.setAttribute("data-snapshot-value", (sel as HTMLSelectElement).value);
+  }
+
   // Snapshot the DOM before teardown; onCleanup destroys the charts.
   const frozen = el.cloneNode(true) as HTMLElement;
   dispose();
@@ -284,6 +293,23 @@ class Reader {
     const els = Array.from(this.root.querySelectorAll(sel));
     if (els.length === 0) this.fail(sel, "no elements");
     return els.map((e) => norm(e.textContent)).filter((s): s is string => s !== null);
+  }
+
+  /**
+   * T-4.18: a `<select>`'s option text and its selected value. `<option>` labels
+   * were a snapshot blind spot — a dropdown label change (e.g. the T-4.6 national
+   * option "Slovenija — povprečje N postaj", TodayCard.tsx:130) moved nothing here.
+   * Option text is read from the DOM; the selected value comes from the
+   * `data-snapshot-value` attribute mount() materializes off the live element,
+   * because select.value does not survive cloneNode.
+   */
+  select(sel: string): { selected: string | null; options: string[] } {
+    const el = this.one(sel) as HTMLSelectElement;
+    const options = Array.from(el.querySelectorAll("option"))
+      .map((o) => norm(o.textContent))
+      .filter((s): s is string => s !== null);
+    if (options.length === 0) this.fail(`${sel} > option`, "no <option> elements");
+    return { selected: el.getAttribute("data-snapshot-value"), options };
   }
 
   style(sel: string, prop: string): string | null {
@@ -458,6 +484,10 @@ function captureTodayCard(unit: Unit, status: TodayStatus, last7: Last7): any {
     rendered: {
       // The date/location control is outside the Show, so it renders either way.
       date_badge: r.txt(".today-date-badge"),
+      // T-4.18: the station selector, whose options were previously uncaptured.
+      // Renders in both branches (TodayCard.tsx:125-145 sits before the available
+      // Show); the national option carries the T-4.6 "povprečje N postaj" label.
+      loc_select: r.select(".today-loc-select"),
       category_label: ok ? r.txt(".today-cat") : r.optional(".today-cat", why),
       category_color: ok
         ? r.style(".today-cat", "color")
@@ -553,6 +583,9 @@ function captureAnalysis(unit: Unit): any {
   return {
     rendered: {
       toolbar: r.all(".reg-toolbar > div"),
+      // T-4.18: the variable selector (RegressionPanel.tsx:170-178) — the lone
+      // <select> in the toolbar; its option labels were uncaptured.
+      variable_select: r.select("select"),
       day_label: r.txt(".reg-doy-ctrl > div"),
       title: scatter.txt("[style*='font-size: 15px']"),
       subtitle: scatter.txt("[style*='margin-top: 3px']"),
@@ -1009,6 +1042,28 @@ export async function run(): Promise<RunResult> {
         },
         charts,
       };
+
+      // T-4.18: the title/explain/footer come from TodayTrendChart's createResource
+      // (TodayTrendChart.tsx:144). settle() already awaits that fetch (it goes
+      // through the counted fetch) and expectedCharts=1 waits for the chart, which
+      // mounts only AFTER the <Show> renders this copy — so these are populated, not
+      // empty. Make that guarantee EXPLICIT rather than incidental: an empty value
+      // here means the resource had not resolved when the DOM was frozen, and must
+      // fail the run, not baseline blank. (r.txt already throws if the element is
+      // absent; this catches present-but-empty, which norm() would return as null.)
+      for (const [field, val] of [
+        ["title", trendRendered.title],
+        ["explain", trendRendered.explain],
+        ["footer", trendRendered.footer],
+      ] as const) {
+        if (val == null) {
+          throw new Error(
+            `[snapshot] ${label}.today_trend: ${field} is empty — TodayTrendChart's ` +
+              `createResource had not resolved when the DOM was serialized. ` +
+              `No snapshot was written.`,
+          );
+        }
+      }
     }
 
     const analysisUnit = await mount(


### PR DESCRIPTION
## T-4.18 — snapshot harness: capture select state

Test-infra only. The T-4.6 "blind spot" finding was half wrong:
- **(b) trend title/explain/footer** were NOT captured empty — already covered correctly (empty is structurally impossible; the run throws on a missing element). Made the await explicit, no value change.
- **(a) `<select>` state** WAS uncaptured — Solid sets `select.value` as a property that `cloneNode` drops in jsdom. `mount()` now materializes it to an attribute; new `Reader.select()` captures `{selected, options}`.

**Re-record:** 36 new leaves (18 × 2 select fields), all `<absent> → {…}`, zero previously-populated fields changed.

**Surfaced a real product bug → tracked as T-4.20:** capturing the trend region revealed the national title renders a raw key `"na postaji era5:national"` (T-4.6's rename branch is dead). Now snapshot-covered so the fix is verifiable.

**Gates:** typecheck OK (8 allowlisted), test 38, snapshot green, pytest 18.