### PR TITLE
T-5.4a: structural accessibility (a11y module, chart summaries, data tables, keyboard nav)

### DIFF
--- a/code/ali-je-vroce-era5/charts/DistributionChart.tsx
+++ b/code/ali-je-vroce-era5/charts/DistributionChart.tsx
@@ -1,5 +1,6 @@
 import { onMount, onCleanup, createEffect } from "solid-js";
 import type { TodayStatus } from "../types.ts";
+import { enableChartA11y } from "./highcharts-a11y.ts";
 
 interface Props {
   data:    TodayStatus;
@@ -50,6 +51,11 @@ function buildOptions(r: TodayStatus): Highcharts.Options {
     title:   { text: undefined },
     credits: { enabled: false },
     legend:  { enabled: false },
+    // T-5.4a — screen-reader summary (Slovenian copy awaiting operator review)
+    accessibility: {
+      enabled: true,
+      description: "Porazdelitev najvišjih dnevnih temperatur na dneve okoli izbranega datuma v vseh letih zabeleženega obdobja. Navpična črta označuje današnjo vrednost; barvni pasovi ločijo klimatološke cone od hladne do ekstremne.",
+    },
     tooltip: {
       formatter(this: any) {
         const temp: number = this.x;
@@ -130,6 +136,7 @@ export function DistributionChart(props: Props) {
 
   onMount(async () => {
     const Highcharts = (await import("highcharts")).default;
+    await enableChartA11y(Highcharts);
     const r = props.data;
     if (!r.available || !r.distribution?.length || !r.cutoffs) return;
     chart = Highcharts.chart(container, buildOptions(r));

--- a/code/ali-je-vroce-era5/charts/RegressionChart.tsx
+++ b/code/ali-je-vroce-era5/charts/RegressionChart.tsx
@@ -1,5 +1,6 @@
 import { onMount, onCleanup, createEffect } from "solid-js";
 import type { RegressionResponse } from "../types.ts";
+import { enableChartA11y } from "./highcharts-a11y.ts";
 
 interface Props {
   data:    RegressionResponse;
@@ -69,6 +70,7 @@ export function RegressionChart(props: Props) {
   onMount(async () => {
     const HC = (await import("highcharts")).default;
     await import("highcharts/highcharts-more");
+    await enableChartA11y(HC);
 
     const d = props.data;
     chart = HC.chart(container, {
@@ -79,8 +81,13 @@ export function RegressionChart(props: Props) {
       },
       title:         null,
       credits:       { enabled: false },
-      exporting:     { enabled: false },
-      accessibility: { enabled: false },
+      // T-5.4a — screen-reader summary (Slovenian copy awaiting operator review).
+      // Was `{ enabled: false }` (only to silence the missing-module warning); the
+      // module is now loaded, so this chart is properly exposed to assistive tech.
+      accessibility: {
+        enabled: true,
+        description: "Razsevni diagram letnih vrednosti izbrane spremenljivke z regresijsko linijo trenda in 95-odstotnim intervalom zaupanja; črtkana črta označuje povprečje referenčnega obdobja.",
+      },
       legend: {
         enabled: true,
         itemStyle: { fontFamily: "'Space Grotesk', system-ui, sans-serif", fontWeight: "600", fontSize: "11px", color: "#1a1a18" },

--- a/code/ali-je-vroce-era5/charts/SeaLevelWidget.tsx
+++ b/code/ali-je-vroce-era5/charts/SeaLevelWidget.tsx
@@ -348,7 +348,11 @@ export function SeaLevelWidget() {
   // ── Template ──────────────────────────────────────────────────────────────
 
   return (
-    <div class="sl-widget">
+    <div
+      class="sl-widget"
+      role="group"
+      aria-label="Interaktivni prikaz dviga morske gladine v Kopru po scenarijih IPCC AR6; gumbi izberejo scenarij in verjetnost, drsnik leto, ločnica pa primerja sedanjost s projekcijo."
+    >
 
       {/* Controls bar */}
       <div class="sl-ctrl">

--- a/code/ali-je-vroce-era5/charts/SeasonHeatmap.tsx
+++ b/code/ali-je-vroce-era5/charts/SeasonHeatmap.tsx
@@ -29,6 +29,15 @@ const MODES = [
   { key: "Winter",   label: "Zima" },
 ];
 
+// T-5.4a — visually-hidden (screen-reader-only) style. Kept off the visual layout
+// entirely, so it changes nothing a sighted reader sees. Kebab-case keys because
+// Solid's style() calls setProperty() and silently drops camelCase.
+const SR_ONLY = {
+  position: "absolute", width: "1px", height: "1px", padding: "0",
+  margin: "-1px", overflow: "hidden", clip: "rect(0,0,0,0)",
+  "white-space": "nowrap", border: "0",
+} as const;
+
 interface Props { data: SeasonHeatmapRow[]; }
 interface TipData { row: SeasonHeatmapRow; px: number; py: number; }
 
@@ -67,6 +76,17 @@ export function SeasonHeatmap(props: Props) {
   });
 
   const decadeTicks = createMemo(() => allYears().filter(y => y % 10 === 0));
+
+  // T-5.4a — the same data the colour grid encodes, in a form assistive tech can
+  // read: one row per (season, year). Sorted season-then-year for stable reading.
+  const tableRows = createMemo(() =>
+    [...props.data].sort((a, b) =>
+      a.season === b.season ? a.y - b.y : a.season.localeCompare(b.season))
+  );
+  const gridLabel = createMemo(() => {
+    const ys = allYears();
+    return `Toplotna karta letnih časov po letih od ${ys[0]} do ${ys[ys.length - 1]}: vsak stolpec je eno leto, vsaka vrstica en letni čas, barva pa uvršča povprečno najvišjo temperaturo od hladne do ekstremne glede na referenčno obdobje. Celotni podatki so v tabeli pod grafom.`;
+  });
 
   function cellClass(season: string, cat: string, year: number): string {
     if (!revealedYears().has(year)) return "shm-cell shm-cell--dim";
@@ -140,8 +160,10 @@ export function SeasonHeatmap(props: Props) {
         </button>
       </div>
 
-      {/* Grid */}
-      <div class="shm-grid">
+      {/* Grid — decorative colour encoding; announced as one labelled image so a
+          screen reader gets the summary and skips the unlabeled cells. The numbers
+          live in the visually-hidden table below (T-5.4a). */}
+      <div class="shm-grid" role="img" aria-label={gridLabel()}>
         <For each={SEASON_ORDER}>
           {(season) => (
             <>
@@ -232,6 +254,34 @@ export function SeasonHeatmap(props: Props) {
           </div>
         )}
       </Show>
+
+      {/* T-5.4a — screen-reader data-table fallback (visually hidden). Slovenian
+          caption/headers awaiting operator review. */}
+      <table style={SR_ONLY}>
+        <caption>Podatki toplotne karte letnih časov po letih</caption>
+        <thead>
+          <tr>
+            <th scope="col">Letni čas</th>
+            <th scope="col">Leto</th>
+            <th scope="col">Kategorija</th>
+            <th scope="col">Povprečni maksimum (°C)</th>
+            <th scope="col">Uvrstitev</th>
+          </tr>
+        </thead>
+        <tbody>
+          <For each={tableRows()}>
+            {(r) => (
+              <tr>
+                <td>{SEASON_LABEL[r.season as Season] ?? r.season}</td>
+                <td>{r.y}</td>
+                <td>{CAT_LABELS[r.cat] ?? r.cat}</td>
+                <td>{r.avg.toFixed(1)}</td>
+                <td>{r.rank}. od {r.total}</td>
+              </tr>
+            )}
+          </For>
+        </tbody>
+      </table>
     </div>
   );
 }

--- a/code/ali-je-vroce-era5/charts/SpeiHeatmap.tsx
+++ b/code/ali-je-vroce-era5/charts/SpeiHeatmap.tsx
@@ -32,6 +32,14 @@ const MODES = [
   { key: "Winter",   label: "Zima" },
 ];
 
+// T-5.4a — visually-hidden (screen-reader-only) style. Kebab-case keys because
+// Solid's style() calls setProperty() and silently drops camelCase.
+const SR_ONLY = {
+  position: "absolute", width: "1px", height: "1px", padding: "0",
+  margin: "-1px", overflow: "hidden", clip: "rect(0,0,0,0)",
+  "white-space": "nowrap", border: "0",
+} as const;
+
 interface SpeiRow {
   season:  string;
   y:       number;
@@ -87,6 +95,16 @@ export function SpeiHeatmap(props: SpeiHeatmapProps) {
   });
 
   const decadeTicks = createMemo(() => allYears().filter(y => y % 10 === 0));
+
+  // T-5.4a — the same data the colour grid encodes, in a form assistive tech can
+  // read: one row per (season, year). Sorted season-then-year for stable reading.
+  const tableRows = createMemo(() =>
+    [...props.data.data].sort((a, b) =>
+      a.season === b.season ? a.y - b.y : a.season.localeCompare(b.season))
+  );
+  const gridLabel = createMemo(() =>
+    `Toplotna karta sušnega indeksa SPEI po letnih časih in letih od ${props.data.year_min} do ${props.data.year_max}: vsak stolpec je eno leto, vsaka vrstica en letni čas, barva pa označuje razmere od hude suše do zelo mokrega. Celotni podatki so v tabeli pod grafom.`
+  );
 
   function isExtreme(cat: string) { return cat === "extreme_dry" || cat === "extreme_wet"; }
 
@@ -162,8 +180,10 @@ export function SpeiHeatmap(props: SpeiHeatmapProps) {
         </button>
       </div>
 
-      {/* Grid */}
-      <div class="shm-grid">
+      {/* Grid — decorative colour encoding; announced as one labelled image so a
+          screen reader gets the summary and skips the unlabeled cells. The numbers
+          live in the visually-hidden table below (T-5.4a). */}
+      <div class="shm-grid" role="img" aria-label={gridLabel()}>
         <For each={SEASON_ORDER}>
           {(season) => (
             <>
@@ -258,6 +278,36 @@ export function SpeiHeatmap(props: SpeiHeatmapProps) {
           );
         }}
       </Show>
+
+      {/* T-5.4a — screen-reader data-table fallback (visually hidden). Slovenian
+          caption/headers awaiting operator review. */}
+      <table style={SR_ONLY}>
+        <caption>Podatki toplotne karte sušnega indeksa SPEI po letnih časih in letih</caption>
+        <thead>
+          <tr>
+            <th scope="col">Letni čas</th>
+            <th scope="col">Leto</th>
+            <th scope="col">Kategorija</th>
+            <th scope="col">SPEI</th>
+            <th scope="col">Vodna bilanca (mm)</th>
+            <th scope="col">Uvrstitev</th>
+          </tr>
+        </thead>
+        <tbody>
+          <For each={tableRows()}>
+            {(r) => (
+              <tr>
+                <td>{SEASON_LABEL[r.season as Season] ?? r.season}</td>
+                <td>{r.y}</td>
+                <td>{CAT_LABELS[r.cat] ?? r.cat}</td>
+                <td>{r.spei >= 0 ? "+" : ""}{r.spei.toFixed(2)}</td>
+                <td>{r.balance.toFixed(0)}</td>
+                <td>{r.rank}. od {r.total}</td>
+              </tr>
+            )}
+          </For>
+        </tbody>
+      </table>
     </div>
   );
 }

--- a/code/ali-je-vroce-era5/charts/SpeiTrendChart.tsx
+++ b/code/ali-je-vroce-era5/charts/SpeiTrendChart.tsx
@@ -1,4 +1,5 @@
 import { createSignal, createMemo, For, Show, onMount, onCleanup } from "solid-js";
+import { enableChartA11y } from "./highcharts-a11y.ts";
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -81,6 +82,11 @@ function SpeiScatterChart(props: ChartProps) {
       title:   { text: "" },
       credits: { enabled: false },
       legend:  { enabled: false },
+      // T-5.4a — screen-reader summary (Slovenian copy awaiting operator review)
+      accessibility: {
+        enabled: true,
+        description: "Razsevni diagram sušnega indeksa SPEI po letih za izbrano postajo in obdobje, z linijo trenda Theil-Sen ter pragovoma hude suše (−1,5) in zelo mokrega (+1,5).",
+      },
       tooltip: {
         formatter(this: any) {
           const v = this.y as number;
@@ -120,6 +126,7 @@ function SpeiScatterChart(props: ChartProps) {
 
   onMount(async () => {
     const Highcharts = (await import("highcharts")).default;
+    await enableChartA11y(Highcharts);
     chart = Highcharts.chart(container, buildOpts() as any);
   });
 

--- a/code/ali-je-vroce-era5/charts/TodayGauge.tsx
+++ b/code/ali-je-vroce-era5/charts/TodayGauge.tsx
@@ -1,5 +1,6 @@
 import { onMount, onCleanup, createEffect } from "solid-js";
 import type { TodayStatus } from "../types.ts";
+import { enableChartA11y } from "./highcharts-a11y.ts";
 
 interface Props {
   data: TodayStatus;
@@ -28,6 +29,11 @@ export function TodayGauge(props: Props) {
   onMount(async () => {
     const Highcharts = (await import("highcharts")).default;
     await import("highcharts/highcharts-more");
+    // T-5.4a — load the a11y module so this decorative gauge is deterministically
+    // marked aria-hidden (accessibility.enabled stays false below): its value is
+    // already announced by the "°C" text under it and by TodayCard, so a second
+    // screen-reader region would only duplicate.
+    await enableChartA11y(Highcharts);
 
     const r = props.data;
     const catKey = r.category_key ?? "nope";

--- a/code/ali-je-vroce-era5/charts/TropicalChart.tsx
+++ b/code/ali-je-vroce-era5/charts/TropicalChart.tsx
@@ -8,6 +8,7 @@
 // `fetchEra5Tropical` (`api.ts:444`) over datasette.
 import { createEffect, onMount, onCleanup } from "solid-js";
 import { todayYear } from "../clock";
+import { enableChartA11y } from "./highcharts-a11y.ts";
 
 export interface TropTrend {
   model_used:      boolean | "nb";
@@ -154,12 +155,19 @@ export function TropHighchart(props: ChartProps) {
   onMount(async () => {
     const Highcharts = (await import("highcharts")).default;
     await import("highcharts/highcharts-more");
+    await enableChartA11y(Highcharts);
 
     chart = Highcharts.chart(container, {
       chart: { type: "column", height: 300, backgroundColor: "transparent", animation: false, style: { fontFamily: "Space Grotesk, sans-serif" } },
       title:   { text: undefined },
       credits: { enabled: false },
       legend:  { enabled: true, itemStyle: { fontSize: "10px", fontWeight: "400", color: INK } },
+      // T-5.4a — screen-reader summary (Slovenian copy awaiting operator review).
+      // Parameterised by cfg so days vs nights each get their own wording.
+      accessibility: {
+        enabled: true,
+        description: `Stolpčni prikaz letnega števila — ${props.cfg.tooltipNoun.toLowerCase()}, torej koliko ${props.cfg.unitLabel} na leto preseže izbrani temperaturni prag — z modelom trenda negativne binomske regresije in intervalom zaupanja; zadnji stolpec je leto v teku.`,
+      },
       tooltip: {
         formatter(this: any) {
           if (this.series.type === "line") return `<b>${Math.round(this.x)}</b><br>Trend: <b>${this.y!.toFixed(1)}</b> ${props.cfg.unitLabel}`;

--- a/code/ali-je-vroce-era5/charts/YearRoundChart.tsx
+++ b/code/ali-je-vroce-era5/charts/YearRoundChart.tsx
@@ -1,5 +1,6 @@
 import { onMount, onCleanup, createEffect } from "solid-js";
 import type { CalendarData } from "../api.ts";
+import { enableChartA11y } from "./highcharts-a11y.ts";
 
 interface Props {
   data: CalendarData;
@@ -49,6 +50,7 @@ export function YearRoundChart(props: Props) {
 
   onMount(async () => {
     const Highcharts = (await import("highcharts")).default;
+    await enableChartA11y(Highcharts);
 
     const colData = buildSeries(props.data, props.var);
 
@@ -67,6 +69,11 @@ export function YearRoundChart(props: Props) {
       subtitle: { text: undefined },
       credits:  { enabled: false },
       legend:   { enabled: false },
+      // T-5.4a — screen-reader summary (Slovenian copy awaiting operator review)
+      accessibility: {
+        enabled: true,
+        description: "Trend spremembe po dnevih v letu čez celotno koledarsko leto — vsak stolpec je en dan, višina je trend na desetletje, navpična črta pa označuje izbrani datum.",
+      },
       xAxis: {
         min: 0.5, max: 365.5,
         tickPositions: MONTH_MIDS,

--- a/code/ali-je-vroce-era5/charts/highcharts-a11y.ts
+++ b/code/ali-je-vroce-era5/charts/highcharts-a11y.ts
@@ -1,0 +1,44 @@
+// T-5.4a — Highcharts accessibility bootstrap.
+//
+// Loads the accessibility + export-data modules as SIDE-EFFECT imports — the same
+// idiom every chart on this page already uses for `highcharts/highcharts-more`
+// (e.g. RegressionChart.tsx:71) — and registers one global default so the
+// screen-reader "view as data table" affordance stays available without the
+// visible export hamburger button ever appearing.
+//
+// Order matters: export-data @requires modules/exporting, and accessibility must
+// register after core. All three are awaited before any chart calls
+// Highcharts.chart(), so a chart is never constructed before the modules exist.
+//
+// Idempotent + memoised: the imports and setOptions run exactly once no matter how
+// many chart instances call this. `enableChartA11y` takes the Highcharts instance
+// the caller already imported (a singleton) rather than importing core itself, so
+// there is no second copy of Highcharts.
+//
+// SNAPSHOT: the three module paths below are aliased to tests/snapshot/highcharts-stub.ts
+// in tests/snapshot/vite.config.mjs. Under the harness these imports are no-op
+// side effects and HC.setOptions is the stub's no-op, so nothing here reaches real
+// Highcharts — exactly as the existing highcharts-more / modules/map aliases do.
+
+let ready: Promise<void> | null = null;
+
+export function enableChartA11y(HC: any): Promise<void> {
+  if (!ready) {
+    ready = (async () => {
+      await import("highcharts/modules/exporting");
+      await import("highcharts/modules/export-data");
+      await import("highcharts/modules/accessibility");
+      HC.setOptions({
+        // exporting.enabled:false keeps the export-data API (chart.viewData /
+        // getDataRows) available — so the accessibility module still offers
+        // "view as data table" inside its clipped, opacity-0.01 screen-reader
+        // region — WITHOUT ever drawing the visible export/context menu button.
+        // Verified in a real browser (Highcharts 12.6.0): 0 visible buttons, the
+        // view-data-table proxy present in the SR region. Purely additive; no
+        // rendered pixel changes (T-5.4a).
+        exporting: { enabled: false },
+      });
+    })();
+  }
+  return ready;
+}

--- a/code/ali-je-vroce-era5/components/HeroCards.tsx
+++ b/code/ali-je-vroce-era5/components/HeroCards.tsx
@@ -257,7 +257,10 @@ function HeroCard(props: { res: RegressionResult; unit: string; dateLabel: strin
   const risk = () => CLIMATE_RISKS[res().loc];
 
   return (
-    <div style={{
+    <div
+      role="group"
+      aria-label={`Podrobnosti lokacije ${res().loc.replace(/_/g, " ")}: stoletni temperaturni trend, kategorija tveganja in vpliv podnebne spremembe.`}
+      style={{
       background:    "var(--color-card)",
       border:        "1px solid var(--color-rule)",
       "border-radius": "var(--radius, 10px)",

--- a/code/ali-je-vroce-era5/components/StationMap.tsx
+++ b/code/ali-je-vroce-era5/components/StationMap.tsx
@@ -1,4 +1,5 @@
 import { onMount, onCleanup, createEffect } from "solid-js";
+import { enableChartA11y } from "../charts/highcharts-a11y.ts";
 import type { SiteMeta } from "../types.ts";
 
 interface Props {
@@ -41,6 +42,7 @@ export function StationMap(props: Props) {
     const mapMod = await import("highcharts/modules/map") as any;
     const initFn = mapMod.default ?? mapMod;
     if (typeof initFn === 'function') initFn(Highcharts);
+    await enableChartA11y(Highcharts);
 
     const topoUrl = `https://code.highcharts.com/mapdata/countries/${props.meta.country}/${props.meta.country}-all.topo.json`;
     const topo = await fetch(topoUrl).then(r => r.json());
@@ -59,6 +61,11 @@ export function StationMap(props: Props) {
       subtitle: { text: null },
       credits:  { enabled: false },
       legend:   { enabled: false },
+      // T-5.4a — screen-reader summary (Slovenian copy awaiting operator review)
+      accessibility: {
+        enabled: true,
+        description: "Zemljevid Slovenije z merilnimi postajami; barva točke označuje višinski pas postaje. Postajo lahko izberete tudi s spustnim seznamom v analizi trendov.",
+      },
       mapNavigation: {
         enabled: true,
         buttonOptions: { verticalAlign: "bottom" },

--- a/code/ali-je-vroce-era5/components/TodayLast7Chart.tsx
+++ b/code/ali-je-vroce-era5/components/TodayLast7Chart.tsx
@@ -1,5 +1,6 @@
 import { onMount, onCleanup, createEffect } from "solid-js";
 import type { Last7 } from "../types.ts";
+import { enableChartA11y } from "../charts/highcharts-a11y.ts";
 
 const CAT_ORDER  = ["freezing", "cold", "nope", "hot", "hell"];
 const CAT_COLORS = ["#3a5a8a", "#6c8fb6", "#e7d9b8", "#c25a2c", "#962c1a"];
@@ -18,6 +19,7 @@ export function TodayLast7Chart(props: Props) {
 
   onMount(async () => {
     const Highcharts = (await import("highcharts")).default;
+    await enableChartA11y(Highcharts);
 
     const points = props.days.map((d) => {
       const [, mm, dd] = d.date.split("-");
@@ -43,6 +45,11 @@ export function TodayLast7Chart(props: Props) {
       title:   { text: null },
       credits: { enabled: false },
       legend:  { enabled: false },
+      // T-5.4a — screen-reader summary (Slovenian copy awaiting operator review)
+      accessibility: {
+        enabled: true,
+        description: "Gibanje toplotne kategorije v zadnjih sedmih dneh — vsaka točka je en dan, uvrščen od zmrzujoče do peklensko glede na zgodovinske percentile.",
+      },
       tooltip: {
         formatter(this: any) {
           const p = this.point as any;

--- a/code/ali-je-vroce-era5/components/TodayTrendChart.tsx
+++ b/code/ali-je-vroce-era5/components/TodayTrendChart.tsx
@@ -2,6 +2,7 @@ import { createResource, Show, ErrorBoundary, onMount, onCleanup, createEffect }
 import { fetchAnnualTrend, ERA5_NATIONAL } from "../api.ts";
 import { todayYear } from "../clock.ts";
 import { sectionErrorFallback } from "./SectionError.tsx";
+import { enableChartA11y } from "../charts/highcharts-a11y.ts";
 import type { AnnualTrend } from "../types.ts";
 
 const INK      = "#0E0E0C";
@@ -39,6 +40,7 @@ function TrendHighchart(props: ChartProps) {
   onMount(async () => {
     const Highcharts = (await import("highcharts")).default;
     await import("highcharts/highcharts-more");
+    await enableChartA11y(Highcharts);
 
     const d = props.trend;
     // Rendered as a visible plotline label below, on a component that mounts on
@@ -58,6 +60,11 @@ function TrendHighchart(props: ChartProps) {
       title:   { text: null },
       credits: { enabled: false },
       legend:  { enabled: false },
+      // T-5.4a — screen-reader summary (Slovenian copy awaiting operator review)
+      accessibility: {
+        enabled: true,
+        description: "Letni trend najvišjih temperatur okoli izbranega datuma z linijo Theil-Sen, 95-odstotnim intervalom zaupanja in projekcijo do leta 2050. Vsaka pika je vrednost enega leta.",
+      },
       tooltip: {
         formatter(this: any) {
           if (this.series.name === "Annual value") return `<b>${Math.round(this.x)}</b>: ${this.y.toFixed(1)} °C`;

--- a/tests/snapshot/vite.config.mjs
+++ b/tests/snapshot/vite.config.mjs
@@ -37,6 +37,12 @@ export default defineConfig({
       // Order matters: the exact-match regexes keep `highcharts/...` submodules
       // from being caught by the bare `highcharts` rule.
       { find: /^highcharts\/modules\/map$/, replacement: here("./highcharts-stub.ts") },
+      // T-5.4a — the accessibility bootstrap (charts/highcharts-a11y.ts) side-effect
+      // imports these three; alias them to the stub so the harness never loads the
+      // real modules (which would expect real Highcharts internals the stub omits).
+      { find: /^highcharts\/modules\/accessibility$/, replacement: here("./highcharts-stub.ts") },
+      { find: /^highcharts\/modules\/export-data$/, replacement: here("./highcharts-stub.ts") },
+      { find: /^highcharts\/modules\/exporting$/, replacement: here("./highcharts-stub.ts") },
       { find: /^highcharts\/highcharts-more$/, replacement: here("./highcharts-stub.ts") },
       { find: /^highcharts$/, replacement: here("./highcharts-stub.ts") },
     ],

--- a/tests/typecheck-allowlist.txt
+++ b/tests/typecheck-allowlist.txt
@@ -17,11 +17,11 @@
 #   yarn typecheck 2>&1 | grep -E '^\S.*\([0-9]+,[0-9]+\): error TS' \
 #     | sed -E 's/: error (TS[0-9]+).*/: \1/'
 
-code/ali-je-vroce-era5/charts/DistributionChart.tsx(41,10): TS2352
-code/ali-je-vroce-era5/charts/RegressionChart.tsx(37,23): TS2724
-code/ali-je-vroce-era5/charts/RegressionChart.tsx(74,33): TS2352
-code/ali-je-vroce-era5/charts/RegressionChart.tsx(90,36): TS2694
-code/ali-je-vroce-era5/charts/TodayGauge.tsx(37,41): TS2352
-code/ali-je-vroce-era5/charts/YearRoundChart.tsx(55,41): TS2352
-code/ali-je-vroce-era5/components/TodayLast7Chart.tsx(34,41): TS2352
-code/ali-je-vroce-era5/components/TodayTrendChart.tsx(50,41): TS2352
+code/ali-je-vroce-era5/charts/DistributionChart.tsx(42,10): TS2352
+code/ali-je-vroce-era5/charts/RegressionChart.tsx(38,23): TS2724
+code/ali-je-vroce-era5/charts/RegressionChart.tsx(76,33): TS2352
+code/ali-je-vroce-era5/charts/RegressionChart.tsx(97,36): TS2694
+code/ali-je-vroce-era5/charts/TodayGauge.tsx(43,41): TS2352
+code/ali-je-vroce-era5/charts/YearRoundChart.tsx(57,41): TS2352
+code/ali-je-vroce-era5/components/TodayLast7Chart.tsx(36,41): TS2352
+code/ali-je-vroce-era5/components/TodayTrendChart.tsx(52,41): TS2352


### PR DESCRIPTION
## T-5.4a — structural/programmatic accessibility

The page was `role=0, aria=0, <table>=0` — unusable on a screen reader. This adds the accessible layer without changing anything visible.

- Shared Highcharts a11y loader wired into all 10 chart instances
- Slovenian `accessibility.description` on 8 data-bearing charts; `role="img"`+aria-label on 2 DOM heatmaps (with hidden `<table>` fallbacks); `role="group"` landmarks
- On-demand data-table fallback (built-in `viewData()`, 0 visible buttons)
- Keyboard nav of data points

**Before/after (per chart):** role 1→4, aria-label 1→5, on-demand `<table>`. Snapshot **byte-identical** — purely additive, no visible change.

Slovenian summary wording is functional-for-now; polish deferred to T-5.5 (i18n extraction). Colour-cue accessibility is T-5.4b (separate).

**Gates:** typecheck OK (8 allowlisted, relocated), test 45, snapshot green (no re-record), pytest 25.