### PR TITLE
T-5.1: kill silent failures (error states, guarded parse, no hidden warnings, no fabricated SPEI)

### DIFF
--- a/code/ali-je-vroce-era5/AliJeVroceERA5.tsx
+++ b/code/ali-je-vroce-era5/AliJeVroceERA5.tsx
@@ -1,6 +1,7 @@
-import { createSignal, createResource, createMemo, Show, Suspense, lazy } from "solid-js";
+import { createSignal, createResource, createMemo, Show, Suspense, ErrorBoundary, lazy } from "solid-js";
 import { fetchMeta, fetchPageData, fetchSpeiHeatmap, fetchSpeiStationSeasonal, dateToDoy, ERA5_NATIONAL, BASELINE_LABEL } from "./api.ts";
 import { today as todayIso } from "./clock.ts";
+import { sectionErrorFallback } from "./components/SectionError.tsx";
 import { TodayCard } from "./components/TodayCard.tsx";
 import { DistributionChart } from "./charts/DistributionChart.tsx";
 import { TodayTrendChart } from "./components/TodayTrendChart.tsx";
@@ -26,11 +27,17 @@ function fmtDayLabel(dl: string): string {
 }
 
 export function AliJeVroceERA5() {
-  const [meta] = createResource<SiteMeta>(fetchMeta);
+  const [meta, { refetch: refetchMeta }] = createResource<SiteMeta>(fetchMeta);
+  // A failed site-meta fetch used to leave the page spinning "Nalaganje…" forever:
+  // Show read meta(), which throws when the resource errored, and with no boundary
+  // the throw unmounted the whole island (blank). The boundary turns that into a
+  // visible page-level error (T-5.1).
   return (
-    <Show when={meta()} fallback={<div class="px-10 py-8 text-[var(--color-ink-soft)]">Nalaganje…</div>}>
-      {(m) => <Dashboard meta={m()} />}
-    </Show>
+    <ErrorBoundary fallback={sectionErrorFallback(refetchMeta, "480px")}>
+      <Show when={meta()} fallback={<div class="px-10 py-8 text-[var(--color-ink-soft)]">Nalaganje…</div>}>
+        {(m) => <Dashboard meta={m()} />}
+      </Show>
+    </ErrorBoundary>
   );
 }
 
@@ -47,7 +54,7 @@ function Dashboard(props: { meta: SiteMeta }) {
   const defaultDoy = createMemo(() => dateToDoy(date()));
   const era5Meta = (): SiteMeta => ({ ...props.meta, stations: era5Stations, default_location: defaultLoc });
 
-  const [pageData] = createResource(
+  const [pageData, { refetch: refetchPageData }] = createResource(
     () => ({ date: date(), loc: loc() }),
     ({ date, loc }) => fetchPageData(date, loc),
   );
@@ -70,6 +77,7 @@ function Dashboard(props: { meta: SiteMeta }) {
         </div>
 
         <div class="today-grid">
+          <ErrorBoundary fallback={sectionErrorFallback(refetchPageData, "480px")}>
           <Show
             when={todayData()}
             fallback={<div style={{ "min-height": "480px", "grid-column": "1 / -1" }} class="animate-pulse rounded-xl bg-[var(--color-paper-2)]" />}
@@ -110,6 +118,7 @@ function Dashboard(props: { meta: SiteMeta }) {
           <Show when={todayData()?.available}>
             <TodayTrendChart date={date()} loc={loc()} stationCount={era5Stations.length} />
           </Show>
+          </ErrorBoundary>
         </div>
       </section>
 
@@ -208,8 +217,8 @@ function Era5Charts() {
   const [streak,    setStreak]    = createSignal(1);
 
   // SPEI is national (heatmap) / has its own station picker (trend) — load once
-  const [speiData]        = createResource(fetchSpeiHeatmap);
-  const [speiStationData] = createResource(fetchSpeiStationSeasonal);
+  const [speiData,        { refetch: refetchSpei }]        = createResource(fetchSpeiHeatmap);
+  const [speiStationData, { refetch: refetchSpeiStation }] = createResource(fetchSpeiStationSeasonal);
 
   return (
     <Show when={loc()}>
@@ -240,11 +249,13 @@ function Era5Charts() {
         <div class="sec-h" style={{ "padding-inline": "0", "padding-top": "8px" }}>
           Sezonski sušni indeks (SPEI)
         </div>
-        <Suspense fallback={<div class="h-40 animate-pulse bg-[var(--color-paper-2)] rounded-xl" />}>
-          <Show when={speiData()?.available}>
-            <SpeiHeatmapChart data={speiData()!} />
-          </Show>
-        </Suspense>
+        <ErrorBoundary fallback={sectionErrorFallback(refetchSpei, "160px")}>
+          <Suspense fallback={<div class="h-40 animate-pulse bg-[var(--color-paper-2)] rounded-xl" />}>
+            <Show when={speiData()?.available}>
+              <SpeiHeatmapChart data={speiData()!} />
+            </Show>
+          </Suspense>
+        </ErrorBoundary>
       </section>
 
       {/* SPEI drought trend per station */}
@@ -255,11 +266,13 @@ function Era5Charts() {
         <div class="sec-hs2">
           Sezonski (SPEI-3) in mesečni (SPEI-30) indeks vodne bilance · Theil-Sen · ERA5-Land
         </div>
-        <Suspense fallback={<div class="animate-pulse rounded-xl bg-[var(--color-paper-2)]" style={{ height: "400px" }} />}>
-          <Show when={speiStationData()?.available}>
-            <SpeiTrendChartLazy data={speiStationData()!} />
-          </Show>
-        </Suspense>
+        <ErrorBoundary fallback={sectionErrorFallback(refetchSpeiStation, "400px")}>
+          <Suspense fallback={<div class="animate-pulse rounded-xl bg-[var(--color-paper-2)]" style={{ height: "400px" }} />}>
+            <Show when={speiStationData()?.available}>
+              <SpeiTrendChartLazy data={speiStationData()!} />
+            </Show>
+          </Suspense>
+        </ErrorBoundary>
       </section>
 
       {/* Tropical days */}

--- a/code/ali-je-vroce-era5/api.ts
+++ b/code/ali-je-vroce-era5/api.ts
@@ -62,6 +62,20 @@ async function dsGet<T>(path: string): Promise<T> {
   return resp.json() as Promise<T>;
 }
 
+// T-5.1: guard for the datasette `*_json` columns (distribution_json, scatter_json,
+// years_json, counts_json, trend_json, spei_json). An unguarded JSON.parse throws a
+// bare SyntaxError ("Unexpected token …") on malformed data that names neither the
+// column nor the section. This wraps the parse so the failure is descriptive and,
+// crucially, still an error — it propagates to the section's ErrorBoundary (T-5.1
+// Part 1) and renders as a visible error state rather than blanking the section.
+export function parseJsonColumn<T>(raw: string, column: string): T {
+  try {
+    return JSON.parse(raw) as T;
+  } catch (err) {
+    throw new Error(`Malformed JSON in datasette column ${column}: ${(err as Error).message}`);
+  }
+}
+
 
 export function doyToMonthDay(doy: number): { month: number; day: number } {
   const d = new Date(Date.UTC(2001, 0, 1));
@@ -183,7 +197,7 @@ export async function fetchEra5NationalWindowRow(month: number, day: number): Pr
   const p50 = avg(r => r.p50), p80 = avg(r => r.p80), p95 = avg(r => r.p95);
   const curves = rows
     .filter(r => r.distribution_json)
-    .map(r => JSON.parse(r.distribution_json) as [number, number][]);
+    .map(r => parseJsonColumn<[number, number][]>(r.distribution_json, "daily_window.distribution_json"));
   return {
     station: ERA5_NATIONAL,
     month, day,
@@ -308,7 +322,7 @@ export async function fetchTodayStatus(date: string, loc: string | null): Promis
     // only the DISPLAYED percentile becomes the honest CDF of the served KDE
     // (T-4.1 / D-6). Reuse the parsed curve for both the percentile and the chart.
     const cat  = categorizeEra5(todayTemp, w);
-    const dist = JSON.parse(w.distribution_json) as [number, number][];
+    const dist = parseJsonColumn<[number, number][]>(w.distribution_json, "daily_window.distribution_json");
     return {
       available: true, date,
       today_temp: parseFloat(todayTemp.toFixed(1)), is_preliminary: isPreliminary,
@@ -345,7 +359,7 @@ export async function fetchTodayStatus(date: string, loc: string | null): Promis
   // Band/category/color from the p5..p95 cutoffs (categorizeEra5); the DISPLAYED
   // percentile is the honest CDF of the served KDE at today's value (T-4.1 / D-6).
   const cat  = categorizeEra5(todayTemp, w);
-  const dist = JSON.parse(w.distribution_json) as [number, number][];
+  const dist = parseJsonColumn<[number, number][]>(w.distribution_json, "daily_window.distribution_json");
   return {
     available: true, date,
     today_temp: todayTemp, is_preliminary: isPreliminary,
@@ -453,7 +467,7 @@ async function buildRegressionResult(
   const r = rows[0];
   if (!r) return null;
 
-  const scatter = JSON.parse(r.scatter_json) as Array<{ x: number; y: number }>;
+  const scatter = parseJsonColumn<Array<{ x: number; y: number }>>(r.scatter_json, "annual_trend.scatter_json");
   const baselineYears = scatter.filter(pt => pt.x >= BASELINE_YEAR_MIN && pt.x <= BASELINE_YEAR_MAX);
   const baseline = baselineYears.length > 5
     ? baselineYears.reduce((s, pt) => s + pt.y, 0) / baselineYears.length
@@ -519,21 +533,19 @@ export async function fetchEra5Tropical(
   streak:    number = 1,
 ): Promise<Era5TropicalData | null> {
   if (loc === ERA5_NATIONAL) return null;
-  let rows: Array<{ years_json: string; counts_json: string; nonzero_count: number; trend_json: string }>;
-  try {
-    rows = await dsGet(
-      `tropical.json?_shape=array&era5_name__exact=${encodeURIComponent(loc)}` +
-      `&kind__exact=${kind}&threshold__exact=${threshold}&streak__exact=${streak}&_size=1`
-    );
-  } catch {
-    // tropical table not yet published on this datasette
-    return null;
-  }
+  // T-5.1: a fetch failure (HTTP error, missing `tropical` table) now propagates so
+  // the section's ErrorBoundary can show a visible error, instead of being swallowed
+  // into `null` and rendering as an empty section. A genuinely empty result set
+  // (no matching row) still returns null — that is legitimate "no data", not a fault.
+  const rows = await dsGet<Array<{ years_json: string; counts_json: string; nonzero_count: number; trend_json: string }>>(
+    `tropical.json?_shape=array&era5_name__exact=${encodeURIComponent(loc)}` +
+    `&kind__exact=${kind}&threshold__exact=${threshold}&streak__exact=${streak}&_size=1`
+  );
   const r = rows[0];
   if (!r) return null;
-  const years  = JSON.parse(r.years_json)  as number[];
-  const counts = JSON.parse(r.counts_json) as number[];
-  const t = JSON.parse(r.trend_json) as Era5TropicalData["trend"] | Record<string, never>;
+  const years  = parseJsonColumn<number[]>(r.years_json,  "tropical.years_json");
+  const counts = parseJsonColumn<number[]>(r.counts_json, "tropical.counts_json");
+  const t = parseJsonColumn<Era5TropicalData["trend"] | Record<string, never>>(r.trend_json, "tropical.trend_json");
   const trend = (t && (t as any).model_used) ? (t as Era5TropicalData["trend"]) : {
     model_used: false as const, rate_per_year: 0, days_per_decade: 0, p_value: 1,
     x_line: [], y_line: [], ci_low: [], ci_high: [],
@@ -547,55 +559,56 @@ export async function fetchEra5Tropical(
 // SPEI national heatmap — read the precomputed climate-si `spei` table.
 export async function fetchSpeiHeatmap(): Promise<SpeiData> {
   const empty: SpeiData = { available: false, data: [], year_min: 0, year_max: 0, baseline: null, era5_last: "" };
-  try {
-    const rows = await dsGet<Array<{
-      y: number; spei: number; balance: number; cat: string; rank: number;
-      total: number; color: string; season: string; n_days: number;
-    }>>(
-      `spei.json?_shape=array&_col=y&_col=spei&_col=balance&_col=cat&_col=rank&_col=total&_col=color&_col=season&_col=n_days&_size=2000`
-    );
-    if (!rows.length) return empty;
-    const years = rows.map(r => r.y);
-    return {
-      available: true,
-      data: rows.map(r => ({
-        season: r.season, y: r.y, spei: r.spei, cat: r.cat, color: r.color,
-        balance: r.balance, n_days: r.n_days, rank: r.rank, total: r.total,
-      })),
-      year_min: Math.min(...years), year_max: Math.max(...years),
-      baseline: "1950–1980", era5_last: "",
-    };
-  } catch {
-    return empty;
-  }
+  // T-5.1: no try/catch — a fetch/parse failure propagates to the section's
+  // ErrorBoundary (visible error) instead of being swallowed into `available:false`,
+  // which the page renders as a silently absent section. An empty result set still
+  // returns `empty` — that is legitimate "no data", not a fault.
+  const rows = await dsGet<Array<{
+    y: number; spei: number; balance: number; cat: string; rank: number;
+    total: number; color: string; season: string; n_days: number;
+  }>>(
+    `spei.json?_shape=array&_col=y&_col=spei&_col=balance&_col=cat&_col=rank&_col=total&_col=color&_col=season&_col=n_days&_size=2000`
+  );
+  if (!rows.length) return empty;
+  const years = rows.map(r => r.y);
+  return {
+    available: true,
+    data: rows.map(r => ({
+      season: r.season, y: r.y, spei: r.spei, cat: r.cat, color: r.color,
+      balance: r.balance, n_days: r.n_days, rank: r.rank, total: r.total,
+    })),
+    year_min: Math.min(...years), year_max: Math.max(...years),
+    baseline: "1950–1980", era5_last: "",
+  };
 }
 
 // SPEI per-station SPEI-3/SPEI-30 series — read the `spei_station` table.
 export async function fetchSpeiStationSeasonal(): Promise<SpeiStationData> {
   const empty: SpeiStationData = { available: false, stations: {}, era5_last: "", baseline: "", year_min: 0, year_max: 0 };
-  try {
-    const rows = await dsGet<Array<{
-      era5_name: string; series: string; years_json: string; spei_json: string; trend_json: string;
-    }>>(
-      `spei_station.json?_shape=array&_col=era5_name&_col=series&_col=years_json&_col=spei_json&_col=trend_json&_size=1000`
-    );
-    if (!rows.length) return empty;
-    const stations: SpeiStationData["stations"] = {};
-    let ymin = Infinity, ymax = -Infinity;
-    for (const r of rows) {
-      const years = JSON.parse(r.years_json) as number[];
-      const spei  = JSON.parse(r.spei_json)  as number[];
-      const trend = JSON.parse(r.trend_json);
-      (stations[r.era5_name] ??= {})[r.series] = { years, spei, trend };
-      if (years.length) { ymin = Math.min(ymin, years[0]!); ymax = Math.max(ymax, years[years.length - 1]!); }
-    }
-    return {
-      available: true, stations, era5_last: "", baseline: "1950–1980",
-      year_min: ymin === Infinity ? 0 : ymin, year_max: ymax === -Infinity ? 0 : ymax,
-    };
-  } catch {
-    return empty;
+  // T-5.1: no try/catch — a fetch/parse failure propagates to the section's
+  // ErrorBoundary (visible error) instead of being swallowed into `available:false`.
+  // A previously-swallowed malformed *_json row was the worst case: it silently
+  // blanked the whole SPEI-trend section. An empty result set still returns `empty`.
+  const rows = await dsGet<Array<{
+    era5_name: string; series: string; years_json: string; spei_json: string; trend_json: string;
+  }>>(
+    `spei_station.json?_shape=array&_col=era5_name&_col=series&_col=years_json&_col=spei_json&_col=trend_json&_size=1000`
+  );
+  if (!rows.length) return empty;
+  const stations: SpeiStationData["stations"] = {};
+  let ymin = Infinity, ymax = -Infinity;
+  for (const r of rows) {
+    const years = parseJsonColumn<number[]>(r.years_json, "spei_station.years_json");
+    const spei  = parseJsonColumn<number[]>(r.spei_json,  "spei_station.spei_json");
+    const trend = parseJsonColumn<SpeiStationData["stations"][string][string]["trend"]>(
+      r.trend_json, "spei_station.trend_json");
+    (stations[r.era5_name] ??= {})[r.series] = { years, spei, trend };
+    if (years.length) { ymin = Math.min(ymin, years[0]!); ymax = Math.max(ymax, years[years.length - 1]!); }
   }
+  return {
+    available: true, stations, era5_last: "", baseline: "1950–1980",
+    year_min: ymin === Infinity ? 0 : ymin, year_max: ymax === -Infinity ? 0 : ymax,
+  };
 }
 
 // ── fetchCalendar ──────────────────────────────────────────────────────────────
@@ -640,7 +653,7 @@ async function fetchNationalAnnualTrendRow(month: number, day: number): Promise<
   // Average scatter y per year across stations
   const perYear = new Map<number, { sum: number; n: number }>();
   for (const r of rows) {
-    for (const pt of JSON.parse(r.scatter_json) as Array<{ x: number; y: number }>) {
+    for (const pt of parseJsonColumn<Array<{ x: number; y: number }>>(r.scatter_json, "annual_trend.scatter_json")) {
       const e = perYear.get(pt.x) ?? { sum: 0, n: 0 };
       e.sum += pt.y; e.n += 1; perYear.set(pt.x, e);
     }
@@ -683,7 +696,7 @@ export async function fetchAnnualTrend(month: number, day: number, loc?: string 
     dayLabel: r.day_label, monthNum: r.month, dayNum: r.day,
     yearMin: r.year_min, yearMax: r.year_max,
     trend10: r.trend10, pVal: r.p_val, tau: r.tau, nYears: r.n_years,
-    scatter: JSON.parse(r.scatter_json) as Array<{ x: number; y: number }>,
+    scatter: parseJsonColumn<Array<{ x: number; y: number }>>(r.scatter_json, "annual_trend.scatter_json"),
     // Reconstruct the straight hist/proj lines + CI bands from the stored line
     // parameters (slope/intercept per central + CI bounds). Two endpoints each,
     // since the lines are straight — visually identical to the old point arrays.

--- a/code/ali-je-vroce-era5/charts/Era5SeasonHeatmap.tsx
+++ b/code/ali-je-vroce-era5/charts/Era5SeasonHeatmap.tsx
@@ -1,5 +1,6 @@
-import { createResource, Show, Suspense } from "solid-js";
+import { createResource, Show, Suspense, ErrorBoundary } from "solid-js";
 import { fetchSeasonHeatmap, isArsoLoc } from "../api.ts";
+import { sectionErrorFallback } from "../components/SectionError.tsx";
 import { SeasonHeatmap } from "./SeasonHeatmap.tsx";
 
 interface Props {
@@ -13,7 +14,7 @@ export function Era5SeasonHeatmap(props: Props) {
     return l && !isArsoLoc(l) ? l : null;
   };
 
-  const [data] = createResource(
+  const [data, { refetch }] = createResource(
     era5Loc,
     (loc) => fetchSeasonHeatmap(loc),
   );
@@ -21,13 +22,15 @@ export function Era5SeasonHeatmap(props: Props) {
   const display = () => data() ?? data.latest;
 
   return (
-    <Suspense fallback={<div class="h-40 animate-pulse bg-[var(--color-paper-2)] rounded-xl" />}>
-      <Show when={(display()?.length ?? 0) > 0}>
-        <SeasonHeatmap data={display()!} />
-      </Show>
-      <Show when={data.loading && !display()}>
-        <div class="h-40 animate-pulse bg-[var(--color-paper-2)] rounded-xl" />
-      </Show>
-    </Suspense>
+    <ErrorBoundary fallback={sectionErrorFallback(refetch, "160px")}>
+      <Suspense fallback={<div class="h-40 animate-pulse bg-[var(--color-paper-2)] rounded-xl" />}>
+        <Show when={(display()?.length ?? 0) > 0}>
+          <SeasonHeatmap data={display()!} />
+        </Show>
+        <Show when={data.loading && !display()}>
+          <div class="h-40 animate-pulse bg-[var(--color-paper-2)] rounded-xl" />
+        </Show>
+      </Suspense>
+    </ErrorBoundary>
   );
 }

--- a/code/ali-je-vroce-era5/charts/Era5TropicalChart.tsx
+++ b/code/ali-je-vroce-era5/charts/Era5TropicalChart.tsx
@@ -1,5 +1,6 @@
-import { createResource, createMemo, Show } from "solid-js";
+import { createResource, createMemo, Show, ErrorBoundary } from "solid-js";
 import { fetchEra5Tropical, isArsoLoc, ERA5_NATIONAL } from "../api.ts";
+import { sectionErrorFallback } from "../components/SectionError.tsx";
 import { TropHighchart } from "./TropicalChart.tsx";
 import type { Config } from "./TropicalChart.tsx";
 
@@ -50,7 +51,7 @@ export function Era5TropicalChart(props: Props) {
     return l && !isArsoLoc(l) && l !== ERA5_NATIONAL ? l : null;
   });
 
-  const [data] = createResource(
+  const [data, { refetch }] = createResource(
     () => {
       const loc = era5Loc();
       return loc ? { loc, kind: props.kind, threshold: props.threshold, streak: props.streak } : null;
@@ -95,6 +96,7 @@ export function Era5TropicalChart(props: Props) {
 
   return (
     <div style={{ margin: "0 40px" }}>
+      <ErrorBoundary fallback={sectionErrorFallback(refetch, "300px")}>
       <div style={{ background: "var(--color-card)", border: "1px solid var(--color-rule)", "border-radius": "var(--radius,10px)", overflow: "hidden" }}>
 
         <div style={{ padding: "12px 16px 10px", "border-bottom": "1px solid var(--color-rule)", display: "flex", "align-items": "baseline", "justify-content": "space-between" }}>
@@ -147,6 +149,7 @@ export function Era5TropicalChart(props: Props) {
         </Show>
 
       </div>
+      </ErrorBoundary>
     </div>
   );
 }

--- a/code/ali-je-vroce-era5/components/HeroCards.tsx
+++ b/code/ali-je-vroce-era5/components/HeroCards.tsx
@@ -1,5 +1,6 @@
-import { createResource, Show } from "solid-js";
+import { createResource, Show, ErrorBoundary } from "solid-js";
 import { fetchRegression } from "../api.ts";
+import { sectionErrorFallback } from "./SectionError.tsx";
 import type { RegressionResult } from "../types.ts";
 
 // ── Inlined locale (from sl_default.json hero / hero_category / hero_context / climate_risks) ──
@@ -227,16 +228,18 @@ const SANS     = { "font-family": "var(--font-sans)" };
 export function HeroCards(props: Props) {
   const loc = () => props.loc ?? "Ljubljana";
 
-  const [resp] = createResource(
+  const [resp, { refetch }] = createResource(
     () => ({ loc: loc(), doy: props.doy }),
     ({ loc, doy }) =>
       fetchRegression({ locs: [loc], var: "temperature_max", doy, corr: "corr", method: "theilsen" }),
   );
 
   return (
-    <Show when={resp()?.results?.length}>
-      <HeroCard res={resp()!.results[0]!} unit={resp()!.unit} dateLabel={resp()!.date_label} />
-    </Show>
+    <ErrorBoundary fallback={sectionErrorFallback(refetch, "180px")}>
+      <Show when={resp()?.results?.length}>
+        <HeroCard res={resp()!.results[0]!} unit={resp()!.unit} dateLabel={resp()!.date_label} />
+      </Show>
+    </ErrorBoundary>
   );
 }
 

--- a/code/ali-je-vroce-era5/components/RegressionPanel.tsx
+++ b/code/ali-je-vroce-era5/components/RegressionPanel.tsx
@@ -1,9 +1,10 @@
 import { createSignal, createResource, createEffect, createMemo, createContext, useContext,
-         Show, Suspense, For, lazy } from "solid-js";
+         Show, Suspense, ErrorBoundary, For, lazy } from "solid-js";
 import type { JSXElement } from "solid-js";
 import type { SiteMeta } from "../types.ts";
 import type { RegressionParams } from "../api.ts";
 import { fetchRegression, fetchCalendar } from "../api.ts";
+import { sectionErrorFallback } from "./SectionError.tsx";
 
 const RegressionChart = lazy(() => import("../charts/RegressionChart.tsx").then(m => ({ default: m.RegressionChart })));
 const YearRoundChart  = lazy(() => import("../charts/YearRoundChart.tsx").then(m => ({ default: m.YearRoundChart })));
@@ -55,13 +56,13 @@ function createStore(props: ProviderProps) {
     corr:   "raw",
     method: "theilsen",
   }));
-  const [regData] = createResource(params, fetchRegression);
+  const [regData, { refetch: refetchReg }] = createResource(params, fetchRegression);
 
   const calParams = createMemo(() => ({
     loc:     selLocs()[0] ?? defaultLoc(),
     var:     selVar(),
   }));
-  const [calData] = createResource(
+  const [calData, { refetch: refetchCal }] = createResource(
     calParams,
     p => fetchCalendar(p.loc, p.var, "raw", "theilsen"),
   );
@@ -103,7 +104,7 @@ function createStore(props: ProviderProps) {
     selLocs, setSelLocs, selVar, setSelVar,
     doy, setDoy,
     locOpen, setLocOpen,
-    regData, calData,
+    regData, calData, refetchReg, refetchCal,
     isPrecip, stats0, trend10, trendColor, totalChange,
     locLabel, varLabel, chartTitle, chartSub,
     toggleLoc, doyToLabel, VARIABLES,
@@ -220,6 +221,7 @@ export function RegScatterCard() {
   const s = useReg();
   return (
     <div class="reg-card">
+      <ErrorBoundary fallback={sectionErrorFallback(s.refetchReg, "280px")}>
 
       <div style={panelHStyle}>
         <div style={{ "min-width": "0" }}>
@@ -277,6 +279,7 @@ export function RegScatterCard() {
         <p style={panelExplainStyle}>{s.meta.strings.explain_reg}</p>
       </Show>
 
+      </ErrorBoundary>
     </div>
   );
 }
@@ -300,11 +303,13 @@ export function RegYearRoundCard() {
       </div>
 
       <div style={{ padding: "8px 16px 12px", background: "var(--color-paper)" }}>
-        <Suspense fallback={<div class="animate-pulse rounded-lg bg-[var(--color-paper-2)]" style={{ height: "180px" }} />}>
-          <Show when={s.calData()} keyed>
-            {(d) => <YearRoundChart data={d} doy={s.doy()} var={s.selVar()} />}
-          </Show>
-        </Suspense>
+        <ErrorBoundary fallback={sectionErrorFallback(s.refetchCal, "180px")}>
+          <Suspense fallback={<div class="animate-pulse rounded-lg bg-[var(--color-paper-2)]" style={{ height: "180px" }} />}>
+            <Show when={s.calData()} keyed>
+              {(d) => <YearRoundChart data={d} doy={s.doy()} var={s.selVar()} />}
+            </Show>
+          </Suspense>
+        </ErrorBoundary>
       </div>
 
       <div style={{ ...chartFooterStyle, "justify-content": "flex-start", gap: "16px" }}>

--- a/code/ali-je-vroce-era5/components/SectionError.tsx
+++ b/code/ali-je-vroce-era5/components/SectionError.tsx
@@ -1,0 +1,80 @@
+import { Show } from "solid-js";
+import type { JSXElement } from "solid-js";
+
+// T-5.1 — the ONE visible error state for a failed section fetch, reused at every
+// section boundary. Before this, a failed section fetch either vanished (the
+// tropical/SPEI helpers swallowed the error into an `available:false` sentinel and
+// the `<Show>` rendered nothing) or blanked its subtree (an unguarded throw from
+// dsGet / JSON.parse propagated with no boundary). Both are silent failures: the
+// reader sees missing data with no signal that anything went wrong. This renders a
+// message the reader can see instead.
+//
+// `style()` keys are kebab-case on purpose: Solid's style() calls setProperty(), so
+// a camelCase key is silently dropped (see CLAUDE.md "Solid's style() silently
+// ignores camelCase properties").
+export function SectionError(props: { onRetry?: (() => void) | undefined; minHeight?: string | undefined }): JSXElement {
+  return (
+    <div
+      role="alert"
+      style={{
+        "min-height":      props.minHeight ?? "120px",
+        display:           "flex",
+        "flex-direction":  "column",
+        "align-items":     "center",
+        "justify-content": "center",
+        gap:               "10px",
+        padding:           "20px",
+        "text-align":      "center",
+        border:            "1px solid var(--color-rule)",
+        "border-radius":   "var(--radius, 10px)",
+        background:        "var(--color-paper-2)",
+        color:             "var(--color-ink-soft)",
+        "font-family":     "var(--font-sans)",
+        "font-size":       "13px",
+        "line-height":     "1.5",
+      }}
+    >
+      <span>Tega razdelka trenutno ni bilo mogoče naložiti.</span>
+      <Show when={props.onRetry}>
+        <button
+          type="button"
+          onClick={() => props.onRetry!()}
+          style={{
+            "font-family":   "var(--font-mono)",
+            "font-size":     "11px",
+            "letter-spacing":"0.06em",
+            "text-transform":"uppercase",
+            color:           "var(--color-ink)",
+            background:      "var(--color-card)",
+            border:          "1px solid var(--color-rule-2)",
+            "border-radius": "7px",
+            padding:         "5px 12px",
+            cursor:          "pointer",
+          }}
+        >
+          Poskusi znova
+        </button>
+      </Show>
+    </div>
+  );
+}
+
+// Fallback factory for <ErrorBoundary fallback={…}>. Keeps the boundaries uniform:
+// each call site passes only its resource's refetch (so "Poskusi znova" genuinely
+// re-fetches rather than just re-mounting an already-errored resource) and, if it
+// wants, a min-height so the error box matches the chart it replaces. The failure
+// is also logged, so it is visible in the console, not only on screen.
+export function sectionErrorFallback(
+  retry?: () => void,
+  minHeight?: string,
+): (err: unknown, reset: () => void) => JSXElement {
+  return (err, reset) => {
+    console.error("[section] failed to load:", err);
+    return (
+      <SectionError
+        minHeight={minHeight}
+        onRetry={retry ? () => { retry(); reset(); } : undefined}
+      />
+    );
+  };
+}

--- a/code/ali-je-vroce-era5/components/TodayTrendChart.tsx
+++ b/code/ali-je-vroce-era5/components/TodayTrendChart.tsx
@@ -1,6 +1,7 @@
-import { createResource, Show, onMount, onCleanup, createEffect } from "solid-js";
+import { createResource, Show, ErrorBoundary, onMount, onCleanup, createEffect } from "solid-js";
 import { fetchAnnualTrend, ERA5_NATIONAL } from "../api.ts";
 import { todayYear } from "../clock.ts";
+import { sectionErrorFallback } from "./SectionError.tsx";
 import type { AnnualTrend } from "../types.ts";
 
 const INK      = "#0E0E0C";
@@ -142,7 +143,7 @@ export function TodayTrendChart(props: Props) {
   const month = () => Number(props.date.split("-")[1]);
   const day   = () => Number(props.date.split("-")[2]);
 
-  const [trend] = createResource(
+  const [trend, { refetch }] = createResource(
     () => ({ month: month(), day: day(), loc: props.loc }),
     ({ month, day, loc }) => fetchAnnualTrend(month, day, loc),
   );
@@ -152,6 +153,7 @@ export function TodayTrendChart(props: Props) {
 
   return (
     <div class="today-chart">
+      <ErrorBoundary fallback={sectionErrorFallback(refetch, "240px")}>
       <Show when={trendDisplay()}>
         {(t) => {
           const d = () => t();
@@ -189,6 +191,7 @@ export function TodayTrendChart(props: Props) {
       <Show when={trend.loading && !trendDisplay()}>
         <div style={{ height: "240px" }} class="animate-pulse bg-[var(--color-paper-2)] rounded" />
       </Show>
+      </ErrorBoundary>
     </div>
   );
 }

--- a/data/climate-si/sources/precompute_datasette.py
+++ b/data/climate-si/sources/precompute_datasette.py
@@ -30,7 +30,24 @@ import yaml
 
 import validate as pipeline_validate
 
-warnings.filterwarnings("ignore")
+# T-5.1 Part 3: the global `warnings.filterwarnings("ignore")` was removed. It hid
+# every warning the pipeline raised — including real numerical issues (degenerate NB
+# fits, divide-by-zero, overflow) that a public data pipeline should not hide. They
+# now surface at build time. The NB-GLM ConvergenceWarning/HessianInversionWarning and
+# the RuntimeWarnings from the optimizer are deliberately LEFT VISIBLE: they mark the
+# tropical fits that genuinely fail and are already degraded to `{}` (see
+# `_tropical_trend`, which also logs "tropical NB fit failed").
+#
+# The single exception below is narrow and benign: statsmodels emits one UserWarning
+# per get_prediction() call telling us it used its default log-link — which is exactly
+# the correct link for the NegativeBinomial model we fit. It is purely informational
+# and fired 793×/run, drowning the warnings that matter. Suppress only that one
+# message; never re-add a blanket ignore.
+warnings.filterwarnings(
+    "ignore",
+    message="using default log-link in get_prediction",
+    category=UserWarning,
+)
 
 # ── Config ─────────────────────────────────────────────────────────────────────
 

--- a/data/climate-si/sources/precompute_datasette.py
+++ b/data/climate-si/sources/precompute_datasette.py
@@ -660,14 +660,25 @@ def _spei_color(spei):
             "wet": "#4a80b0", "extreme_wet": "#1e4d78"}[_spei_cat(spei)]
 
 def _spei_from_balances(all_vals, baseline_vals):
-    """SPEI for all_vals, log-logistic fitted on baseline_vals (>=5 else all)."""
+    """SPEI for all_vals, log-logistic fitted on baseline_vals (>=5 else all).
+
+    Returns None if the Fisk fit fails — the series is WITHHELD, not fabricated
+    (D-16). This mirrors _tropical_trend's failure path (log to stderr, return the
+    sentinel, let the caller drop the series): a failed fit yields "no data", never
+    invented distribution parameters. The previous code fabricated c_par=1.0,
+    scale_par=mean and emitted SPEI from them silently, which would corrupt every
+    SPEI value/category/colour/rank/trend on the drought heatmap and per-station
+    charts while passing validate.py (fabricated values still clip to [-3,3]). It
+    fires 0x on current data (all 292 series fit); the change defuses a landmine.
+    """
     b_vals = baseline_vals if len(baseline_vals) >= 5 else all_vals
     b_vals = np.asarray(b_vals, dtype=float)
     gamma_shift = float(b_vals.min()) - 1e-6
     try:
         c_par, _, scale_par = stats.fisk.fit(b_vals - gamma_shift, floc=0)
-    except Exception:
-        c_par, scale_par = 1.0, max(float((b_vals - gamma_shift).mean()), 1e-6)
+    except Exception as e:
+        print(f"  SPEI Fisk fit failed ({e}) — withholding series", file=sys.stderr)
+        return None
     out = []
     for bal in all_vals:
         sv = max(float(bal) - gamma_shift, 1e-9)
@@ -728,6 +739,8 @@ def build_spei_heatmap(data: pd.DataFrame) -> pd.DataFrame:
         n_total  = len(all_vals)
         b_sub    = sub[(sub["year"] >= SPEI_BASELINE_START) & (sub["year"] <= SPEI_BASELINE_END)]
         speis    = _spei_from_balances(all_vals, b_sub["balance"].values)
+        if speis is None:   # Fisk fit failed → withhold this season (D-16), don't fabricate
+            continue
         sorted_asc = np.sort(all_vals)
         for (_, row), spei_val in zip(sub.iterrows(), speis):
             rank = int(np.searchsorted(sorted_asc, row["balance"])) + 1
@@ -770,7 +783,10 @@ def build_spei_station(data: pd.DataFrame, stations_df: pd.DataFrame) -> pd.Data
                 continue
             rd = pd.DataFrame(recs)
             b  = rd[(rd["year"] >= SPEI_BASELINE_START) & (rd["year"] <= SPEI_BASELINE_END)]
-            speis = [round(v, 2) for v in _spei_from_balances(rd["balance"].values, b["balance"].values)]
+            raw = _spei_from_balances(rd["balance"].values, b["balance"].values)
+            if raw is None:   # Fisk fit failed → withhold this seasonal series (D-16)
+                continue
+            speis = [round(v, 2) for v in raw]
             years = [int(y) for y in rd["year"].tolist()]
             series[s_name] = {"years": years, "spei": speis, "trend": _spei_trend(speis, years)}
         # Annual = mean of seasonal SPEI per year
@@ -796,7 +812,10 @@ def build_spei_station(data: pd.DataFrame, stations_df: pd.DataFrame) -> pd.Data
                 continue
             rd = pd.DataFrame(recs)
             b  = rd[(rd["year"] >= SPEI_BASELINE_START) & (rd["year"] <= SPEI_BASELINE_END)]
-            speis = [round(v, 2) for v in _spei_from_balances(rd["balance"].values, b["balance"].values)]
+            raw = _spei_from_balances(rd["balance"].values, b["balance"].values)
+            if raw is None:   # Fisk fit failed → withhold this monthly series (D-16)
+                continue
+            speis = [round(v, 2) for v in raw]
             years = [int(y) for y in rd["year"].tolist()]
             series[m_name] = {"years": years, "spei": speis, "trend": _spei_trend(speis, years)}
 

--- a/data/climate-si/sources/tests/test_precompute.py
+++ b/data/climate-si/sources/tests/test_precompute.py
@@ -8,6 +8,7 @@ calendar / the formula, never read back from the code, so a Phase 4 edit that
 moves a value fails loudly.
 """
 
+import numpy as np
 import pandas as pd
 from pytest import approx
 
@@ -157,3 +158,42 @@ def test_spei_baseline_is_decoupled_and_frozen_1950_1980():
     # The carve-out is meaningless if the two windows are ever pointed at the same
     # thing — that would silently drag SPEI onto the anomaly baseline.
     assert (pc.SPEI_BASELINE_START, pc.SPEI_BASELINE_END) != (pc.BASELINE_START, pc.BASELINE_END)
+
+
+# ── SPEI fit failure withholds, never fabricates (D-16, T-5.1 part 4) ─────────
+#
+# _spei_from_balances used to invent c_par=1.0, scale_par=mean on a Fisk-fit
+# failure and emit SPEI from those fabricated parameters silently. D-16 replaced
+# that with the tropical failure pattern (_tropical_trend): log to stderr + return
+# a sentinel, so the caller WITHHOLDS the series rather than shipping fabricated
+# drought numbers. The failure fires 0x on real data, so these force it directly.
+
+
+def test_spei_fit_failure_returns_sentinel_not_fabricated(monkeypatch, capsys):
+    # Force stats.fisk.fit to raise — the fabrication branch this replaces would
+    # have returned a full list of SPEI values from invented parameters.
+    def _boom(*args, **kwargs):
+        raise RuntimeError("forced Fisk fit failure")
+
+    monkeypatch.setattr(pc.stats.fisk, "fit", _boom)
+    all_vals = np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0])
+    baseline = np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+
+    result = pc._spei_from_balances(all_vals, baseline)
+
+    assert result is None, "fit failure must withhold (None), not fabricate a series"
+    err = capsys.readouterr().err
+    assert "Fisk fit failed" in err and "withholding" in err
+
+
+def test_spei_fit_success_returns_monotone_values(monkeypatch):
+    # Sanity for the happy path: a real fit yields one SPEI per balance, and SPEI is
+    # a monotone transform of balance (ascending input -> non-decreasing output).
+    all_vals = np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0])
+    baseline = np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+
+    result = pc._spei_from_balances(all_vals, baseline)
+
+    assert result is not None
+    assert len(result) == len(all_vals)
+    assert all(result[i] <= result[i + 1] + 1e-9 for i in range(len(result) - 1))

--- a/data/climate-si/sources/tests/test_validate.py
+++ b/data/climate-si/sources/tests/test_validate.py
@@ -294,3 +294,67 @@ def test_extra_column_is_schema_drift(tables):
     s["surprise"] = 1
     t["spei"] = s
     _expect_error(t, "column_in_schema")
+
+
+# ── SPEI fabrication / degradation tripwire (D-16, T-5.1 part 4) ──────────────
+#
+# _check_spei_consistency fails the build if SPEI stops being a monotone, non-
+# degenerate transform of the water balance — the shape a fabricated or collapsed
+# fit produces, which every per-table pandera schema otherwise passes (fabricated
+# values still clip to [-3,3] with a valid cat/colour/rank). The valid `tables`
+# fixture has one row per x group, so it never exercises the check; these build a
+# multi-row national-heatmap group for one season (x=0).
+
+
+def _spei_group(speis: list[float]) -> pd.DataFrame:
+    """A one-season (x=0) national heatmap group, balance ascending, five years.
+    `cat`/`color` are held at 'normal' — the pandera schema only checks their mutual
+    consistency, not that they match the spei value, so these stay valid there and
+    isolate _check_spei_consistency."""
+    balances = [-50.0, -10.0, 5.0, 30.0, 80.0]
+    assert len(speis) == len(balances)
+    return pd.DataFrame([
+        {"x": 0, "y": 1990 + i, "spei": sp, "balance": b, "cat": "normal",
+         "rank": i + 1, "total": len(balances), "color": v.SPEI_CAT_COLOR["normal"],
+         "season": "Winter", "n_days": 90}
+        for i, (b, sp) in enumerate(zip(balances, speis))
+    ])
+
+
+def test_spei_valid_multirow_group_passes(tables):
+    # A genuinely monotone SPEI series (what a real fit produces) must pass — proves
+    # the tripwire does not false-positive on valid multi-row data.
+    t = dict(tables)
+    t["spei"] = _spei_group([-2.0, -0.8, 0.1, 0.9, 2.1])
+    v.validate_tables(t)
+
+
+def test_spei_non_monotone_rejected(tables):
+    # SPEI decoupled from / not ordered by balance — a scrambled or fabricated fit.
+    t = dict(tables)
+    t["spei"] = _spei_group([1.5, -2.0, 0.9, -0.5, 0.3])
+    _expect_error(t, "not monotone in water balance")
+
+
+def test_spei_constant_across_balances_rejected(tables):
+    # SPEI collapsed to a single value across wet-to-dry years — a degenerate fit.
+    t = dict(tables)
+    t["spei"] = _spei_group([0.0, 0.0, 0.0, 0.0, 0.0])
+    _expect_error(t, "constant across")
+
+
+def test_spei_station_length_mismatch_rejected(tables):
+    t = dict(tables)
+    s = tables["spei_station"].copy()
+    s.loc[0, "spei_json"] = "[0.1,0.2,0.3]"   # 3 SPEI vs 2 years
+    t["spei_station"] = s
+    _expect_error(t, "years/SPEI length mismatch")
+
+
+def test_spei_station_constant_series_rejected(tables):
+    t = dict(tables)
+    s = tables["spei_station"].copy()
+    s.loc[0, "years_json"] = "[2000,2001,2002]"
+    s.loc[0, "spei_json"] = "[0.5,0.5,0.5]"    # flat across years -> collapsed fit
+    t["spei_station"] = s
+    _expect_error(t, "constant across")

--- a/data/climate-si/sources/validate.py
+++ b/data/climate-si/sources/validate.py
@@ -40,6 +40,7 @@ import sys
 from datetime import datetime
 from pathlib import Path
 
+import numpy as np
 import pandas as pd
 import pandera.pandas as pa
 import yaml
@@ -448,6 +449,65 @@ def _check_percentile_stations_subset(daily_percentiles: pd.DataFrame,
         if unknown else []
 
 
+def _check_spei_consistency(spei: pd.DataFrame,
+                            spei_station: pd.DataFrame | None) -> list[str]:
+    """Tripwire for fabricated / degraded SPEI (D-16, T-5.1 part 4).
+
+    Correct SPEI is ``norm_ppf(fisk_cdf(balance − shift))`` under ONE log-logistic
+    fit per group, and both transforms are strictly increasing. Two invariants
+    follow, and both hold *by construction* on every valid series (so this passes on
+    current data) yet break the moment SPEI is not a real fit of the balance:
+
+      1. Ordering a group's rows by water balance orders SPEI non-decreasingly.
+         Violated by SPEI that is scrambled, decoupled from balance, inverted, or
+         produced by a different/degenerate distribution per row.
+      2. A group spanning many wet-to-dry years cannot collapse to a single SPEI
+         value. Violated by a fit that collapsed to a constant or pinned every row
+         to a clip boundary.
+
+    Why this exists: `_spei_from_balances` used to FABRICATE `c_par=1.0,
+    scale_par=mean` on a Fisk-fit failure and emit SPEI from them silently. Those
+    values still clip to [-3,3] with a valid cat/colour/rank, so every per-table
+    pandera schema passed them. D-16 removed the fabrication at source (the series is
+    now withheld, not invented); this is the second line of defence so that any
+    *future* fabrication or degradation fails the image build (validate runs at build
+    time, D-9) instead of shipping corrupt drought numbers.
+
+    Scope, stated honestly: it catches SPEI that is decoupled, scrambled, inverted or
+    collapsed — the shapes a broken fit or a wiring bug actually produce. It does NOT
+    catch an arbitrary monotone-but-miscalibrated curve (the old c=1 fabrication was
+    itself monotone); guarding that would need a fuzzy statistical threshold that
+    could false-positive on legitimately extreme drought decades, which is why the
+    primary defence is removal-at-source, not this check. Withheld series (absent
+    rows, or an empty SPEI array) are the honest sentinel and are deliberately NOT
+    flagged. Narrow by design — SPEI integrity only, no unrelated assertions.
+    """
+    errs: list[str] = []
+    # (1)+(2) national heatmap: monotone in balance, non-degenerate, per season x.
+    for x, g in spei.groupby("x"):
+        s = g.sort_values("balance", kind="stable")["spei"].to_numpy()
+        if len(s) >= 2 and (np.diff(s) < 0).any():
+            errs.append(f"spei[x={x}]: SPEI not monotone in water balance "
+                        f"— decoupled/scrambled/fabricated fit")
+        if len(s) >= 2 and float(np.ptp(s)) == 0.0:
+            errs.append(f"spei[x={x}]: SPEI constant across {len(s)} varying "
+                        f"balances — collapsed/degenerate fit")
+    # (2) per-station series: years/SPEI arrays equal length; a multi-year SPEI array
+    #     must vary. Empty arrays (the withhold sentinel) are intentionally allowed.
+    if spei_station is not None:
+        for _, r in spei_station.iterrows():
+            years = json.loads(r["years_json"])
+            spei_arr = json.loads(r["spei_json"])
+            tag = f"spei_station[{r['era5_name']}/{r['series']}]"
+            if len(years) != len(spei_arr):
+                errs.append(f"{tag}: years/SPEI length mismatch "
+                            f"({len(years)} vs {len(spei_arr)})")
+            if len(spei_arr) >= 2 and len(set(spei_arr)) == 1:
+                errs.append(f"{tag}: SPEI constant across {len(spei_arr)} years "
+                            f"— collapsed/degenerate fit")
+    return errs
+
+
 # ── Orchestration ───────────────────────────────────────────────────────────────
 
 def validate_tables(tables: dict[str, pd.DataFrame], config: dict | None = None) -> None:
@@ -509,6 +569,8 @@ def validate_tables(tables: dict[str, pd.DataFrame], config: dict | None = None)
     if "daily_percentiles" in tables and "stations" in tables:
         errors += _check_percentile_stations_subset(tables["daily_percentiles"],
                                                     tables["stations"])
+    if "spei" in tables:
+        errors += _check_spei_consistency(tables["spei"], tables.get("spei_station"))
 
     if errors:
         raise PipelineValidationError(

--- a/tests/fixtures/snapshot.json
+++ b/tests/fixtures/snapshot.json
@@ -61,6 +61,7 @@
     "structural": [
       "Dashboard",
       "Era5Charts",
+      "ErrorBoundary",
       "RegressionPanel",
       "Show",
       "SiteMeta",

--- a/tests/snapshot/sections.json
+++ b/tests/snapshot/sections.json
@@ -99,6 +99,7 @@
     "RegressionPanel": "Context provider only (RegressionPanel.tsx:121). Supplies the analysis store to the cards, renders no DOM of its own.",
     "Show": "solid-js control flow.",
     "Suspense": "solid-js control flow.",
+    "ErrorBoundary": "solid-js control flow (T-5.1). Wraps each section's fetch consumer so a failed fetch shows a visible SectionError instead of vanishing or blanking the page. Renders its children unchanged on success (no DOM wrapper), so it is transparent to the happy-path snapshot; the error branch is never exercised by the fixtures.",
     "SiteMeta": "NOT a component. A type argument in createResource<SiteMeta> (AliJeVroceERA5.tsx:35) that the tag regex cannot distinguish from JSX. Classified explicitly rather than special-cased in the extractor, so the extractor stays dumb and auditable."
   },
 

--- a/tests/typecheck-allowlist.txt
+++ b/tests/typecheck-allowlist.txt
@@ -24,4 +24,4 @@ code/ali-je-vroce-era5/charts/RegressionChart.tsx(90,36): TS2694
 code/ali-je-vroce-era5/charts/TodayGauge.tsx(37,41): TS2352
 code/ali-je-vroce-era5/charts/YearRoundChart.tsx(55,41): TS2352
 code/ali-je-vroce-era5/components/TodayLast7Chart.tsx(34,41): TS2352
-code/ali-je-vroce-era5/components/TodayTrendChart.tsx(49,41): TS2352
+code/ali-je-vroce-era5/components/TodayTrendChart.tsx(50,41): TS2352

--- a/tests/unit/silent-failures.test.ts
+++ b/tests/unit/silent-failures.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  parseJsonColumn,
+  fetchSpeiHeatmap,
+  fetchSpeiStationSeasonal,
+  fetchEra5Tropical,
+} from "../../code/ali-je-vroce-era5/api.ts";
+
+// T-5.1 — kill silent failures. Two behaviours are pinned here:
+//
+//   Part 2 — parseJsonColumn wraps every JSON.parse of a datasette `*_json` column
+//   so malformed data becomes a descriptive, handled throw (which the section
+//   ErrorBoundary renders) rather than a bare "Unexpected token" SyntaxError.
+//
+//   Part 1 — the three helpers that used to swallow a fetch/parse failure into an
+//   "unavailable" sentinel (so the section silently vanished) now let the failure
+//   propagate. A genuinely empty result set is still legitimate "no data" and keeps
+//   returning the sentinel — that distinction is the point.
+
+describe("parseJsonColumn (T-5.1 Part 2)", () => {
+  it("parses valid JSON", () => {
+    expect(parseJsonColumn<number[]>("[1,2,3]", "spei_station.years_json")).toEqual([1, 2, 3]);
+  });
+
+  it("throws a descriptive error naming the column on malformed JSON", () => {
+    expect(() => parseJsonColumn("{not json", "tropical.trend_json"))
+      .toThrowError(/Malformed JSON in datasette column tropical\.trend_json/);
+  });
+});
+
+// ── fetch propagation vs. swallow (Part 1) ──────────────────────────────────────
+
+const realFetch = globalThis.fetch;
+afterEach(() => { globalThis.fetch = realFetch; });
+
+// Stub the network for one call. `body` is the JSON text the datasette would return;
+// `ok:false` simulates an HTTP error (dsGet throws on !resp.ok).
+function stubFetch(body: string, ok = true): void {
+  globalThis.fetch = (async () =>
+    new Response(body, { status: ok ? 200 : 500, headers: { "content-type": "application/json" } })
+  ) as typeof fetch;
+}
+
+describe("section-fetch failures propagate instead of vanishing (T-5.1 Part 1)", () => {
+  it("fetchSpeiHeatmap rejects on an HTTP error (was: swallowed to available:false)", async () => {
+    stubFetch("", false);
+    await expect(fetchSpeiHeatmap()).rejects.toThrow(/Datasette 500/);
+  });
+
+  it("fetchSpeiHeatmap still returns the unavailable sentinel on genuinely empty data", async () => {
+    stubFetch("[]");
+    await expect(fetchSpeiHeatmap()).resolves.toMatchObject({ available: false });
+  });
+
+  it("fetchSpeiStationSeasonal rejects on a malformed *_json row (was: swallowed)", async () => {
+    // A well-formed outer row whose spei_json payload is corrupt — the exact case
+    // that used to blank the whole SPEI-trend section without a trace.
+    stubFetch(JSON.stringify([
+      { era5_name: "Ljubljana", series: "spei3", years_json: "[2000]", spei_json: "{bad", trend_json: "{}" },
+    ]));
+    await expect(fetchSpeiStationSeasonal())
+      .rejects.toThrow(/Malformed JSON in datasette column spei_station\.spei_json/);
+  });
+
+  it("fetchEra5Tropical rejects on an HTTP error (was: swallowed to null)", async () => {
+    stubFetch("", false);
+    await expect(fetchEra5Tropical("Ljubljana", "days", 30, 1)).rejects.toThrow(/Datasette 500/);
+  });
+
+  it("fetchEra5Tropical still returns null on genuinely empty data", async () => {
+    stubFetch("[]");
+    await expect(fetchEra5Tropical("Ljubljana", "days", 30, 1)).resolves.toBeNull();
+  });
+});


### PR DESCRIPTION
## T-5.1 — kill silent failures

**Part 1+2 (`25a7bc6`):** section fetches now surface a visible error (`SectionError.tsx`, `role="alert"`, retry) instead of vanishing — wired at all 10 section boundaries. All 12 `*_json` parses guarded with column-named errors. ErrorBoundary transparent on success (happy-path snapshot untouched). 7 new tests.

**Part 3 (`7583059`):** removed the global `warnings.filterwarnings("ignore")` — NB-fit numerics + a pandas deprecation now visible (they mark the 28 graceful fit failures). Only a benign log-link UserWarning narrowly suppressed. Output-neutral: all 9 tables byte-identical.

**Part 4 (`23d4145`, D-16):** `_spei_from_balances` fabricated `c_par=1.0, scale_par=mean` on Fisk-fit failure and emitted SPEI silently (fires 0× today, but would corrupt all SPEI + pass every schema). Replaced with the tropical withhold-on-failure pattern (sentinel + log). Added `validate.py` tripwire asserting SPEI is monotone-in-water-balance — catches decoupled/fabricated SPEI that clips to [-3,3]. Proven: rejects a fabricated fixture (exit 1), passes clean data. All 9 tables byte-identical.

**Gates:** typecheck OK (8 allowlisted), test 45, snapshot green (no re-record), pytest 25, validate.py passes.