### PR TITLE
T-5.5: Slovenian i18n extraction — parameterised catalogue (D-8)

### DIFF
--- a/code/ali-je-vroce-era5/AliJeVroceERA5.tsx
+++ b/code/ali-je-vroce-era5/AliJeVroceERA5.tsx
@@ -8,6 +8,7 @@ import { TodayTrendChart } from "./components/TodayTrendChart.tsx";
 import { RegressionPanel, RegToolbar, RegScatterCard, RegYearRoundCard, useReg,
          panelHStyle, panelTitleStyle, panelSubStyle } from "./components/RegressionPanel.tsx";
 import type { SiteMeta } from "./types.ts";
+import { t, fmtNum, fmtInt, fmtMonthDay } from "./i18n/format.ts";
 
 const Era5SeasonHeatmapChart = lazy(() => import("./charts/Era5SeasonHeatmap.tsx").then(m => ({ default: m.Era5SeasonHeatmap })));
 const StationMap             = lazy(() => import("./components/StationMap.tsx").then(m => ({ default: m.StationMap })));
@@ -17,13 +18,16 @@ const SpeiHeatmapChart       = lazy(() => import("./charts/SpeiHeatmap.tsx").the
 const SpeiTrendChartLazy     = lazy(() => import("./charts/SpeiTrendChart.tsx").then(m => ({ default: m.SpeiTrendChart })));
 const SeaLevelChart          = lazy(() => import("./charts/SeaLevelWidget.tsx").then(m => ({ default: m.SeaLevelWidget })));
 
-const EN_MONTHS: Record<string, string> = {
-  Jan:"01", Feb:"02", Mar:"03", Apr:"04", May:"05", Jun:"06",
-  Jul:"07", Aug:"08", Sep:"09", Oct:"10", Nov:"11", Dec:"12",
+// T-5.5 — the datasette `day_label` is an internal "Mon D" key; render its month
+// as a Slovenian short date via the formatter rather than a hand-built string.
+const EN_MONTHS: Record<string, number> = {
+  Jan:1, Feb:2, Mar:3, Apr:4, May:5, Jun:6,
+  Jul:7, Aug:8, Sep:9, Oct:10, Nov:11, Dec:12,
 };
 function fmtDayLabel(dl: string): string {
   const [mon, day] = dl.split(" ");
-  return `${(day ?? "").padStart(2, "0")}.${EN_MONTHS[mon ?? ""] ?? "??"}`;
+  const m = EN_MONTHS[mon ?? ""] ?? 0;
+  return m ? fmtMonthDay(m, Number(day)) : "??";
 }
 
 export function AliJeVroceERA5() {
@@ -34,7 +38,7 @@ export function AliJeVroceERA5() {
   // visible page-level error (T-5.1).
   return (
     <ErrorBoundary fallback={sectionErrorFallback(refetchMeta, "480px")}>
-      <Show when={meta()} fallback={<div class="px-10 py-8 text-[var(--color-ink-soft)]">Nalaganje…</div>}>
+      <Show when={meta()} fallback={<div class="px-10 py-8 text-[var(--color-ink-soft)]">{t("loading")}</div>}>
         {(m) => <Dashboard meta={m()} />}
       </Show>
     </ErrorBoundary>
@@ -71,8 +75,8 @@ function Dashboard(props: { meta: SiteMeta }) {
       <section class="today-status">
         <div class="sec-heading">
           <div class="today-heading-text">
-            <span class="today-heading-title">ERA5 — Ali je vroče?</span>
-            <span class="today-heading-subtitle">reanaliza ERA5-Land v primerjavi z zgodovinskimi percentili</span>
+            <span class="today-heading-title">{t("sections.today_title")}</span>
+            <span class="today-heading-subtitle">{t("sections.today_subtitle")}</span>
           </div>
         </div>
 
@@ -101,15 +105,23 @@ function Dashboard(props: { meta: SiteMeta }) {
             <div class="today-chart">
               <div class="today-chart-title">
                 {isNat()
-                  ? `Dnevne najvišje temperature v Sloveniji za dva tedna okoli ${fmtDayLabel(todayData()!.day_label ?? "")} od ${todayData()!.year_min}`
-                  : `Dnevne najvišje temperature na postaji ${todayData()!.loc!.replace(/_/g, " ")} za dva tedna okoli ${fmtDayLabel(todayData()!.day_label ?? "")} od ${todayData()!.year_min}`}
+                  ? t("today.chart_title_nat", { day: fmtDayLabel(todayData()!.day_label ?? ""), year_min: todayData()!.year_min ?? 0 })
+                  : t("today.chart_title_station", { station: todayData()!.loc!.replace(/_/g, " "), day: fmtDayLabel(todayData()!.day_label ?? ""), year_min: todayData()!.year_min ?? 0 })}
               </div>
               <DistributionChart data={todayData()!} chartId="dist-chart" />
               <p class="today-explain" style={{ "font-size": "12px", "padding-top": "6px" }}>
-                Krivulja prikazuje, kako pogosto se je pojavila vsaka vrhunska temperatura na dneve, kot je danes, v vseh letih. Barve označujejo klimatološke cone — od hladne modre prek tipičnega bežastega pasu do ekstremne rdeče.
+                {t("today.chart_explain")}
               </p>
               <div class="today-foot">
-                {`${isNat() ? "Slovenija" : "Danes"}: ${todayData()!.today_temp!.toFixed(1)} °C · ${todayData()!.percentile!.toFixed(0)}. percentil · mediana ${todayData()!.cutoffs!.p50.toFixed(1)} °C · ${(todayData()!.n_samples ?? 0).toLocaleString()} opazovanj · ${todayData()!.year_min}–${todayData()!.year_max}`}
+                {t("today.foot2", {
+                  region: isNat() ? t("today.foot2_region_nat") : t("today.foot2_region_day"),
+                  temp: fmtNum(todayData()!.today_temp!, 1),
+                  pct: fmtInt(todayData()!.percentile!),
+                  median: fmtNum(todayData()!.cutoffs!.p50, 1),
+                  count: todayData()!.n_samples ?? 0,
+                  year_min: todayData()!.year_min ?? 0,
+                  year_max: todayData()!.year_max ?? 0,
+                })}
               </div>
             </div>
           </Show>
@@ -129,7 +141,7 @@ function Dashboard(props: { meta: SiteMeta }) {
         syncLoc={mapLoc}
         onLocChange={setMapLoc}
       >
-        <div class="sec-hs">Analiza trendov · ERA5-Land reanaliza</div>
+        <div class="sec-hs">{t("sections.trends_analysis")}</div>
 
         <RegToolbar />
 
@@ -140,10 +152,10 @@ function Dashboard(props: { meta: SiteMeta }) {
             <div style={{ ...panelHStyle, background: "var(--color-card)" }}>
               <div>
                 <div style={panelTitleStyle}>
-                  {mapLoc() ? mapLoc()!.replace(/_/g, " ") : `Slovenija — vseh ${era5Stations.length} postaj`}
+                  {mapLoc() ? mapLoc()!.replace(/_/g, " ") : t("map.panel_title_all", { count: era5Stations.length })}
                 </div>
                 <div style={{ ...panelSubStyle, "margin-top": "3px" }}>
-                  {era5Stations.length} postaj · ERA5
+                  {t("map.panel_sub_count", { count: era5Stations.length })}
                 </div>
               </div>
             </div>
@@ -152,10 +164,10 @@ function Dashboard(props: { meta: SiteMeta }) {
             </Suspense>
             <div style={{ padding: "8px 12px 10px", "border-top": "1px solid var(--color-rule)", display: "flex", gap: "10px", "flex-wrap": "wrap", background: "var(--color-card)" }}>
               {([
-                ["#7bafd4", "Alpska (>1500m)"],
-                ["#a3c4a0", "Gorska (800–1500m)"],
-                ["#c8b97a", "Predgorska (400–800m)"],
-                ["#c25a2c", "Nižinska (<400m)"],
+                ["#7bafd4", t("map.legend_alpine")],
+                ["#a3c4a0", t("map.legend_mountain")],
+                ["#c8b97a", t("map.legend_foothill")],
+                ["#c25a2c", t("map.legend_lowland")],
               ] as [string, string][]).map(([color, label]) => (
                 <span style={{ display: "flex", "align-items": "center", gap: "5px", "font-family": "var(--font-mono)", "font-size": "9px", "letter-spacing": "0.06em", "text-transform": "uppercase", color: "var(--color-ink-soft)" }}>
                   <span style={{ width: "10px", height: "10px", "border-radius": "50%", background: color, display: "inline-block", border: "1px solid rgba(0,0,0,0.15)", "flex-shrink": "0" }} />
@@ -189,13 +201,13 @@ function TropControls(props: {
   return (
     <div style={{ display: "flex", gap: "24px", "align-items": "center", "flex-wrap": "wrap", margin: "0 40px 12px" }}>
       <label style={{ display: "flex", "align-items": "center", gap: "8px" }}>
-        <span style={ctlLabel}>Prag:</span>
+        <span style={ctlLabel}>{t("tropical.ctrl_threshold")}</span>
         <input type="range" min={props.min} max={props.max} step={1} value={props.threshold}
                onInput={(e) => props.setThreshold(Number(e.currentTarget.value))} />
-        <span style={{ ...ctlLabel, color: "var(--color-ink)" }}>{props.threshold} °C</span>
+        <span style={{ ...ctlLabel, color: "var(--color-ink)" }}>{t("common.temp_c", { temp: fmtInt(props.threshold) })}</span>
       </label>
       <label style={{ display: "flex", "align-items": "center", gap: "8px" }}>
-        <span style={ctlLabel}>Min. zap. {props.unit}:</span>
+        <span style={ctlLabel}>{props.unit === "noči" ? t("tropical.ctrl_streak_nights") : t("tropical.ctrl_streak_days")}</span>
         <select value={props.streak} onInput={(e) => props.setStreak(Number(e.currentTarget.value))}
                 style={{ "font-family": "var(--font-mono)", "font-size": "11px", padding: "2px 6px" }}>
           <option value={1}>1</option>
@@ -225,7 +237,7 @@ function Era5Charts() {
       {/* Location impact details */}
       <section class="sec-p" style={{ "padding-top": "16px", "padding-bottom": "24px" }}>
         <div class="sec-hs" style={{ "padding-inline": "0", "padding-top": "0", "padding-bottom": "10px" }}>
-          Podrobnosti lokacije
+          {t("sections.location_details")}
         </div>
         <Suspense fallback={<div style={{ height: "180px" }} class="animate-pulse rounded-xl bg-[var(--color-paper-2)]" />}>
           <HeroCardsPanel loc={loc()} doy={s.doy()} />
@@ -234,10 +246,10 @@ function Era5Charts() {
 
       <section class="sec-p" style={{ "padding-bottom": "40px" }}>
         <div class="sec-h" style={{ "padding-inline": "0", "padding-top": "24px" }}>
-          Sezonski pregled
+          {t("sections.season_overview")}
         </div>
         <div class="sec-hs2">
-          Povprečna najvišja temperatura po sezonah · ERA5-Land · barve glede na referenčno obdobje {BASELINE_LABEL}
+          {t("sections.season_overview_sub", { baseline: BASELINE_LABEL })}
         </div>
         <Suspense fallback={<div class="h-40 animate-pulse bg-[var(--color-paper-2)] rounded-xl" />}>
           <Era5SeasonHeatmapChart loc={loc()} label={st()?.label} />
@@ -247,7 +259,7 @@ function Era5Charts() {
       {/* SPEI drought heatmap (national) */}
       <section class="sec-p" style={{ "padding-bottom": "40px" }}>
         <div class="sec-h" style={{ "padding-inline": "0", "padding-top": "8px" }}>
-          Sezonski sušni indeks (SPEI)
+          {t("sections.spei")}
         </div>
         <ErrorBoundary fallback={sectionErrorFallback(refetchSpei, "160px")}>
           <Suspense fallback={<div class="h-40 animate-pulse bg-[var(--color-paper-2)] rounded-xl" />}>
@@ -261,10 +273,10 @@ function Era5Charts() {
       {/* SPEI drought trend per station */}
       <section class="sec-p" style={{ "padding-bottom": "40px" }}>
         <div class="sec-h" style={{ "padding-inline": "0", "padding-top": "8px" }}>
-          Sušni trend po postaji — SPEI
+          {t("sections.spei_trend")}
         </div>
         <div class="sec-hs2">
-          Sezonski (SPEI-3) in mesečni (SPEI-30) indeks vodne bilance · Theil-Sen · ERA5-Land
+          {t("sections.spei_trend_sub")}
         </div>
         <ErrorBoundary fallback={sectionErrorFallback(refetchSpeiStation, "400px")}>
           <Suspense fallback={<div class="animate-pulse rounded-xl bg-[var(--color-paper-2)]" style={{ height: "400px" }} />}>
@@ -277,9 +289,9 @@ function Era5Charts() {
 
       {/* Tropical days */}
       <section class="sec-p" style={{ "padding-bottom": "40px" }}>
-        <div class="sec-h" style={{ "padding-inline": "0", "padding-top": "8px" }}>Tropski dnevi</div>
+        <div class="sec-h" style={{ "padding-inline": "0", "padding-top": "8px" }}>{t("sections.tropical_days")}</div>
         <div class="sec-hs2">
-          Število dni z najvišjo temperaturo nad pragom · ERA5-Land · lapsna korekcija nadmorske višine
+          {t("sections.tropical_days_sub")}
         </div>
         <TropControls threshold={daysThr()} setThreshold={setDaysThr} min={25} max={35} streak={streak()} setStreak={setStreak} unit="dni" />
         <Suspense fallback={<div class="h-56 animate-pulse bg-[var(--color-paper-2)] rounded-xl" />}>
@@ -289,9 +301,9 @@ function Era5Charts() {
 
       {/* Tropical nights */}
       <section class="sec-p" style={{ "padding-bottom": "60px" }}>
-        <div class="sec-h" style={{ "padding-inline": "0", "padding-top": "8px" }}>Tropske noči</div>
+        <div class="sec-h" style={{ "padding-inline": "0", "padding-top": "8px" }}>{t("sections.tropical_nights")}</div>
         <div class="sec-hs2">
-          Število noči z najnižjo temperaturo nad pragom · ERA5-Land · lapsna korekcija nadmorske višine
+          {t("sections.tropical_nights_sub")}
         </div>
         <TropControls threshold={nightsThr()} setThreshold={setNightsThr} min={15} max={25} streak={streak()} setStreak={setStreak} unit="noči" />
         <Suspense fallback={<div class="h-56 animate-pulse bg-[var(--color-paper-2)] rounded-xl" />}>
@@ -302,10 +314,10 @@ function Era5Charts() {
       {/* Sea level rise — Koper (IPCC AR6 projections, static) */}
       <section class="sec-p" style={{ "padding-bottom": "40px" }}>
         <div class="sec-h" style={{ "padding-inline": "0", "padding-top": "8px" }}>
-          Dvig morske gladine — Koper
+          {t("sections.sea_level")}
         </div>
         <div class="sec-hs2" style={{ "margin-bottom": "16px" }}>
-          Projekcije dviga morske gladine po scenarijih IPCC AR6 z viharnimi nalivi · severni Jadran
+          {t("sections.sea_level_sub")}
         </div>
         <Suspense fallback={<div class="animate-pulse rounded-xl bg-[#071e26]" style={{ height: "500px" }} />}>
           <SeaLevelChart />

--- a/code/ali-je-vroce-era5/api.ts
+++ b/code/ali-je-vroce-era5/api.ts
@@ -11,6 +11,8 @@ import { CAT_COLORS, cdfPercentile } from "./percentile.ts";
 // T-4.5 (D-4): dateToDoy reads the calendar day in Europe/Ljubljana, the same day
 // boundary clock.ts uses. This is a PURE date-parts read, not a system-clock read.
 import { calendarDateIn, LJUBLJANA_TZ } from "./clock.ts";
+// T-5.5 (D-8) — Slovenian catalogue + Slovenian number/date formatting.
+import { t, fmtNum, fmtMonthDay } from "./i18n/format.ts";
 
 // podnebnik.org datasette serves each DB at the root (no /datasette prefix),
 // e.g. https://stage-data.podnebnik.org/climate-si — override with VITE_DATASETTE_URL for dev.
@@ -48,11 +50,13 @@ export function isArsoLoc(loc: string): boolean {
   return loc.startsWith("arso:");
 }
 
-const VAR_LABELS: Record<string, string> = {
-  temperature_max:  "Max temperature (°C)",
-  temperature_min:  "Min temperature (°C)",
-  temperature_mean: "Mean temperature (°C)",
-};
+// T-5.5 — variable labels moved to the catalogue (reg.var_*); one source shared
+// with RegressionPanel's picker. `et0_evapotranspiration` maps to reg.var_et0.
+export function varLabel(v: string): string {
+  const key = v === "et0_evapotranspiration" ? "reg.var_et0" : `reg.var_${v}`;
+  const lbl = t(key);
+  return lbl === key ? `${v} (°C)` : lbl;
+}
 
 // ── Helpers ────────────────────────────────────────────────────────────────────
 
@@ -278,16 +282,17 @@ export async function fetchMeta(): Promise<SiteMeta> {
 
   return {
     country:          "si",
-    name:             "Slovenija",
+    name:             t("meta.name"),
     default_location: "Ljubljana",
-    languages:        ["en"],
-    default_language: "en",
+    // D-8 — Slovenian only for v1 (was ["en"]/"en", contradicting the whole page).
+    languages:        ["sl"],
+    default_language: "sl",
     map:      { center_lat: 46.1, center_lon: 14.8, zoom: 7 },
-    branding: { site_title: "Podnebnik · Ali je vroče?" },
+    branding: { site_title: t("meta.site_title") },
     stations,
     strings: {
-      explain_reg: "Theil-Sen regresija + Yue-Wang TFPW Mann-Kendall test · ERA5-Land · nadmorska korekcija",
-      explain_cal: "Trend na desetletje za vsak dan v letu · rdeča = ogrevanje · modra = ohlajanje · prosojnost = statistična značilnost",
+      explain_reg: t("reg.explain_reg"),
+      explain_cal: t("reg.explain_cal"),
     },
   };
 }
@@ -452,8 +457,8 @@ export async function fetchRegression(p: RegressionParams): Promise<RegressionRe
 
   return {
     results:    era5Results.filter(Boolean) as RegressionResult[],
-    date_label: dayLabel(month, day),
-    ylabel:     VAR_LABELS[p.var] ?? `${p.var} (°C)`,
+    date_label: fmtMonthDay(month, day),
+    ylabel:     varLabel(p.var),
     unit:       "°C",
   };
 }
@@ -492,11 +497,11 @@ async function buildRegressionResult(
     baseline,
     stats: {
       method: "Theil-Sen + TFPW MK", trend10: r.trend10, metric: r.trend10,
-      metric_lbl: "trend / 10y", p_val: r.p_val,
+      metric_lbl: "trend / 10 let", p_val: r.p_val,
       direction: r.trend10 >= 0 ? "up" : "down",
       chg_str: `${r.trend10 >= 0 ? "+" : ""}${r.trend10.toFixed(2)} °C/10y`,
-      fit_desc: `τ = ${r.tau.toFixed(2)}`,
-      sig_label: r.p_val < 0.05 ? "p < 0.05" : `p = ${r.p_val.toFixed(3)}`,
+      fit_desc: `τ = ${fmtNum(r.tau, 2)}`,
+      sig_label: r.p_val < 0.05 ? "p < 0,05" : `p = ${fmtNum(r.p_val, 3)}`,
       n_years: r.n_years, ar1: null,
     },
   };

--- a/code/ali-je-vroce-era5/charts/DistributionChart.tsx
+++ b/code/ali-je-vroce-era5/charts/DistributionChart.tsx
@@ -1,6 +1,7 @@
 import { onMount, onCleanup, createEffect } from "solid-js";
 import type { TodayStatus } from "../types.ts";
 import { enableChartA11y } from "./highcharts-a11y.ts";
+import { t, fmtNum } from "../i18n/format.ts";
 
 interface Props {
   data:    TodayStatus;
@@ -19,7 +20,10 @@ const ZONE_COLORS = [
   "#962c1a",   // p95+     Extreme
 ];
 
-const ZONE_LABELS = ["Hladno", "Sveže", "Normalno", "Vroče", "Ekstremno"];
+const ZONE_LABELS = [
+  t("dist.zone_cold"), t("dist.zone_cool"), t("dist.zone_normal"),
+  t("dist.zone_hot"), t("dist.zone_extreme"),
+];
 
 function buildOptions(r: TodayStatus): Highcharts.Options {
   const c       = r.cutoffs!;
@@ -54,18 +58,17 @@ function buildOptions(r: TodayStatus): Highcharts.Options {
     // T-5.4a — screen-reader summary (Slovenian copy awaiting operator review)
     accessibility: {
       enabled: true,
-      description: "Porazdelitev najvišjih dnevnih temperatur na dneve okoli izbranega datuma v vseh letih zabeleženega obdobja. Navpična črta označuje današnjo vrednost; barvni pasovi ločijo klimatološke cone od hladne do ekstremne.",
+      description: t("dist.a11y"),
     },
     tooltip: {
       formatter(this: any) {
         const temp: number = this.x;
-        let zone: string;
-        if      (temp < c.p10) zone = "Hladno";
-        else if (temp < c.p20) zone = "Sveže";
-        else if (temp < c.p80) zone = "Normalno";
-        else if (temp < c.p95) zone = "Vroče";
-        else                   zone = "Ekstremno";
-        return `${temp.toFixed(1)} °C · ${zone}`;
+        const zone =
+          temp < c.p10 ? t("dist.zone_cold") :
+          temp < c.p20 ? t("dist.zone_cool") :
+          temp < c.p80 ? t("dist.zone_normal") :
+          temp < c.p95 ? t("dist.zone_hot") : t("dist.zone_extreme");
+        return t("dist.tooltip", { temp: fmtNum(temp, 1), zone });
       },
     },
     xAxis: {
@@ -83,7 +86,7 @@ function buildOptions(r: TodayStatus): Highcharts.Options {
         width:  3,
         zIndex: 5,
         label: {
-          text:      `DANES: ${todayX.toFixed(1)} °C`,
+          text:      t("dist.today_line", { temp: fmtNum(todayX, 1) }),
           rotation:  -90,
           x:         -4,
           y:         40,
@@ -93,15 +96,15 @@ function buildOptions(r: TodayStatus): Highcharts.Options {
       }],
       plotBands: [
         { from: axisMin,  to: c.p10,  color: "transparent",
-          label: { text: `< ${c.p10.toFixed(1)}°C`,                        align: "center", verticalAlign: "top", y: 18, style: zoneLabelStyle } },
+          label: { text: t("dist.band_below", { p: fmtNum(c.p10, 1) }),                        align: "center", verticalAlign: "top", y: 18, style: zoneLabelStyle } },
         { from: c.p10,   to: c.p20,  color: "transparent",
-          label: { text: `${c.p10.toFixed(1)}–${c.p20.toFixed(1)}°C`,      align: "center", verticalAlign: "top", y: 18, style: zoneLabelStyle } },
+          label: { text: t("dist.band_range", { a: fmtNum(c.p10, 1), b: fmtNum(c.p20, 1) }),      align: "center", verticalAlign: "top", y: 18, style: zoneLabelStyle } },
         { from: c.p20,   to: c.p80,  color: "transparent",
-          label: { text: `${c.p20.toFixed(1)}–${c.p80.toFixed(1)}°C`,      align: "center", verticalAlign: "top", y: 18, style: zoneLabelStyle } },
+          label: { text: t("dist.band_range", { a: fmtNum(c.p20, 1), b: fmtNum(c.p80, 1) }),      align: "center", verticalAlign: "top", y: 18, style: zoneLabelStyle } },
         { from: c.p80,   to: c.p95,  color: "transparent",
-          label: { text: `${c.p80.toFixed(1)}–${c.p95.toFixed(1)}°C`,      align: "center", verticalAlign: "top", y: 18, style: zoneLabelStyle } },
+          label: { text: t("dist.band_range", { a: fmtNum(c.p80, 1), b: fmtNum(c.p95, 1) }),      align: "center", verticalAlign: "top", y: 18, style: zoneLabelStyle } },
         { from: c.p95,   to: axisMax, color: "transparent",
-          label: { text: `> ${c.p95.toFixed(1)}°C`,                        align: "center", verticalAlign: "top", y: 18, style: zoneLabelStyle } },
+          label: { text: t("dist.band_above", { p: fmtNum(c.p95, 1) }),                        align: "center", verticalAlign: "top", y: 18, style: zoneLabelStyle } },
       ],
     },
     yAxis: {

--- a/code/ali-je-vroce-era5/charts/Era5TropicalChart.tsx
+++ b/code/ali-je-vroce-era5/charts/Era5TropicalChart.tsx
@@ -3,35 +3,38 @@ import { fetchEra5Tropical, isArsoLoc, ERA5_NATIONAL } from "../api.ts";
 import { sectionErrorFallback } from "../components/SectionError.tsx";
 import { TropHighchart } from "./TropicalChart.tsx";
 import type { Config } from "./TropicalChart.tsx";
+import { t, fmtNum, fmtInt, fmtSigned } from "../i18n/format.ts";
 
 function pFmt(p: number): string {
-  return p < 0.001 ? "p < 0.001" : p < 0.01 ? "p < 0.01" : p < 0.05 ? `p = ${p.toFixed(3)}` : `p = ${p.toFixed(3)} (ns)`;
+  return p < 0.001 ? "p < 0,001" : p < 0.01 ? "p < 0,01" : p < 0.05 ? `p = ${fmtNum(p, 3)}` : `p = ${fmtNum(p, 3)} (ns)`;
 }
 
 const ERA5_CONFIGS: Record<string, Config> = {
   days: {
     kind:             "days",
-    unitLabel:        "dni",
+    unitLabel:        t("tropical.unit_days"),
     defaultThreshold: 30,
     minT: 25, maxT: 35,
+    // NB: subLabel is currently unreferenced (the section subtitle is rendered from
+    // sections.tropical_days_sub in AliJeVroceERA5). Left as-is — see PROGRESS T-5.5.
     subLabel:         (th, st) => `Število dni z najvišjo temperaturo nad ${th} °C` +
       (st > 1 ? `, v nizih ${st}+ zaporednih dni` : "") +
       ` na leto · lapsna korekcija nadmorske višine · ERA5-Land`,
-    tooltipNoun:      "Tropski dnevi",
-    plainDesc:        (th) => `Tropski dan — ko dnevna temperatura preseže ${th} °C — povečuje toplotni stres in zdravstvena tveganja.`,
-    plainNoun:        "tropski dan",
+    tooltipNoun:      t("tropical.noun_days"),
+    plainDesc:        (th) => t("tropical.plain_desc_days", { th: fmtInt(th) }),
+    plainNoun:        t("tropical.plain_noun_days"),
   },
   nights: {
     kind:             "nights",
-    unitLabel:        "noči",
+    unitLabel:        t("tropical.unit_nights"),
     defaultThreshold: 20,
     minT: 15, maxT: 25,
     subLabel:         (th, st) => `Število noči z najnižjo temperaturo nad ${th} °C` +
       (st > 1 ? `, v nizih ${st}+ zaporednih noči` : "") +
       ` na leto · lapsna korekcija nadmorske višine · ERA5-Land`,
-    tooltipNoun:      "Tropske noči",
-    plainDesc:        (th) => `Tropska noč — ko temperatura čez noč ostane nad ${th} °C — preprečuje telesu okrevanje po dnevni vročini.`,
-    plainNoun:        "tropska noč",
+    tooltipNoun:      t("tropical.noun_nights"),
+    plainDesc:        (th) => t("tropical.plain_desc_nights", { th: fmtInt(th) }),
+    plainNoun:        t("tropical.plain_noun_nights"),
   },
 };
 
@@ -69,21 +72,24 @@ export function Era5TropicalChart(props: Props) {
     const dpd = tr.days_per_decade;
     const p   = tr.p_value;
 
-    const techLine =
-      `NB GLM: ${tr.rate_per_year >= 0 ? "+" : ""}${tr.rate_per_year.toFixed(2)}%/leto · ` +
-      `${dpd >= 0 ? "+" : ""}${dpd.toFixed(1)} ${cfg().unitLabel}/desetletje · ` +
-      `95% CI · ${p < 0.05 ? `statistično značilen (${pFmt(p)})` : `ni značilen (${pFmt(p)})`} · ` +
-      `AIC ${tr.aic.toFixed(0)} · α=${tr.alpha}.`;
+    const sigphrase = p < 0.05 ? t("tropical.sig_yes", { p: pFmt(p) }) : t("tropical.sig_no", { p: pFmt(p) });
+    const techLine = t("tropical.tech", {
+      rate: fmtSigned(tr.rate_per_year, 2), dpd: fmtSigned(dpd, 1), unit: cfg().unitLabel,
+      sigphrase, aic: fmtInt(tr.aic), alpha: tr.alpha,
+    });
 
     const fittedLast = tr.y_line[tr.y_line.length - 1]!;
     const proj2050   = Math.round(fittedLast * Math.pow(1 + tr.rate_per_year / 100, 2050 - tr.fit_year_max));
-    const dir        = dpd > 0 ? "več" : "manj";
-    const sig        = p < 0.05 ? "statistično značilen trend" : "trend, ki še ni statistično značilen";
+    const dir        = dpd > 0 ? t("tropical.dir_more") : t("tropical.dir_less");
+    const sig        = p < 0.05 ? t("tropical.sig_trend_yes") : t("tropical.sig_trend_no");
     const forward    = p < 0.05 && proj2050 > 0
-      ? `Če trend nadaljuje, bi bilo do 2050 tipičnih okoli ${proj2050} ${cfg().unitLabel} na leto.`
-      : `Podatki ne kažejo jasnega signala, a smer spremembe je vredna pozornosti.`;
+      ? t("tropical.forward_yes", { proj2050: fmtInt(proj2050), unit: cfg().unitLabel })
+      : t("tropical.forward_no");
 
-    const plainLine = `${cfg().plainDesc(props.threshold)} Postaja ${props.label ?? ""} kaže ${sig}: grobe ${Math.abs(dpd).toFixed(1)} ${dir} ${cfg().unitLabel} na desetletje. ${forward}`;
+    const plainLine = t("tropical.plain", {
+      plainDesc: cfg().plainDesc(props.threshold), station: props.label ?? "", sig,
+      dpd: fmtNum(Math.abs(dpd), 1), dir, unit: cfg().unitLabel, forward,
+    });
 
     return { tech: techLine, plain: plainLine };
   };
@@ -91,7 +97,7 @@ export function Era5TropicalChart(props: Props) {
   const noTrendReason = () => {
     const d = display();
     if (!d || d.trend.model_used) return null;
-    return `Premalo let z ${cfg().plainNoun}i za izračun trenda (${d.nonzero_count} let z vrednostjo > 0). Potrebnih je vsaj 10.`;
+    return t("tropical.no_trend", { plainNoun: cfg().plainNoun, count: d.nonzero_count });
   };
 
   return (
@@ -106,7 +112,7 @@ export function Era5TropicalChart(props: Props) {
           <Show when={display()}>
             {(d) => (
               <div style={{ "font-family": "var(--font-mono)", "font-size": "10px", color: "var(--color-ink-soft)", "letter-spacing": "0.06em", "text-transform": "uppercase" }}>
-                {d().years.length} let · {d().nonzero_count} z vrednostjo &gt; 0
+                {t("tropical.header_count", { count: d().years.length, nonzero: d().nonzero_count })}
               </div>
             )}
           </Show>
@@ -141,7 +147,7 @@ export function Era5TropicalChart(props: Props) {
         <Show when={display()}>
           <div style={{ padding: "0 16px 10px", display: "flex", "align-items": "center", gap: "5px", "font-family": "var(--font-mono)", "font-size": "9px", "letter-spacing": "0.06em", "text-transform": "uppercase", color: "var(--color-ink-soft)" }}>
             <span style={{ width: "10px", height: "10px", background: "rgba(194,90,44,0.4)", "border-radius": "2px", display: "inline-block", border: "1px solid rgba(0,0,0,0.15)", "flex-shrink": "0" }} />
-            Zadnji stolpec — leto v teku
+            {t("tropical.year_legend")}
           </div>
         </Show>
 

--- a/code/ali-je-vroce-era5/charts/RegressionChart.tsx
+++ b/code/ali-je-vroce-era5/charts/RegressionChart.tsx
@@ -1,6 +1,7 @@
 import { onMount, onCleanup, createEffect } from "solid-js";
 import type { RegressionResponse } from "../types.ts";
 import { enableChartA11y } from "./highcharts-a11y.ts";
+import { t, fmtNum, fmtSigned } from "../i18n/format.ts";
 
 interface Props {
   data:    RegressionResponse;
@@ -86,7 +87,7 @@ export function RegressionChart(props: Props) {
       // module is now loaded, so this chart is properly exposed to assistive tech.
       accessibility: {
         enabled: true,
-        description: "Razsevni diagram letnih vrednosti izbrane spremenljivke z regresijsko linijo trenda in 95-odstotnim intervalom zaupanja; črtkana črta označuje povprečje referenčnega obdobja.",
+        description: t("regchart.a11y"),
       },
       legend: {
         enabled: true,
@@ -97,7 +98,8 @@ export function RegressionChart(props: Props) {
         formatter(this: Highcharts.TooltipFormatterContextObject) {
           const pt = this.point as any;
           const loc = (this.series.name ?? "").replace(/_/g, " ");
-          return `<b>${loc}</b><br/>${this.x}: <b>${(this.y as number).toFixed(2)}</b> ${d.unit}${pt.anomaly != null ? `<br/>anomaly: ${pt.anomaly > 0 ? "+" : ""}${pt.anomaly.toFixed(2)}` : ""}`;
+          const base = t("regchart.tooltip", { loc, x: this.x, y: fmtNum(this.y as number, 2), unit: d.unit });
+          return base + (pt.anomaly != null ? t("regchart.tooltip_anomaly", { a: fmtSigned(pt.anomaly, 2) }) : "");
         },
       },
       xAxis: { type: "linear", title: { text: null }, gridLineWidth: 0, tickInterval: 10 },
@@ -119,7 +121,7 @@ export function RegressionChart(props: Props) {
           dashStyle: "Dash",
           zIndex: 2,
           label: {
-            text:  `${res.stats.n_years}-YR MEAN ${res.baseline.toFixed(1)}`,
+            text:  t("regchart.baseline_label", { count: res.stats.n_years, baseline: fmtNum(res.baseline, 1) }),
             align: "right",
             x:     -4,
             style: { color: res.color ?? "#999", fontSize: "9px", fontFamily: "'JetBrains Mono', monospace" },
@@ -150,7 +152,7 @@ export function RegressionChart(props: Props) {
       yAxis.addPlotLine({
         id: `baseline-${res.loc}`, value: res.baseline, color: res.color ?? "#999",
         width: 1, dashStyle: "Dash", zIndex: 2,
-        label: { text: `${res.stats.n_years}-YR MEAN ${res.baseline.toFixed(1)}`,
+        label: { text: t("regchart.baseline_label", { count: res.stats.n_years, baseline: fmtNum(res.baseline, 1) }),
           align: "right", x: -4, style: { color: res.color ?? "#999", fontSize: "9px", fontFamily: "'JetBrains Mono', monospace" } },
       });
     }

--- a/code/ali-je-vroce-era5/charts/SeaLevelWidget.tsx
+++ b/code/ali-je-vroce-era5/charts/SeaLevelWidget.tsx
@@ -1,6 +1,7 @@
 import { createSignal, createMemo, createEffect, onMount, onCleanup } from "solid-js";
 import L from "leaflet";
 import "leaflet/dist/leaflet.css";
+import { t } from "../i18n/format.ts";
 
 // ── Projection data (IPCC AR6, localised for northern Adriatic / DRSV 2023) ──
 
@@ -351,17 +352,17 @@ export function SeaLevelWidget() {
     <div
       class="sl-widget"
       role="group"
-      aria-label="Interaktivni prikaz dviga morske gladine v Kopru po scenarijih IPCC AR6; gumbi izberejo scenarij in verjetnost, drsnik leto, ločnica pa primerja sedanjost s projekcijo."
+      aria-label={t("sea.a11y")}
     >
 
       {/* Controls bar */}
       <div class="sl-ctrl">
         <div class="sl-ctrl-group">
-          <span class="sl-lbl">Scenarij</span>
+          <span class="sl-lbl">{t("sea.scenario")}</span>
           <div class="sl-btn-row">
             {([
-              { key: "ssp245", label: "SSP2-4.5", sub: "Srednja pot" },
-              { key: "ssp585", label: "SSP5-8.5", sub: "Vožnja po avtocesti" },
+              { key: "ssp245", label: "SSP2-4.5", sub: t("sea.scn_mid") },
+              { key: "ssp585", label: "SSP5-8.5", sub: t("sea.scn_highway") },
             ] as const).map(s => (
               <button class={"sl-btn" + (scn() === s.key ? " sl-btn--active" : "")} onClick={() => setScn(s.key)}>
                 {s.label}<span class="sl-btn-sub">{s.sub}</span>
@@ -371,12 +372,12 @@ export function SeaLevelWidget() {
         </div>
 
         <div class="sl-ctrl-group">
-          <span class="sl-lbl">Verjetnost ekstremov</span>
+          <span class="sl-lbl">{t("sea.prob")}</span>
           <div class="sl-btn-row">
             {([
-              { key: "p70", label: "pogost (70 %)" },
-              { key: "p20", label: "redek (20 %)" },
-              { key: "p01", label: "ekstrem (1 %)" },
+              { key: "p70", label: t("sea.prob_common") },
+              { key: "p20", label: t("sea.prob_rare") },
+              { key: "p01", label: t("sea.prob_extreme") },
             ] as const).map(p => (
               <button class={"sl-btn" + (prob() === p.key ? " sl-btn--active" : "")} onClick={() => setProb(p.key)}>
                 {p.label}
@@ -387,15 +388,15 @@ export function SeaLevelWidget() {
 
         <div class="sl-ctrl-group sl-ctrl-group--year">
           <div class="sl-year-header">
-            <span class="sl-lbl">Leto: <strong style={{ color: "var(--sl-txt)" }}>{Math.round(year())}</strong></span>
+            <span class="sl-lbl">{t("sea.year")} <strong style={{ color: "var(--sl-txt)" }}>{Math.round(year())}</strong></span>
             <span class="sl-inline-stats">
-              {visHa()} ha<span class="sl-inline-sep">·</span>{visBuild()} stavb
+              {visHa()} ha<span class="sl-inline-sep">·</span>{visBuild()} {t("sea.buildings_short")}
             </span>
           </div>
           <div class="sl-year-row">
             <input type="range" min="2024" max="2100" step="1" value={Math.round(year())}
               onInput={(e) => { stopPlay(); setYear(+e.currentTarget.value); }} />
-            <button class="sl-play-btn" aria-label={playing() ? "Ustavi" : "Predvajaj"}
+            <button class="sl-play-btn" aria-label={playing() ? t("sea.pause") : t("sea.play")}
               onClick={() => playing() ? stopPlay() : startPlay()}>
               {playing() ? "⏸" : "▶"}
             </button>
@@ -412,19 +413,19 @@ export function SeaLevelWidget() {
           <canvas ref={canvasEl}
             style={{ position: "absolute", inset: "0", width: "100%", height: "100%", "pointer-events": "none", "z-index": "410" }} />
           <div ref={divLineEl}   class="sl-div-line" />
-          <div ref={divHandleEl} class="sl-div-handle" aria-label="Premakni ločnico">⟺</div>
-          <div class="sl-lbl-today">DANES</div>
+          <div ref={divHandleEl} class="sl-div-handle" aria-label={t("sea.move_divider")}>⟺</div>
+          <div class="sl-lbl-today">{t("sea.today")}</div>
           <div ref={futureLblEl} class="sl-future-lbl">{Math.round(year())}</div>
         </div>
 
         {/* Stats card */}
         <div class="sl-stats-card">
-          <div class="sl-stats-label">Skupni dvig gladine</div>
+          <div class="sl-stats-label">{t("sea.total_rise")}</div>
           <div class="sl-rise-big">
             <span class="sl-rise-val">+{Math.round(meanRise())}</span>
             <span class="sl-rise-unit"> cm</span>
           </div>
-          <div class="sl-stats-sub">srednja vrednost · {scn() === 'ssp245' ? 'SSP2-4.5' : 'SSP5-8.5'}</div>
+          <div class="sl-stats-sub">{t("sea.mean_sub", { scn: scn() === 'ssp245' ? 'SSP2-4.5' : 'SSP5-8.5' })}</div>
 
           {/* Vertical gauge (desktop) */}
           <div class="sl-gauge-wrap">
@@ -456,31 +457,31 @@ export function SeaLevelWidget() {
           <div class="sl-impacts">
             <div class="sl-impact-row">
               <span class="sl-impact-val">{visHa()}</span>
-              <span class="sl-impact-lbl">ha poplavljenih</span>
+              <span class="sl-impact-lbl">{t("sea.impact_ha")}</span>
             </div>
             <div class="sl-impact-row">
               <span class="sl-impact-val">{visBuild()}</span>
-              <span class="sl-impact-lbl">ogroženih stavb</span>
+              <span class="sl-impact-lbl">{t("sea.impact_build")}</span>
             </div>
           </div>
 
           {/* Legend */}
           <div class="sl-legend">
             <span class="sl-leg-swatch" style={{ background: "rgba(60,30,200,0.82)" }}/>
-            <span class="sl-leg-txt">Danes in prihodnost</span>
+            <span class="sl-leg-txt">{t("sea.legend_today")}</span>
           </div>
           <div class="sl-legend">
             <span class="sl-leg-swatch" style={{ background: "rgba(210,30,45,0.83)" }}/>
-            <span class="sl-leg-txt">Novo v prihodnosti</span>
+            <span class="sl-leg-txt">{t("sea.legend_future")}</span>
           </div>
 
           {/* Sources */}
           <details class="sl-src">
-            <summary>Viri podatkov</summary>
-            <p>Projekcije: IPCC AR6 (Fox-Kemper et al. 2021), lokalizirano za severni Jadran — DRSV 2023.</p>
-            <p>Posledice: Kovačič et al. 2016/2019.</p>
-            <p>Karta: © <a href="https://opentopomap.org">OpenTopoMap</a> (CC-BY-SA), © <a href="https://www.openstreetmap.org">OpenStreetMap</a>.</p>
-            <p class="sl-src-warn">⚠ Poplavne cone so shematske — zamenjava z LIDAR DEM poligoni sledi.</p>
+            <summary>{t("sea.sources")}</summary>
+            <p>{t("sea.src_proj")}</p>
+            <p>{t("sea.src_impact")}</p>
+            <p>{t("sea.src_map")} © <a href="https://opentopomap.org">OpenTopoMap</a> (CC-BY-SA), © <a href="https://www.openstreetmap.org">OpenStreetMap</a>.</p>
+            <p class="sl-src-warn">{t("sea.src_warn")}</p>
           </details>
         </div>
 

--- a/code/ali-je-vroce-era5/charts/SeasonHeatmap.tsx
+++ b/code/ali-je-vroce-era5/charts/SeasonHeatmap.tsx
@@ -1,19 +1,21 @@
 import { createSignal, createMemo, For, Show, onCleanup } from "solid-js";
 import type { SeasonHeatmapRow } from "../types.ts";
+import { t, fmtNum } from "../i18n/format.ts";
 
 const SEASON_ORDER = ["Autumn", "Summer", "Spring", "Winter"] as const;
 type Season = typeof SEASON_ORDER[number];
 
 const SEASON_LABEL: Record<Season, string> = {
-  Autumn: "Jesen", Summer: "Poletje", Spring: "Pomlad", Winter: "Zima",
+  Autumn: t("season.label_Autumn"), Summer: t("season.label_Summer"),
+  Spring: t("season.label_Spring"), Winter: t("season.label_Winter"),
 };
 
 const CAT_LABELS: Record<string, string> = {
-  cold:    "Hladno (<10. pct)",
-  cool:    "Sveže (10–20. pct)",
-  normal:  "Normalno (20–80. pct)",
-  hot:     "Vroče (80–95. pct)",
-  extreme: "Ekstremno (>95. pct)",
+  cold:    t("season.cat_cold"),
+  cool:    t("season.cat_cool"),
+  normal:  t("season.cat_normal"),
+  hot:     t("season.cat_hot"),
+  extreme: t("season.cat_extreme"),
 };
 
 const CAT_COLORS: Record<string, string> = {
@@ -21,12 +23,12 @@ const CAT_COLORS: Record<string, string> = {
 };
 
 const MODES = [
-  { key: "all",      label: "Vse letne čase" },
-  { key: "extremes", label: "Samo ekstremi" },
-  { key: "Autumn",   label: "Jesen" },
-  { key: "Summer",   label: "Poletje" },
-  { key: "Spring",   label: "Pomlad" },
-  { key: "Winter",   label: "Zima" },
+  { key: "all",      label: t("season.mode_all") },
+  { key: "extremes", label: t("season.mode_extremes") },
+  { key: "Autumn",   label: t("season.label_Autumn") },
+  { key: "Summer",   label: t("season.label_Summer") },
+  { key: "Spring",   label: t("season.label_Spring") },
+  { key: "Winter",   label: t("season.label_Winter") },
 ];
 
 // T-5.4a — visually-hidden (screen-reader-only) style. Kept off the visual layout
@@ -85,7 +87,7 @@ export function SeasonHeatmap(props: Props) {
   );
   const gridLabel = createMemo(() => {
     const ys = allYears();
-    return `Toplotna karta letnih časov po letih od ${ys[0]} do ${ys[ys.length - 1]}: vsak stolpec je eno leto, vsaka vrstica en letni čas, barva pa uvršča povprečno najvišjo temperaturo od hladne do ekstremne glede na referenčno obdobje. Celotni podatki so v tabeli pod grafom.`;
+    return t("season.grid_a11y", { from: ys[0] ?? 0, to: ys[ys.length - 1] ?? 0 });
   });
 
   function cellClass(season: string, cat: string, year: number): string {
@@ -112,10 +114,10 @@ export function SeasonHeatmap(props: Props) {
       }
     }
     return [
-      { n: ext,          lbl: "Ekstremne sezone" },
-      { n: cold,         lbl: "Hladne sezone" },
-      { n: extSince2010, lbl: "Ekstremne od 2010" },
-      { n: hotRecent,    lbl: `Vroče ali ekstremne (${recentFrom}–${ym})` },
+      { n: ext,          lbl: t("season.stat_extreme") },
+      { n: cold,         lbl: t("season.stat_cold") },
+      { n: extSince2010, lbl: t("season.stat_extreme_since") },
+      { n: hotRecent,    lbl: t("season.stat_hot_recent", { from: recentFrom, to: ym }) },
     ];
   });
 
@@ -156,7 +158,7 @@ export function SeasonHeatmap(props: Props) {
           )}
         </For>
         <button class="shm-btn shm-btn--anim" onClick={() => animating() ? stopAnimate() : startAnimate()}>
-          {animating() ? "⏹ Ustavi" : "▶ Animacija"}
+          {animating() ? t("season.anim_stop") : t("season.anim_play")}
         </button>
       </div>
 
@@ -244,13 +246,13 @@ export function SeasonHeatmap(props: Props) {
               top:  `${Math.max(8, td().py - 52)}px`,
             }}
           >
-            <strong>{td().row.season} {td().row.y}</strong>
+            <strong>{SEASON_LABEL[td().row.season as Season] ?? td().row.season} {td().row.y}</strong>
             <div class="shm-tip-row">
               <span class="shm-tip-sw" style={{ background: td().row.color }} />
               {CAT_LABELS[td().row.cat]}
             </div>
-            Povprečni maks: <b>{td().row.avg.toFixed(1)} °C</b><br />
-            {td().row.rank}. najtoplejša {SEASON_LABEL[td().row.season as Season] ?? td().row.season} od {td().row.total} let
+            {t("season.tooltip_avg_label")} <b>{t("common.temp_c", { temp: fmtNum(td().row.avg, 1) })}</b><br />
+            {t("season.tooltip_rank", { rank: td().row.rank, season: SEASON_LABEL[td().row.season as Season] ?? td().row.season, count: td().row.total })}
           </div>
         )}
       </Show>
@@ -258,14 +260,14 @@ export function SeasonHeatmap(props: Props) {
       {/* T-5.4a — screen-reader data-table fallback (visually hidden). Slovenian
           caption/headers awaiting operator review. */}
       <table style={SR_ONLY}>
-        <caption>Podatki toplotne karte letnih časov po letih</caption>
+        <caption>{t("season.table_caption")}</caption>
         <thead>
           <tr>
-            <th scope="col">Letni čas</th>
-            <th scope="col">Leto</th>
-            <th scope="col">Kategorija</th>
-            <th scope="col">Povprečni maksimum (°C)</th>
-            <th scope="col">Uvrstitev</th>
+            <th scope="col">{t("season.th_season")}</th>
+            <th scope="col">{t("season.th_year")}</th>
+            <th scope="col">{t("season.th_category")}</th>
+            <th scope="col">{t("season.th_avg")}</th>
+            <th scope="col">{t("season.th_rank")}</th>
           </tr>
         </thead>
         <tbody>
@@ -275,8 +277,8 @@ export function SeasonHeatmap(props: Props) {
                 <td>{SEASON_LABEL[r.season as Season] ?? r.season}</td>
                 <td>{r.y}</td>
                 <td>{CAT_LABELS[r.cat] ?? r.cat}</td>
-                <td>{r.avg.toFixed(1)}</td>
-                <td>{r.rank}. od {r.total}</td>
+                <td>{fmtNum(r.avg, 1)}</td>
+                <td>{t("season.rank_of", { rank: r.rank, total: r.total })}</td>
               </tr>
             )}
           </For>

--- a/code/ali-je-vroce-era5/charts/SpeiHeatmap.tsx
+++ b/code/ali-je-vroce-era5/charts/SpeiHeatmap.tsx
@@ -1,18 +1,20 @@
 import { createSignal, createMemo, For, Show, onCleanup } from "solid-js";
+import { t, fmtNum, fmtSigned } from "../i18n/format.ts";
 
 const SEASON_ORDER = ["Autumn", "Summer", "Spring", "Winter"] as const;
 type Season = typeof SEASON_ORDER[number];
 
 const SEASON_LABEL: Record<Season, string> = {
-  Autumn: "Jesen", Summer: "Poletje", Spring: "Pomlad", Winter: "Zima",
+  Autumn: t("spei.label_Autumn"), Summer: t("spei.label_Summer"),
+  Spring: t("spei.label_Spring"), Winter: t("spei.label_Winter"),
 };
 
 const CAT_LABELS: Record<string, string> = {
-  extreme_dry: "Huda suša (SPEI < −1,5)",
-  dry:         "Suho (SPEI −1,5 do −1,0)",
-  normal:      "Normalno (SPEI −1,0 do 1,0)",
-  wet:         "Mokro (SPEI 1,0 do 1,5)",
-  extreme_wet: "Zelo mokro (SPEI > 1,5)",
+  extreme_dry: t("spei.cat_extreme_dry"),
+  dry:         t("spei.cat_dry"),
+  normal:      t("spei.cat_normal"),
+  wet:         t("spei.cat_wet"),
+  extreme_wet: t("spei.cat_extreme_wet"),
 };
 
 const CAT_COLORS: Record<string, string> = {
@@ -24,12 +26,12 @@ const CAT_COLORS: Record<string, string> = {
 };
 
 const MODES = [
-  { key: "all",      label: "Vse letne čase" },
-  { key: "extremes", label: "Samo ekstremi" },
-  { key: "Autumn",   label: "Jesen" },
-  { key: "Summer",   label: "Poletje" },
-  { key: "Spring",   label: "Pomlad" },
-  { key: "Winter",   label: "Zima" },
+  { key: "all",      label: t("spei.mode_all") },
+  { key: "extremes", label: t("spei.mode_extremes") },
+  { key: "Autumn",   label: t("spei.label_Autumn") },
+  { key: "Summer",   label: t("spei.label_Summer") },
+  { key: "Spring",   label: t("spei.label_Spring") },
+  { key: "Winter",   label: t("spei.label_Winter") },
 ];
 
 // T-5.4a — visually-hidden (screen-reader-only) style. Kebab-case keys because
@@ -103,7 +105,7 @@ export function SpeiHeatmap(props: SpeiHeatmapProps) {
       a.season === b.season ? a.y - b.y : a.season.localeCompare(b.season))
   );
   const gridLabel = createMemo(() =>
-    `Toplotna karta sušnega indeksa SPEI po letnih časih in letih od ${props.data.year_min} do ${props.data.year_max}: vsak stolpec je eno leto, vsaka vrstica en letni čas, barva pa označuje razmere od hude suše do zelo mokrega. Celotni podatki so v tabeli pod grafom.`
+    t("spei.grid_a11y", { from: props.data.year_min, to: props.data.year_max })
   );
 
   function isExtreme(cat: string) { return cat === "extreme_dry" || cat === "extreme_wet"; }
@@ -132,10 +134,10 @@ export function SpeiHeatmap(props: SpeiHeatmapProps) {
       }
     }
     return [
-      { n: extDry,          lbl: "Sezone hude suše (SPEI < −1,5)" },
-      { n: extWet,          lbl: "Izjemno mokre sezone (SPEI > 1,5)" },
-      { n: extDrySince2000, lbl: "Sezone hude suše od 2000" },
-      { n: dryRecent,       lbl: `Suho ali suša (${recentFrom}–${ym})` },
+      { n: extDry,          lbl: t("spei.stat_extreme_dry") },
+      { n: extWet,          lbl: t("spei.stat_extreme_wet") },
+      { n: extDrySince2000, lbl: t("spei.stat_extreme_dry_since") },
+      { n: dryRecent,       lbl: t("spei.stat_dry_recent", { from: recentFrom, to: ym }) },
     ];
   });
 
@@ -176,7 +178,7 @@ export function SpeiHeatmap(props: SpeiHeatmapProps) {
           )}
         </For>
         <button class="shm-btn shm-btn--anim" onClick={() => animating() ? stopAnimate() : startAnimate()}>
-          {animating() ? "⏹ Ustavi" : "▶ Animacija"}
+          {animating() ? t("spei.anim_stop") : t("spei.anim_play")}
         </button>
       </div>
 
@@ -257,7 +259,6 @@ export function SpeiHeatmap(props: SpeiHeatmapProps) {
       {/* Floating tooltip */}
       <Show when={tipData()}>
         {(td) => {
-          const speiSign = td().row.spei >= 0 ? "+" : "";
           return (
             <div
               class="shm-tip"
@@ -271,9 +272,9 @@ export function SpeiHeatmap(props: SpeiHeatmapProps) {
                 <span class="shm-tip-sw" style={{ background: td().row.color }} />
                 {CAT_LABELS[td().row.cat] ?? td().row.cat}
               </div>
-              SPEI: <b>{speiSign}{td().row.spei.toFixed(2)}</b><br />
-              Vodni bilans: <b>{td().row.balance.toFixed(0)} mm P−ET₀</b><br />
-              {td().row.rank}. najsušnejša {SEASON_LABEL[td().row.season as Season] ?? td().row.season} od {td().row.total} let
+              {t("spei.tooltip_spei")}<b>{fmtSigned(td().row.spei, 2)}</b><br />
+              {t("spei.tooltip_balance")}<b>{fmtNum(td().row.balance, 0)}{t("spei.tooltip_balance_unit")}</b><br />
+              {t("spei.tooltip_rank", { rank: td().row.rank, season: SEASON_LABEL[td().row.season as Season] ?? td().row.season, count: td().row.total })}
             </div>
           );
         }}
@@ -282,15 +283,15 @@ export function SpeiHeatmap(props: SpeiHeatmapProps) {
       {/* T-5.4a — screen-reader data-table fallback (visually hidden). Slovenian
           caption/headers awaiting operator review. */}
       <table style={SR_ONLY}>
-        <caption>Podatki toplotne karte sušnega indeksa SPEI po letnih časih in letih</caption>
+        <caption>{t("spei.table_caption")}</caption>
         <thead>
           <tr>
-            <th scope="col">Letni čas</th>
-            <th scope="col">Leto</th>
-            <th scope="col">Kategorija</th>
-            <th scope="col">SPEI</th>
-            <th scope="col">Vodna bilanca (mm)</th>
-            <th scope="col">Uvrstitev</th>
+            <th scope="col">{t("spei.th_season")}</th>
+            <th scope="col">{t("spei.th_year")}</th>
+            <th scope="col">{t("spei.th_category")}</th>
+            <th scope="col">{t("spei.th_spei")}</th>
+            <th scope="col">{t("spei.th_balance")}</th>
+            <th scope="col">{t("spei.th_rank")}</th>
           </tr>
         </thead>
         <tbody>
@@ -300,9 +301,9 @@ export function SpeiHeatmap(props: SpeiHeatmapProps) {
                 <td>{SEASON_LABEL[r.season as Season] ?? r.season}</td>
                 <td>{r.y}</td>
                 <td>{CAT_LABELS[r.cat] ?? r.cat}</td>
-                <td>{r.spei >= 0 ? "+" : ""}{r.spei.toFixed(2)}</td>
-                <td>{r.balance.toFixed(0)}</td>
-                <td>{r.rank}. od {r.total}</td>
+                <td>{fmtSigned(r.spei, 2)}</td>
+                <td>{fmtNum(r.balance, 0)}</td>
+                <td>{t("spei.rank_of", { rank: r.rank, total: r.total })}</td>
               </tr>
             )}
           </For>

--- a/code/ali-je-vroce-era5/charts/SpeiTrendChart.tsx
+++ b/code/ali-je-vroce-era5/charts/SpeiTrendChart.tsx
@@ -1,5 +1,6 @@
 import { createSignal, createMemo, For, Show, onMount, onCleanup } from "solid-js";
 import { enableChartA11y } from "./highcharts-a11y.ts";
+import { t, fmtNum, fmtSigned, fmtMonthShort } from "../i18n/format.ts";
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -30,6 +31,14 @@ export interface SpeiStationData {
 const SEASONS = ["Annual", "Winter", "Spring", "Summer", "Autumn"] as const;
 const MONTHS  = ["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"] as const;
 type Period   = typeof SEASONS[number] | typeof MONTHS[number];
+
+// T-5.5 — the season/month period keys stay English (they index the datasette);
+// only their display label is Slovenian (seasons from the catalogue, months from
+// the Intl short-month formatter).
+function periodLabel(p: string): string {
+  const mi = (MONTHS as readonly string[]).indexOf(p);
+  return mi >= 0 ? fmtMonthShort(mi + 1) : t(`speitrend.season_${p}`);
+}
 
 const INK      = "#0E0E0C";
 const INK_SOFT = "#6B655B";
@@ -85,14 +94,13 @@ function SpeiScatterChart(props: ChartProps) {
       // T-5.4a — screen-reader summary (Slovenian copy awaiting operator review)
       accessibility: {
         enabled: true,
-        description: "Razsevni diagram sušnega indeksa SPEI po letih za izbrano postajo in obdobje, z linijo trenda Theil-Sen ter pragovoma hude suše (−1,5) in zelo mokrega (+1,5).",
+        description: t("speitrend.a11y"),
       },
       tooltip: {
         formatter(this: any) {
           const v = this.y as number;
-          const cat = v < -1.5 ? "Huda suša" : v < -1.0 ? "Suho" : v < 1.0 ? "Normalno" : v < 1.5 ? "Mokro" : "Zelo mokro";
-          const sign = v >= 0 ? "+" : "";
-          return `<b>${props.season} ${this.x}</b><br>${scaleLabel}: <b>${sign}${v.toFixed(2)}</b><br>${cat}`;
+          const cat = v < -1.5 ? t("speitrend.tooltip_cat_huda") : v < -1.0 ? t("speitrend.tooltip_cat_suho") : v < 1.0 ? t("speitrend.tooltip_cat_normalno") : v < 1.5 ? t("speitrend.tooltip_cat_mokro") : t("speitrend.tooltip_cat_zelo_mokro");
+          return t("speitrend.tooltip", { season: periodLabel(props.season), x: this.x, scale: scaleLabel, v: fmtSigned(v, 2), cat });
         },
       },
       xAxis: {
@@ -109,9 +117,9 @@ function SpeiScatterChart(props: ChartProps) {
         plotLines: [
           { value: 0,    color: INK,       width: 1, dashStyle: "Solid", zIndex: 3 },
           { value: -1.5, color: "#8b3a0f", width: 1, dashStyle: "Dash",  zIndex: 3,
-            label: { text: "huda suša", style: { fontSize: "9px", color: "#8b3a0f", ...MONO } } },
+            label: { text: t("speitrend.threshold_dry"), style: { fontSize: "9px", color: "#8b3a0f", ...MONO } } },
           { value:  1.5, color: "#1e4d78", width: 1, dashStyle: "Dash",  zIndex: 3,
-            label: { text: "zelo mokro", style: { fontSize: "9px", color: "#1e4d78", ...MONO }, align: "right" as const } },
+            label: { text: t("speitrend.threshold_wet"), style: { fontSize: "9px", color: "#1e4d78", ...MONO }, align: "right" as const } },
         ],
       },
       series: [
@@ -173,26 +181,29 @@ export function SpeiTrendChart(props: SpeiTrendChartProps) {
     if (sl !== 0) {
       if (sl < 0) {
         if (curVal <= -1.5) {
-          thresholdLine = "Trendna linija je že prečkala prag hude suše (SPEI −1,5).";
+          thresholdLine = t("speitrend.threshold_crossed_dry");
         } else {
           const yr = Math.round((-1.5 - ic) / sl);
-          if (yr > lastYear && yr < 2200) thresholdLine = `Pri tem trendu doseže hudo sušo (SPEI −1,5) okoli leta ${yr}.`;
+          if (yr > lastYear && yr < 2200) thresholdLine = t("speitrend.threshold_reach_dry", { year: yr });
         }
       } else {
         if (curVal >= 1.5) {
-          thresholdLine = "Trendna linija je že prečkala prag zelo mokrega (SPEI +1,5).";
+          thresholdLine = t("speitrend.threshold_crossed_wet");
         } else {
           const yr = Math.round((1.5 - ic) / sl);
-          if (yr > lastYear && yr < 2200) thresholdLine = `Pri tem trendu doseže zelo mokro (SPEI +1,5) okoli leta ${yr}.`;
+          if (yr > lastYear && yr < 2200) thresholdLine = t("speitrend.threshold_reach_wet", { year: yr });
         }
       }
     }
 
     const sig = p < 0.05
-      ? `statistično značilen (p < 0,05)`
-      : `ni statistično značilen (p = ${p.toFixed(3)})`;
+      ? t("speitrend.sig_significant")
+      : t("speitrend.sig_not", { p: fmtNum(p, 3) });
 
-    const tech = `Theil-Sen naklon: ${slope >= 0 ? "+" : ""}${slope.toFixed(3)} SPEI/desetletje · Mann-Kendall: ${tr.mk_trend} · ${sig}. Negativen trend pomeni, da razmere postajajo sušnejše glede na osnovno obdobje ${props.data.baseline}.${thresholdLine ? " " + thresholdLine : ""}`;
+    const tech = t("speitrend.tech", {
+      slope: fmtSigned(slope, 3), mk: tr.mk_trend, sig, baseline: props.data.baseline,
+      threshold: thresholdLine ? " " + thresholdLine : "",
+    });
 
     return { slope, p, tech };
   });
@@ -239,11 +250,11 @@ export function SpeiTrendChart(props: SpeiTrendChartProps) {
       {/* Season + month row */}
       <div style={{ display: "flex", "flex-wrap": "wrap", gap: "5px", "align-items": "center", margin: "0 40px 14px" }}>
         <For each={SEASONS}>
-          {(s) => <button style={periodBtnStyle(s)} onClick={() => setPeriod(s)}>{s}</button>}
+          {(s) => <button style={periodBtnStyle(s)} onClick={() => setPeriod(s)}>{periodLabel(s)}</button>}
         </For>
         <span style={{ display: "inline-block", width: "1px", height: "16px", background: "var(--color-rule-2)", margin: "0 4px" }} />
         <For each={MONTHS}>
-          {(m) => <button style={periodBtnStyle(m)} onClick={() => setPeriod(m)}>{m}</button>}
+          {(m) => <button style={periodBtnStyle(m)} onClick={() => setPeriod(m)}>{periodLabel(m)}</button>}
         </For>
       </div>
 
@@ -255,12 +266,18 @@ export function SpeiTrendChart(props: SpeiTrendChartProps) {
           <div style={{ padding: "12px 16px 10px", "border-bottom": "1px solid var(--color-rule)", display: "flex", "justify-content": "space-between", "align-items": "flex-start", gap: "12px" }}>
             <div>
               <div style={{ "font-family": "var(--font-sans)", "font-weight": "500", "font-size": "14px", color: "var(--color-ink)" }}>
-                {station().replace(/_/g, " ")} — {period()} {scaleLabel()}
+                {station().replace(/_/g, " ")} — {periodLabel(period())} {scaleLabel()}
               </div>
               <Show when={series()}>
                 {(s) => (
                   <div style={{ "font-family": "var(--font-mono)", "font-size": "10px", color: "var(--color-ink-soft)", "letter-spacing": "0.06em", "text-transform": "uppercase", "margin-top": "2px" }}>
-                    {s().years.length} {isMonth() ? "mesecev" : "sezon"} · {s().years[0]}–{s().years[s().years.length - 1]}
+                    {t("speitrend.header_count", {
+                      count: s().years.length,
+                      unit1: isMonth() ? t("speitrend.unit_months_one") : t("speitrend.unit_seasons_one"),
+                      unit2: isMonth() ? t("speitrend.unit_months_other") : t("speitrend.unit_seasons_other"),
+                      y0: s().years[0] ?? 0,
+                      y1: s().years[s().years.length - 1] ?? 0,
+                    })}
                   </div>
                 )}
               </Show>
@@ -271,10 +288,10 @@ export function SpeiTrendChart(props: SpeiTrendChartProps) {
               {(ts) => (
                 <div style={{ "text-align": "right", "flex-shrink": "0" }}>
                   <div style={{ "font-family": "var(--font-sans)", "font-size": "32px", "font-weight": "700", "line-height": "1", color: ts().slope < 0 ? "#8b3a0f" : "#1e4d78" }}>
-                    {ts().slope >= 0 ? "+" : ""}{ts().slope.toFixed(2)}
+                    {fmtSigned(ts().slope, 2)}
                   </div>
                   <div style={{ "font-family": "var(--font-mono)", "font-size": "9px", "letter-spacing": "0.07em", "text-transform": "uppercase", color: "var(--color-ink-soft)", "margin-top": "2px" }}>
-                    SPEI / desetletje
+                    {t("speitrend.slope_unit")}
                   </div>
                 </div>
               )}
@@ -298,7 +315,7 @@ export function SpeiTrendChart(props: SpeiTrendChartProps) {
           </Show>
           <Show when={!trendStats() && series()}>
             <p style={{ margin: "0", padding: "8px 16px 12px", "font-family": "var(--font-sans)", "font-size": "12px", color: "var(--color-ink-soft)", "line-height": "1.55", "border-top": "1px solid var(--color-rule)" }}>
-              Premalo podatkov za izračun trenda.
+              {t("speitrend.too_little")}
             </p>
           </Show>
 

--- a/code/ali-je-vroce-era5/charts/TodayGauge.tsx
+++ b/code/ali-je-vroce-era5/charts/TodayGauge.tsx
@@ -1,6 +1,7 @@
 import { onMount, onCleanup, createEffect } from "solid-js";
 import type { TodayStatus } from "../types.ts";
 import { enableChartA11y } from "./highcharts-a11y.ts";
+import { t, fmtNum } from "../i18n/format.ts";
 
 interface Props {
   data: TodayStatus;
@@ -116,7 +117,7 @@ export function TodayGauge(props: Props) {
         class="font-mono text-sm font-semibold px-4 py-1 rounded-full leading-tight"
         style={tempStyle()}
       >
-        {props.data.today_temp?.toFixed(1)} °C
+        {props.data.today_temp != null ? t("common.temp_c", { temp: fmtNum(props.data.today_temp, 1) }) : " °C"}
       </div>
     </div>
   );

--- a/code/ali-je-vroce-era5/charts/TropicalChart.tsx
+++ b/code/ali-je-vroce-era5/charts/TropicalChart.tsx
@@ -9,6 +9,7 @@
 import { createEffect, onMount, onCleanup } from "solid-js";
 import { todayYear } from "../clock";
 import { enableChartA11y } from "./highcharts-a11y.ts";
+import { t, fmtNum, fmtSigned } from "../i18n/format.ts";
 
 export interface TropTrend {
   model_used:      boolean | "nb";
@@ -51,7 +52,7 @@ const ACCENT   = "#C25A2C";
 const MONO     = { fontFamily: "'JetBrains Mono', monospace" };
 
 function pFmt(p: number): string {
-  return p < 0.001 ? "p < 0.001" : p < 0.01 ? "p < 0.01" : p < 0.05 ? `p = ${p.toFixed(3)}` : `p = ${p.toFixed(3)} (ns)`;
+  return p < 0.001 ? "p < 0,001" : p < 0.01 ? "p < 0,01" : p < 0.05 ? `p = ${fmtNum(p, 3)}` : `p = ${fmtNum(p, 3)} (ns)`;
 }
 
 // ── Highcharts inner component ────────────────────────────────────────────────
@@ -126,7 +127,7 @@ export function TropHighchart(props: ChartProps) {
         },
         {
           type: "line",
-          name: `NB fit (${dpd >= 0 ? "+" : ""}${dpd.toFixed(1)} ${props.cfg.unitLabel}/des · ${pFmt(p)})`,
+          name: t("tropical.nb_fit", { dpd: fmtSigned(dpd, 1), unit: props.cfg.unitLabel, p: pFmt(p) }),
           data: trend.x_line.map((x, i) => ({ x, y: trend.y_line[i] })),
           color: INK,
           lineWidth: 2,
@@ -145,7 +146,7 @@ export function TropHighchart(props: ChartProps) {
       value: props.series.trend.fit_year_max + 0.5,
       color: INK_SOFT, width: 1, dashStyle: "Dot" as const, zIndex: 4,
       label: {
-        text: `trend do ${props.series.trend.fit_year_max}`, rotation: 0,
+        text: t("tropical.trend_label", { year: props.series.trend.fit_year_max }), rotation: 0,
         align: "right" as const, x: -4, y: -4,
         style: { fontSize: "9px", color: INK_SOFT, ...MONO },
       },
@@ -166,14 +167,14 @@ export function TropHighchart(props: ChartProps) {
       // Parameterised by cfg so days vs nights each get their own wording.
       accessibility: {
         enabled: true,
-        description: `Stolpčni prikaz letnega števila — ${props.cfg.tooltipNoun.toLowerCase()}, torej koliko ${props.cfg.unitLabel} na leto preseže izbrani temperaturni prag — z modelom trenda negativne binomske regresije in intervalom zaupanja; zadnji stolpec je leto v teku.`,
+        description: t("tropical.a11y", { noun: props.cfg.tooltipNoun.toLowerCase(), unit: props.cfg.unitLabel }),
       },
       tooltip: {
         formatter(this: any) {
-          if (this.series.type === "line") return `<b>${Math.round(this.x)}</b><br>Trend: <b>${this.y!.toFixed(1)}</b> ${props.cfg.unitLabel}`;
+          if (this.series.type === "line") return t("tropical.tooltip_trend", { x: Math.round(this.x), y: fmtNum(this.y!, 1), unit: props.cfg.unitLabel });
           if (this.series.type === "arearange") return false as any;
-          const partial = this.x === todayYear() ? " <i>(leto v teku)</i>" : "";
-          return `<b>${this.x}</b>${partial}<br>${props.cfg.tooltipNoun}: <b>${this.y}</b>`;
+          const partial = this.x === todayYear() ? ` <i>${t("tropical.year_in_progress")}</i>` : "";
+          return t("tropical.tooltip_bar", { x: this.x, partial, noun: props.cfg.tooltipNoun, y: this.y });
         },
       },
       xAxis: {

--- a/code/ali-je-vroce-era5/charts/YearRoundChart.tsx
+++ b/code/ali-je-vroce-era5/charts/YearRoundChart.tsx
@@ -1,6 +1,7 @@
 import { onMount, onCleanup, createEffect } from "solid-js";
 import type { CalendarData } from "../api.ts";
 import { enableChartA11y } from "./highcharts-a11y.ts";
+import { t, fmtNum, fmtSigned, fmtDoy, fmtMonthShort } from "../i18n/format.ts";
 
 interface Props {
   data: CalendarData;
@@ -12,7 +13,7 @@ const MONTH_DOYS = [1, 32, 60, 91, 121, 152, 182, 213, 244, 274, 305, 335];
 const MONTH_MIDS = MONTH_DOYS.map((d, i) =>
   Math.round((d + (MONTH_DOYS[i + 1] ?? 366)) / 2)
 );
-const MONTH_LABELS = ["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"];
+const MONTH_LABELS = Array.from({ length: 12 }, (_, i) => fmtMonthShort(i + 1));
 
 const IS_PRECIP = new Set(["precipitation_sum","et0_evapotranspiration"]);
 const POS_TEMP  = [210, 55,  35] as const;   // red   — warming
@@ -72,7 +73,7 @@ export function YearRoundChart(props: Props) {
       // T-5.4a — screen-reader summary (Slovenian copy awaiting operator review)
       accessibility: {
         enabled: true,
-        description: "Trend spremembe po dnevih v letu čez celotno koledarsko leto — vsak stolpec je en dan, višina je trend na desetletje, navpična črta pa označuje izbrani datum.",
+        description: t("yearround.a11y"),
       },
       xAxis: {
         min: 0.5, max: 365.5,
@@ -120,11 +121,9 @@ export function YearRoundChart(props: Props) {
       },
       tooltip: {
         formatter(this: any) {
-          const ref = new Date(2001, 0, this.x - 1);
-          const label = ref.toLocaleDateString("en-GB", { month: "short", day: "numeric" });
-          const sign = this.y >= 0 ? "+" : "";
-          const pStr = this.point.p < 0.001 ? "< 0.001" : this.point.p.toFixed(3);
-          return `<b>${label}</b><br>Trend: ${sign}${this.y.toFixed(3)} ${props.data.unit}/decade<br>p = ${pStr}`;
+          const label = fmtDoy(Math.round(this.x));
+          const pStr = this.point.p < 0.001 ? "< 0,001" : fmtNum(this.point.p, 3);
+          return t("yearround.tooltip", { label, trend: fmtSigned(this.y, 3), unit: props.data.unit, p: pStr });
         },
         style: { fontSize: "12px", fontFamily: "Space Grotesk, sans-serif" },
       },

--- a/code/ali-je-vroce-era5/charts/highcharts-a11y.ts
+++ b/code/ali-je-vroce-era5/charts/highcharts-a11y.ts
@@ -20,6 +20,8 @@
 // side effects and HC.setOptions is the stub's no-op, so nothing here reaches real
 // Highcharts — exactly as the existing highcharts-more / modules/map aliases do.
 
+import { t } from "../i18n/format.ts";
+
 let ready: Promise<void> | null = null;
 
 export function enableChartA11y(HC: any): Promise<void> {
@@ -37,6 +39,17 @@ export function enableChartA11y(HC: any): Promise<void> {
         // view-data-table proxy present in the SR region. Purely additive; no
         // rendered pixel changes (T-5.4a).
         exporting: { enabled: false },
+        // T-5.5 — the export-data "view as data table" affordance strings, sourced
+        // from the catalogue (hc.*). Extracted AS-IS: the values are still the
+        // English Highcharts defaults, centralised here and FLAGGED for a Slovenian
+        // translation pass (D-8). Setting them to their own defaults is a no-op on
+        // the rendered output today.
+        lang: {
+          viewData:    t("hc.viewData"),
+          hideData:    t("hc.hideData"),
+          downloadCSV: t("hc.downloadCSV"),
+          downloadXLS: t("hc.downloadXLS"),
+        },
       });
     })();
   }

--- a/code/ali-je-vroce-era5/components/HeroCards.tsx
+++ b/code/ali-je-vroce-era5/components/HeroCards.tsx
@@ -2,20 +2,18 @@ import { createResource, Show, ErrorBoundary } from "solid-js";
 import { fetchRegression } from "../api.ts";
 import { sectionErrorFallback } from "./SectionError.tsx";
 import type { RegressionResult } from "../types.ts";
-
-// ── Inlined locale (from sl_default.json hero / hero_category / hero_context / climate_risks) ──
-
-const VERDICT_WARMING = "Sto let segrevanja za <em>{sign}{t100} {unit}</em> – pri trenutnem tempu vsaka <em>{yrs} let</em> doda eno stopinjo.";
-const VERDICT_COOLING = "Sto let ohlajanja za <em>{sign}{t100} {unit}</em> – pri trenutnem tempu vsaka <em>{yrs} let</em> odšteje eno stopinjo.";
-const VERDICT_NONE    = "Na ta dan v letu ni zaznati trenda.";
-const METHOD_THEILSEN = "Theil-Sen + TFPW Mann-Kendall";
+import { t, fmtNum, fmtSigned } from "../i18n/format.ts";
+// T-5.5 — per-location content is centralised in the catalogue; read the raw
+// objects here for the `?.[cat] ?? baseline` fallback and the risk <Show> guard,
+// which a key-returning t() cannot express.
+import { climateRisks, heroContext } from "../i18n/hero-content.ts";
 
 const CATEGORIES: Record<string, string> = {
-  catastrophic: "Katastrofalno",
-  extreme:      "Ekstremno",
-  bad:          "Slabo",
-  moderate:     "Zmerno",
-  baseline:     "Izhodiščno",
+  catastrophic: t("hero.cat_catastrophic"),
+  extreme:      t("hero.cat_extreme"),
+  bad:          t("hero.cat_bad"),
+  moderate:     t("hero.cat_moderate"),
+  baseline:     t("hero.cat_baseline"),
 };
 
 const CAT_STYLE: Record<string, { background: string; color: string }> = {
@@ -24,156 +22,6 @@ const CAT_STYLE: Record<string, { background: string; color: string }> = {
   bad:          { background: "#c2843a", color: "#fff" },
   moderate:     { background: "#b5a06a", color: "#fff" },
   baseline:     { background: "#6c8fb6", color: "#fff" },
-};
-
-const CLIMATE_RISKS: Record<string, string> = {
-  Ljubljana:        "Mestni toplotni otok — poletni vročinski stres in tveganje hudourniških poplav v Ljubljanski kotlini",
-  Maribor:          "Sušni stres v vinogradništvu — zgodnejše trgatve in premik vinskih sort",
-  Celje:            "Okrepitev poplav Savinje v kombinaciji z naraščajočo poletno sušo",
-  Kranj:            "Izguba alpske snežne odeje, ki zmanjšuje poletni pretok Save",
-  Koper:            "Podaljšanje sredozemske suše — tveganje vdora slane vode in dviga morske gladine",
-  Novo_Mesto:       "Suša reke Krke ogroža pridelavo hmelja in sadja",
-  Murska_Sobota:    "Panonska vročina in suša — najtoplejše temperaturne razlike v Sloveniji",
-  Nova_Gorica:      "Sredozemsko sušenje — ekosistem hladnovodne Soče in kraško vinogradništvo v nevarnosti",
-  Postojna:         "Suša kraškega vodonosnika — jamski ekosistem in endemska favna pod toplotnim stresom",
-  Ptuj:             "Nizki vodostaji Drave — vodni stres v vinogradništvu in zmanjšanje hidroenergetskih zmogljivosti",
-  Velenje:          "Upravljanje z vodo po izkopavanju premoga ob stopnjevanju suše in poplav",
-  Trbovlje:         "Ojačanje vročine v savski soteski in naraščajoče tveganje poplav",
-  Tolmin:           "Stopnjevanje ekstremnih poplav Soče — krčenje ekosistema hladnovodnih rib",
-  Kocevje:          "Propad pragozdov pod napadom lubadarja — izguba habitata velikih zveri",
-  Ilirska_Bistrica: "Izčrpavanje kraških izvirov — motnja podzemnega rečnega sistema Pivke",
-  Domzale:          "Mestni toplotni otok v kotlini — kombinirani vročinski in sušni stres za Ljubljansko regijo",
-  Ratece:           "Izguba alpske snežne odeje — grožnja smučarskemu gospodarstvu in nestabilnost permafrost pobočij",
-  Kredarica:        "Izguba Triglavskega ledenika — izsušitev izvirnih vod za Slovenijo reke",
-};
-
-const HERO_CONTEXT: Record<string, Record<string, string>> = {
-  Ljubljana: {
-    baseline:     "Glavno mesto v Ljubljanski kotlini, ki jo obkrožajo hribi in pozimi pastuje hladen zrak. Celinsko podnebje s toplimi poletji in hladnimi zimami, okrepljeno z mestnim toplotnim otokom.",
-    moderate:     "Segrevanje skrajšuje zimsko megleno sezono, a povečuje poletni toplotni stres. Mestno tkivo zadržuje toploto, ponoči postaja vse toplejše po vsej metropolitanski regiji.",
-    bad:          "Vročinski valovi presegajo 35 °C več zaporednih dni. Smrtnost starejših narašča. Kotlinska lega kopiči toploto; poraba klimatskih naprav se poveča in preobremeni omrežje.",
-    extreme:      "Podaljšane vročinske izredne razmere postanejo letni pojav. Reka Ljubljanica poleti splahni, kar ogroža vodooskrbo. Mestna zelenjava trpi pod hudim sušnim stresom.",
-    catastrophic: "Podaljšani poletni vročinski valovi presegajo hladilne zmogljivosti mesta. Hudourniške poplave iz okrepljenih alpskih padavin večkrat ogrozijo nizko ležečo kotlino.",
-  },
-  Maribor: {
-    baseline:     "Drugo največje mesto, dolina reke Drave, severovzhodna Slovenija. Celinsko podnebje z vročimi poletji. Pomembna vinorodna regija — segrevanje že pomika datume trgatve naprej.",
-    moderate:     "Podaljšana rastna sezona kratkoročno koristi vinu, a naraščajoč sušni stres in tveganje poznih zmrzali po zgodnji brstovitvi začenjata ogrožati pridelke.",
-    bad:          "Datumi trgatve se premaknejo 3–4 tedne naprej. Tradicionalne štajerske sorte trpijo pod vročinskim stresom. Fitosanitarni problemi se bistveno okrepijo.",
-    extreme:      "Tradicionalne štajerske vinogradniške sorte postanejo ekonomsko neobstojne. Povpraševanje po namakanju iz Drave se spopada z ekološkimi zahtevami pretoka.",
-    catastrophic: "Ponavljajoča se huda sušna leta sesedejo štajersko vinsko gospodarstvo. Ekstremno nizki vodostaji Drave ogrožajo vodooskrbo doline in obrečne ekosisteme.",
-  },
-  Celje: {
-    baseline:     "Dolina reke Savinje, zgodovinsko podvržena hudim poplavam. Celinsko podnebje. Zaprta dolina ustvarja temperaturne inverzije in zmrzalne žepe pozimi.",
-    moderate:     "Segrevanje zmanjšuje zmrzalne dni, a krepi konvektivne padavine, ki sprožajo poplave Savinje, po katerih je mesto že znano.",
-    bad:          "Dogodki, ki so bili prej stletni poplavni viški, se ponavljajo v desetletjih. Protipoplavna infrastruktura, zgrajena za zgodovinske povratne dobe, je sistematično prekoračena.",
-    extreme:      "Kombinirani poletni sušni in zimski poplavni ekstremi hkrati destabilizirajo kmetijstvo in infrastrukturo v dolini Savinje.",
-    catastrophic: "Pogostejši ekstremni poplavni dogodki preplavljajo staro protipoplavno infrastrukturo. Izmenjava suša–poplava destabilizira kmetijsko savinjsko ravnino.",
-  },
-  Kranj: {
-    baseline:     "Ob vznožju Kamniško-Savinjskih Alp, dolina reke Save, 387 m. Alpski vpliv ohranja razmeroma hladna poletja. Vhod v Triglavski narodni park.",
-    moderate:     "Upadanje alpske snežne odeje zmanjšuje poletni pretok Save, kar vpliva na vodooskrbo za odvodne uporabnike, vključno z Ljubljano.",
-    bad:          "Poletni nizki vodostaji Save postanejo hudi. Hidroelektrična proizvodnja na savski verigi elektrarn v sušnih letih občutno pade.",
-    extreme:      "Umikanje ledenikov v Kamniško-Savinjskih Alpah se pospeši. Kamenje iz destabilizirajočih se pobočij ogroža infrastrukturo v dolini.",
-    catastrophic: "Izguba zanesljive poletne savenice, ki jo napaja snežna odeja, ogroža hidroelektrično hrbtenico slovenskega elektroenergetskega sistema.",
-  },
-  Koper: {
-    baseline:     "Edino slovensko morsko pristanišče, Jadransko morje, 10 m nadmorske višine. Sredozemsko podnebje: mile zime, suha poletja, burjni vetrovi.",
-    moderate:     "Segrevanje morske gladine podaljšuje kopalno sezono. Tveganje suše se poleti povečuje z naraščajočim sredozemskim sušnim signalom.",
-    bad:          "Vdor slane vode v obalne vodonosnike se krepi. Mediteranske invazivne vrste se ustanavljajo v slovenskih obalnih vodah.",
-    extreme:      "Pogostost in resnost neviht s sodro narašča. Obalno kmetijsko zemljišče se sooča s slanostjo od morskih razpršilcev in vdorov podzemne vode.",
-    catastrophic: "Dvig gladine Jadranskega morja ogroža pristaniško infrastrukturo in obalno kmetijstvo. Ekstremni burjni dogodki se krepijo z naraščajočimi temperaturnimi gradienti.",
-  },
-  Novo_Mesto: {
-    baseline:     "Dolina reke Krke, jugovzhodna Slovenija, 220 m. Celinsko s ponekod panonskim vplivom. Pomembna regija za sadje — jabolka, hruške in hmelj.",
-    moderate:     "Segrevanje podaljšuje brezzmrzalno rastno sezono, a povečuje poletni sušni stres na povodju reke Krke.",
-    bad:          "Osnovni pretok reke Krke poleti občutno upade. Pridelava hmelja se sooča z vročinskim in sušnim stresom, ki zahteva drago namakanje.",
-    extreme:      "Večletne suše izčrpavajo reko Krko in podzemno vodo. Sadjarstvo in hmeljarstvo zahtevata temeljito prestrukturiranje.",
-    catastrophic: "Ponavljajoča se sušna leta izčrpavajo osnovni pretok reke Krke. Hmeljarsko in sadjarsko gospodarstvo Dolenjske se sooča s temeljitim prestrukturiranjem.",
-  },
-  Murska_Sobota: {
-    baseline:     "Severovzhodna panonska ravnina, 189 m. Najbolj celinsko postaja — najtoplejša poletja, najhladnejše zime, najmanj padavin. Intenzivno kmetijstvo: koruza, sončnice, pšenica.",
-    moderate:     "Že najbolj sušno izpostavljena regija v Sloveniji. Dni z vročinskim stresom nad 35 °C naraščajo najhitreje. Primanjkljaj kmetijske vode je že občuten.",
-    bad:          "Pridelki koruze in sončnic v sušnih letih padejo za 20–30 %. Poletni ekstremi nad 38 °C postanejo redni.",
-    extreme:      "Večletna sušna zaporedja sesedejo tradicionalno kmetijstvo brez namakanja. Povpraševanje po namakanju preseže trajnostni donos reke Mure.",
-    catastrophic: "Panonsko kmetijsko gospodarstvo se sooča s propadom pod trajnimi večletnimi sušami. Izčrpavanje podzemne vode se pospeši.",
-  },
-  Nova_Gorica: {
-    baseline:     "Zahodna Slovenija, spodnja dolina Soče, 94 m. Sredozemsko-alpski prehod. Toplo in sončno z burjnimi vetrovi. Pomembna vinorodna regija.",
-    moderate:     "Segrevanje pospešuje sredozemski trend sušenja. Burjni dogodki se morda okrepijo. Kakovost vin se preoblikuje z naraščanjem rastnih stopenj.",
-    bad:          "Poletna suša naredi tradicionalno kraško vinogradništvo vse bolj odvisno od namakanja. Nizki poletni pretoki Soče ogrožajo ekologijo.",
-    extreme:      "Hladnovodni ribolov Soče se sooča s toplotnim izumrtjem v spodnjih dosegih, ko poletne temperature presegajo toleranče.",
-    catastrophic: "Ekstremna poletna suša naredi tradiconalno kraško in brdiško vinogradništvo neobstojno brez namakanja.",
-  },
-  Postojna: {
-    baseline:     "Kraška planota, 549 m. Znana po temperaturnih inverzijah — hladen zrak se kopiči v kraški depresiji. Temperature v jamskem ekosistemu so stabilne pri 10 °C.",
-    moderate:     "Segrevanje slabi temperaturne inverzije in zmanjšuje ekstremno hlajenje. Temperature v jamskem ekosistemu se začnejo premikati.",
-    bad:          "Notranje jame začnejo izmerljivo naraščati. Pretok kraških izvirov poleti v sušah upada.",
-    extreme:      "Endemska favna Postojnske jame — človeška ribica in jamski hrošči — se sooča s toplotnim in hidrološkim stresom.",
-    catastrophic: "Napajanje kraškega vodonosnika popusti pod podaljšano sušo. Endemska favna Postojnske jame se sooča s toplotnim stresom brez poti pobega.",
-  },
-  Ptuj: {
-    baseline:     "Najstarejše stalno poseljeno mesto v Sloveniji, dolina reke Drave, 228 m. Severovzhodna celinska cona. Vino, hmelj in žitno kmetijstvo.",
-    moderate:     "Dogodki nizkih vodostajev Drave se pogostijo, kar vpliva na hladilno vodo za hidroelektrarno Formin nizvodno.",
-    bad:          "Datumi trgatve se bistveno premaknejo naprej. Kmetijsko povpraševanje po vodi vse bolj nasprotuje ekološkim zahtevam pretoka.",
-    extreme:      "Ekstremno nizki vodostaji Drave postanejo redni. Hidroelektrarna Formin se v sušnih letih sooča z obveznim omejevanjem.",
-    catastrophic: "Kombinirani sušni in vročinski ekstremi destabilizirajo kmetijsko gospodarstvo v dravski dolini.",
-  },
-  Velenje: {
-    baseline:     "Šaleška dolina, 405 m, osrednja Slovenija. Zgrajena okoli premogovništva. Gorska celinska mikroklima pod vplivom Šaleških jezer.",
-    moderate:     "Ko premogovništvo upada, podnebni vplivi vključujejo povečano tveganje poplav v posedninskih conah.",
-    bad:          "Šaleška jezera se soočajo z naraščajočim izhlapevanjem in cvetenjem alg. Upravljanje z vodo postane kompleksno.",
-    extreme:      "Prehod po premogu oteži podnebne ekstreme. Načrtovani prehod na obnovljivo energijo se sooča s konflikti rabe tal.",
-    catastrophic: "Upravljanje z vodo v posedninskih jezerih postane kritično z naraščajočim izhlapevanjem.",
-  },
-  Trbovlje: {
-    baseline:     "Zasavje, savska soteska, 230 m. Najožja poseljena dolina v Sloveniji. Kotlinska lega ustvarja značilne temperaturne inverzije.",
-    moderate:     "Segrevanje zmanjšuje zimske inverzije, ki kopičijo onesnaženost zraka, a povečuje poletni toplotni stres v zaprti dolini.",
-    bad:          "Poletni vročinski valovi v soteski so okrepljeni z njeno geometrijo in industrijskimi toplotnimi viri.",
-    extreme:      "Ekstremni padavinski dogodki nad Trbovljami povečujejo katastrofalno tveganje poplav v soteski.",
-    catastrophic: "Ekstremni vročinski valovi v soteski so okrepljeni z njeno geometrijo. Tveganje poplav Save narašča z naraščajočimi alpskimi padavinami.",
-  },
-  Tolmin: {
-    baseline:     "Dolina Soče/Isonzo, 194 m. Najtoplejša dolina v Sloveniji kljub alpski legi. Ekstremni padavinski dogodki naredijo to območje najdežnejše v Evropi.",
-    moderate:     "Segrevanje krepi že tako ekstremne padavinske dogodke. Izjemna biotska raznovrstnost doline se sooča z naraščajočim toplotnim pritiskom.",
-    bad:          "Poletni pretoki Soče občutno upadejo. Hladnovodni habitat marmornega postrva se krči navzgor po toku.",
-    extreme:      "Ekstremni poplavni dogodki na sistemu Soča–Idrijca se ponavljajo pogosteje. Smaragdna barva Soče zbledi z umikanjem ledenikov.",
-    catastrophic: "Katastrofalni poplavni dogodki na Soči postanejo pogostejši. Hladnovodni ribolov in naravni turizem sta temeljno ogrožena.",
-  },
-  Kocevje: {
-    baseline:     "Regija Kočevski Rog, 467 m, pokrita z največjim ostankom pragozdov v Srednji Evropi. Medvedi, risi in volkovi v največji gostoti v Evropi.",
-    moderate:     "Segrevanje premakne sestavo gozda k termofilnim vrstam. Izbruhi lubadarja se pospešijo v toplejših, sušnejših poletjih.",
-    bad:          "Pragozd se sooča s strukturno preobrazbo pod kombiniranim pritiskom suše in lubadarja.",
-    extreme:      "Obsežno odmiranje gozda odpre pragozd tveganju požarov, ki je bilo prej zanemarljivo.",
-    catastrophic: "Kočevski pragozd se sooča z nepopravljivo strukturno spremembo. Habitat velikih zveri se krči z upadanjem gozda.",
-  },
-  Ilirska_Bistrica: {
-    baseline:     "Pivška kotlina, 440 m. Prehodno območje med sredozemskim in celinskim podnebjem. Reka Pivka izgine pod zemljo v največji jamski sistem na svetu.",
-    moderate:     "Segrevanje zmanjšuje zimsko snežno odejo, ki napaja kraške izvire Pivke.",
-    bad:          "Površinski pretok reke Pivke izgine zgodaj v sezoni, ko upadejo kraški izviri.",
-    extreme:      "Jamski sistem Postojna–Planina se sooča z zmanjšanim pretokom in naraščajočimi temperaturami vode.",
-    catastrophic: "Kraški izviri, ki napajajo reko Pivko, poleti presahnejo. Edinstveni hidrološki sistem je moten s kaskadnimi učinki.",
-  },
-  Domzale: {
-    baseline:     "Ljubljanska kotlina, 301 m. Primestno in lahko industrijsko. Celinsko podnebje z nekoliko manjšim mestnim toplotnim otokom kot Ljubljana.",
-    moderate:     "Z razširjanjem metropolitanske regije se mestni toplotni otoški učinki krepijo.",
-    bad:          "Poletni toplotni otok po kotlini ustvarja trajen vročinski stres za 400.000 prebivalcev regije.",
-    extreme:      "Kombinirani vročinski in sušni dogodki bistveno zmanjšajo kakovost življenja in povečajo smrtnost.",
-    catastrophic: "Urbanizacija v kombinaciji s podnebnim segrevanjem ustvari trajen toplotni otok s kumulativnimi učinki na javno zdravje.",
-  },
-  Ratece: {
-    baseline:     "Tarbizijska kotlina, Julijske Alpe, 864 m. Eno najsušnejših mest v Sloveniji kljub alpski legi. Ekstremno hladne zime, obilna snežna odeja.",
-    moderate:     "Globina in trajanje snežne odeje se opazno zmanjšujeta. Čas spomladanskega odtajanja se premika naprej.",
-    bad:          "Smučarsko letovišče Kranjska Gora se sooča z ekonomsko neobstojnimi snežnimi sezonami.",
-    extreme:      "Taljenje permafrosta v Julijskih Alpah sproži naraščajoče kamenje in nestabilnost pobočij.",
-    catastrophic: "Izguba zanesljive zimske snežne odeje konča smučarsko gospodarstvo v dolini Kranjske Gore.",
-  },
-  Kredarica: {
-    baseline:     "Vrh masiva Triglava, 2514 m — najvišja meteorološka postaja v Sloveniji. Stalni sneg, ostanki ledenikov, ekstremni vetrovi.",
-    moderate:     "Triglavski ledenik — zadnji ledenik v Sloveniji — se vidno umika. Segrevanje je tukaj dvojno od nižinskega.",
-    bad:          "Triglavski ledenik izgubi več kot polovico preostalega volumna. Ikonična silhueta se sooča s trajno spremembo.",
-    extreme:      "Triglavski ledenik popolnoma izgine. Visokogorski ekosistem nad gozdno mejo propade.",
-    catastrophic: "Popolna izguba Triglavskega ledenika — narodni simbol in vir savinjskih rek. Propad alpskega ekosistema sproži kaskadne učinke.",
-  },
 };
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -187,31 +35,26 @@ function trendCategory(trend10: number): string {
 }
 
 function stars(p: number): string {
-  if (p < 0.001) return "★★★  p < 0.001";
-  if (p < 0.01)  return "★★  p < 0.01";
-  if (p < 0.05)  return `★  p = ${p.toFixed(3)}`;
-  return `p = ${p.toFixed(3)} (ns)`;
+  if (p < 0.001) return "★★★  p < 0,001";
+  if (p < 0.01)  return "★★  p < 0,01";
+  if (p < 0.05)  return `★  p = ${fmtNum(p, 3)}`;
+  return `p = ${fmtNum(p, 3)} (ns)`;
 }
 
 function ar1Label(ar1: number | null): string {
   if (ar1 === null) return "—";
   const abs = Math.abs(ar1);
-  const d   = abs < 0.1 ? "zanemarljiva" : abs < 0.3 ? "šibka" : "zmerna";
-  return `AR(1) = ${ar1} · ${d}`;
+  const strength = abs < 0.1 ? t("hero.ar1_negligible") : abs < 0.3 ? t("hero.ar1_weak") : t("hero.ar1_moderate");
+  return t("hero.ar1", { ar1: fmtNum(ar1, 2), strength });
 }
 
 function verdictHtml(st: RegressionResult["stats"], unit: string): string {
-  if (st.trend10 === 0) return VERDICT_NONE;
-  const isPos  = st.trend10 > 0;
-  const sign   = isPos ? "+" : "−";
-  const t100   = (Math.abs(st.trend10) * 10).toFixed(2);
-  const yrs    = (Math.abs(10 / st.trend10)).toFixed(1);
-  const tmpl   = isPos ? VERDICT_WARMING : VERDICT_COOLING;
-  return tmpl
-    .replace("{sign}", sign)
-    .replace("{t100}", t100)
-    .replace("{unit}", unit)
-    .replace("{yrs}", yrs);
+  if (st.trend10 === 0) return t("hero.verdict_none");
+  const isPos = st.trend10 > 0;
+  // fmtSigned reproduces the old "{sign}{t100}" (warming "+", cooling "−").
+  const t100  = fmtSigned(st.trend10 * 10, 2);
+  const yrs   = fmtNum(Math.abs(10 / st.trend10), 1);
+  return t(isPos ? "hero.verdict_warming" : "hero.verdict_cooling", { t100, unit, yrs });
 }
 
 // ── Component ─────────────────────────────────────────────────────────────────
@@ -248,18 +91,17 @@ function HeroCard(props: { res: RegressionResult; unit: string; dateLabel: strin
   const st  = () => res().stats;
   const cat = () => trendCategory(st().trend10);
   const isPos = () => st().trend10 >= 0;
-  const sign  = () => isPos() ? "+" : "−";
   const signColor = () => isPos() ? "#C25A2C" : "#3A5A8A";
 
   const nValues = () => (st() as any).n_values as number | undefined;
 
-  const ctx = () => HERO_CONTEXT[res().loc]?.[cat()] ?? HERO_CONTEXT[res().loc]?.["baseline"];
-  const risk = () => CLIMATE_RISKS[res().loc];
+  const ctx = () => heroContext[res().loc]?.[cat()] ?? heroContext[res().loc]?.["baseline"];
+  const risk = () => climateRisks[res().loc];
 
   return (
     <div
       role="group"
-      aria-label={`Podrobnosti lokacije ${res().loc.replace(/_/g, " ")}: stoletni temperaturni trend, kategorija tveganja in vpliv podnebne spremembe.`}
+      aria-label={t("hero.group_a11y", { station: res().loc.replace(/_/g, " ") })}
       style={{
       background:    "var(--color-card)",
       border:        "1px solid var(--color-rule)",
@@ -279,17 +121,17 @@ function HeroCard(props: { res: RegressionResult; unit: string; dateLabel: strin
             </span>
             <span style={{ width: "4px", height: "4px", "border-radius": "50%", background: "var(--color-ink-soft)", display: "inline-block", "flex-shrink": "0" }} />
             <span style={{ ...MONO, "font-size": "10px", color: "var(--color-ink-soft)", "letter-spacing": "0.06em", "text-transform": "uppercase" }}>
-              {props.dateLabel} · temperature max
+              {props.dateLabel} · {t("hero.eyebrow_var")}
             </span>
           </div>
 
           {/* Trend number */}
           <div style={{ display: "flex", "align-items": "baseline", gap: "4px", "margin-bottom": "6px" }}>
             <span style={{ "font-family": "var(--font-serif)", "font-size": "42px", "font-weight": "400", "line-height": "1", color: signColor() }}>
-              {sign()}{Math.abs(st().trend10).toFixed(3)}
+              {fmtSigned(st().trend10, 3)}
             </span>
             <span style={{ ...MONO, "font-size": "13px", color: "var(--color-ink-soft)" }}>
-              °C / decade
+              {t("hero.unit_decade")}
             </span>
           </div>
 
@@ -297,7 +139,7 @@ function HeroCard(props: { res: RegressionResult; unit: string; dateLabel: strin
           <Show when={risk()}>
             <div style={{ "margin-top": "8px" }}>
               <div style={{ ...MONO, "font-size": "9px", "letter-spacing": "0.08em", "text-transform": "uppercase", color: "var(--color-ink-soft)", "margin-bottom": "3px" }}>
-                Tveganje vpliva:
+                {t("hero.risk_label")}
               </div>
               <div style={{ ...SANS, "font-size": "11px", color: "var(--color-ink-soft)", "line-height": "1.45" }}>
                 {risk()}
@@ -337,7 +179,7 @@ function HeroCard(props: { res: RegressionResult; unit: string; dateLabel: strin
             <p style={{ ...SANS, margin: "0 0 2px", "font-size": "13px", color: "var(--color-ink)", "line-height": "1.55" }}
                innerHTML={verdictHtml(st(), props.unit)} />
             <p style={{ ...MONO, margin: "0", "font-size": "10px", color: "var(--color-ink-soft)", "letter-spacing": "0.05em" }}>
-              {METHOD_THEILSEN}
+              {t("hero.method_theilsen")}
             </p>
           </div>
         </div>
@@ -346,10 +188,10 @@ function HeroCard(props: { res: RegressionResult; unit: string; dateLabel: strin
       {/* Stats row */}
       <div style={{ display: "flex", "flex-wrap": "wrap", "border-top": "0" }}>
         {([
-          ["Significance", stars(st().p_val)],
-          [st().metric_lbl, st().metric.toFixed(4)],
-          ["Sample", nValues() ? `${nValues()!.toLocaleString()} opazovanj · ${st().n_years} let` : `${st().n_years} let`],
-          ["Autocorrelation", ar1Label(st().ar1)],
+          [t("hero.stat_significance"), stars(st().p_val)],
+          [st().metric_lbl, fmtNum(st().metric, 4)],
+          [t("hero.stat_sample"), nValues() ? t("hero.sample_full", { count: nValues()!, count2: st().n_years }) : t("hero.sample_years", { count: st().n_years })],
+          [t("hero.stat_autocorrelation"), ar1Label(st().ar1)],
         ] as [string, string][]).map(([k, v], i) => (
           <div style={{
             flex:            "1 1 160px",

--- a/code/ali-je-vroce-era5/components/RegressionPanel.tsx
+++ b/code/ali-je-vroce-era5/components/RegressionPanel.tsx
@@ -3,19 +3,19 @@ import { createSignal, createResource, createEffect, createMemo, createContext, 
 import type { JSXElement } from "solid-js";
 import type { SiteMeta } from "../types.ts";
 import type { RegressionParams } from "../api.ts";
-import { fetchRegression, fetchCalendar } from "../api.ts";
+import { fetchRegression, fetchCalendar, varLabel as varLabelOf } from "../api.ts";
 import { sectionErrorFallback } from "./SectionError.tsx";
+import { t, fmtSigned, fmtDoy } from "../i18n/format.ts";
 
 const RegressionChart = lazy(() => import("../charts/RegressionChart.tsx").then(m => ({ default: m.RegressionChart })));
 const YearRoundChart  = lazy(() => import("../charts/YearRoundChart.tsx").then(m => ({ default: m.YearRoundChart })));
 
-const VARIABLES: [string, string][] = [
-  ["temperature_max",  "Max temperature (°C)"],
-  ["temperature_min",  "Min temperature (°C)"],
-  ["temperature_mean", "Mean temperature (°C)"],
-  ["precipitation_sum",      "Precipitation (mm)"],
-  ["et0_evapotranspiration", "ET₀ (mm)"],
+// T-5.5 — variable labels come from the catalogue (reg.var_*, via api.varLabel).
+const VAR_KEYS = [
+  "temperature_max", "temperature_min", "temperature_mean",
+  "precipitation_sum", "et0_evapotranspiration",
 ];
+const VARIABLES: [string, string][] = VAR_KEYS.map(k => [k, varLabelOf(k)]);
 
 interface ProviderProps {
   meta:         SiteMeta;
@@ -26,9 +26,7 @@ interface ProviderProps {
 }
 
 function doyToLabel(doy: number): string {
-  const d = new Date(Date.UTC(2001, 0, 1));
-  d.setUTCDate(d.getUTCDate() + doy - 1);
-  return d.toLocaleDateString("en-GB", { month: "short", day: "numeric" });
+  return fmtDoy(doy);
 }
 
 // ── Store factory ─────────────────────────────────────────────────────────────
@@ -75,10 +73,10 @@ function createStore(props: ProviderProps) {
     if (isPrecip()) return t >= 0 ? "#1a5fc8" : "#a05c20";
     return t >= 0 ? "#cc2222" : "#1a5fc8";
   };
-  const totalChange = () => {
+  const totalChange = (): number | null => {
     const s = stats0();
     if (!s) return null;
-    return (trend10() * s.n_years / 10).toFixed(2);
+    return trend10() * s.n_years / 10;
   };
   const stationLabel = (name: string) => {
     const st = props.meta.stations.find(s => s.name === name);
@@ -86,7 +84,7 @@ function createStore(props: ProviderProps) {
   };
   const locLabel   = () => {
     const locs = selLocs();
-    return locs.length === 1 ? stationLabel(locs[0]!) : `${locs.length} locations`;
+    return locs.length === 1 ? stationLabel(locs[0]!) : t("reg.locations_multi", { count: locs.length });
   };
   const varLabel   = () => VARIABLES.find(([k]) => k === selVar())?.[1] ?? selVar();
   const chartTitle = () => `${varLabel().split("(")[0]!.trim()} · ${doyToLabel(doy())}`;
@@ -136,7 +134,7 @@ export function RegToolbar() {
       {/* Location */}
       <div style={{ position: "relative" }}>
         <div style={pillGroupStyle}>
-          <span style={pgkStyle}>Location</span>
+          <span style={pgkStyle}>{t("reg.location")}</span>
           <button style={locBtnStyle} onClick={() => s.setLocOpen(v => !v)}>
             <span>{s.locLabel()}</span>
             <svg width="9" height="9" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M6 9l6 6 6-6"/></svg>
@@ -145,7 +143,7 @@ export function RegToolbar() {
         <Show when={s.locOpen()}>
           <div style={locMenuStyle} onClick={(e) => e.stopPropagation()}>
             <div style={locMenuHeaderStyle}>
-              <span style={{ "font-size": "11px", "font-weight": "600", "font-family": "var(--font-sans)" }}>Select locations (max 6)</span>
+              <span style={{ "font-size": "11px", "font-weight": "600", "font-family": "var(--font-sans)" }}>{t("reg.select_locations")}</span>
               <button style={{ background: "none", border: "none", cursor: "pointer", color: "var(--color-ink-soft)", "font-size": "14px" }} onClick={() => s.setLocOpen(false)}>✕</button>
             </div>
             <For each={s.meta.stations}>
@@ -166,7 +164,7 @@ export function RegToolbar() {
 
       {/* Variable */}
       <div style={pillGroupStyle}>
-        <span style={pgkStyle}>Variable</span>
+        <span style={pgkStyle}>{t("reg.variable")}</span>
         <div style={{ ...pillStyle, "padding-right": "4px" }}>
           <select
             value={s.selVar()}
@@ -194,7 +192,7 @@ export function RegToolbar() {
 
       {/* DOY control */}
       <div class="reg-doy-ctrl">
-        <span style={{ "font-family": "var(--font-mono)", "font-size": "9px", "letter-spacing": "0.12em", "text-transform": "uppercase", color: "var(--color-ink-soft)", "white-space": "nowrap" }}>Day</span>
+        <span style={{ "font-family": "var(--font-mono)", "font-size": "9px", "letter-spacing": "0.12em", "text-transform": "uppercase", color: "var(--color-ink-soft)", "white-space": "nowrap" }}>{t("reg.day")}</span>
         <div style={{ "font-family": "var(--font-mono)", "font-weight": "600", "font-size": "13px", background: "var(--color-card)", border: "1px solid var(--color-rule-2)", "border-radius": "7px", padding: "4px 10px", "min-width": "60px", "text-align": "center", "white-space": "nowrap" }}>
           {s.doyToLabel(s.doy())}
         </div>
@@ -229,7 +227,7 @@ export function RegScatterCard() {
           <div style={{ ...panelSubStyle, "margin-top": "3px" }}>{s.chartSub()}</div>
         </div>
         <Show when={s.stats0()}>
-          {(st) => <div style={panelSubStyle}>{st().n_years} YR · {st().sig_label}</div>}
+          {(st) => <div style={panelSubStyle}>{t("reg.years_sig", { count: st().n_years, sig: st().sig_label })}</div>}
         </Show>
       </div>
 
@@ -237,11 +235,11 @@ export function RegScatterCard() {
         <Show when={s.totalChange() !== null}>
           <div style={statsBoxStyle}>
             <div style={{ "font-family": "var(--font-sans)", "font-size": "20px", "font-weight": "600", color: s.trendColor(), "letter-spacing": "-0.02em", "line-height": "1", "margin-bottom": "3px" }}>
-              {Number(s.totalChange()) >= 0 ? "+" : ""}{s.totalChange()}
+              {fmtSigned(s.totalChange()!, 2)}
               <span style={{ "font-size": "11px", "font-weight": "400", "margin-left": "3px" }}>{s.isPrecip() ? "mm" : "°C"}</span>
             </div>
             <div style={{ "font-family": "var(--font-mono)", "font-size": "9px", "letter-spacing": "0.08em", "text-transform": "uppercase", color: "var(--color-ink-soft)" }}>
-              change over record
+              {t("reg.change_over_record")}
             </div>
           </div>
         </Show>
@@ -252,7 +250,7 @@ export function RegScatterCard() {
               {(d) => (
                 <Show when={d.results.length > 0} fallback={
                   <div style={{ flex: "1", display: "flex", "align-items": "center", "justify-content": "center", color: "var(--color-ink-soft)", "font-size": "13px", "min-height": "280px" }}>
-                    No data for the selected day and location.
+                    {t("reg.no_data")}
                   </div>
                 }>
                   <RegressionChart data={d} chartId={`reg-${s.selVar()}-${s.doy()}-${s.selLocs().join("_")}`} />
@@ -265,10 +263,10 @@ export function RegScatterCard() {
 
       <div style={chartFooterStyle}>
         <div style={{ display: "flex", gap: "12px", "align-items": "center", "flex-wrap": "wrap" }}>
-          <span style={swatchStyle}><i style={{ background: "var(--color-accent-cool)", "border-radius": "50%", display: "inline-block", width: "8px", height: "8px" }} />Under mean</span>
-          <span style={swatchStyle}><i style={{ background: "var(--color-accent)", "border-radius": "50%", display: "inline-block", width: "8px", height: "8px" }} />Over mean</span>
-          <span style={swatchStyle}><i style={{ background: "var(--color-ink)", "border-radius": "1px", display: "inline-block", width: "14px", height: "3px" }} />Trend line</span>
-          <span style={swatchStyle}><i style={{ background: "rgba(194,90,44,0.25)", "border-radius": "2px", display: "inline-block", width: "10px", height: "10px" }} />95% CI</span>
+          <span style={swatchStyle}><i style={{ background: "var(--color-accent-cool)", "border-radius": "50%", display: "inline-block", width: "8px", height: "8px" }} />{t("reg.under_mean")}</span>
+          <span style={swatchStyle}><i style={{ background: "var(--color-accent)", "border-radius": "50%", display: "inline-block", width: "8px", height: "8px" }} />{t("reg.over_mean")}</span>
+          <span style={swatchStyle}><i style={{ background: "var(--color-ink)", "border-radius": "1px", display: "inline-block", width: "14px", height: "3px" }} />{t("reg.trend_line")}</span>
+          <span style={swatchStyle}><i style={{ background: "rgba(194,90,44,0.25)", "border-radius": "2px", display: "inline-block", width: "10px", height: "10px" }} />{t("common.ci95")}</span>
         </div>
         <Show when={s.stats0()}>
           {(st) => <span style={panelSubStyle}>{st().method ?? "Theil-Sen"} · {st().fit_desc}</span>}
@@ -293,13 +291,13 @@ export function RegYearRoundCard() {
 
       <div style={panelHStyle}>
         <div style={{ "min-width": "0" }}>
-          <div style={panelTitleStyle}>Year-round trend · {s.selLocs()[0]?.replace(/_/g, " ")}</div>
+          <div style={panelTitleStyle}>{t("reg.year_round_title", { station: s.selLocs()[0]?.replace(/_/g, " ") ?? "" })}</div>
           <div style={{ ...panelSubStyle, "margin-top": "3px" }}>
             {(s.VARIABLES.find(([k]) => k === s.selVar())?.[1] ?? s.selVar()).split("(")[0]!.trim()}
             {" · Theil-Sen + MK"}
           </div>
         </div>
-        <div style={panelSubStyle}>trend/decade per day of year · red line = selected day</div>
+        <div style={panelSubStyle}>{t("reg.year_round_sub")}</div>
       </div>
 
       <div style={{ padding: "8px 16px 12px", background: "var(--color-paper)" }}>
@@ -313,9 +311,9 @@ export function RegYearRoundCard() {
       </div>
 
       <div style={{ ...chartFooterStyle, "justify-content": "flex-start", gap: "16px" }}>
-        <span style={swatchStyle}><i style={{ background: "rgba(210,55,35,0.9)", "border-radius": "2px", display: "inline-block", width: "10px", height: "10px" }} />Warming</span>
-        <span style={swatchStyle}><i style={{ background: "rgba(35,90,210,0.9)", "border-radius": "2px", display: "inline-block", width: "10px", height: "10px" }} />Cooling</span>
-        <span style={{ ...panelSubStyle, "margin-left": "auto" }}>opacity = significance · p &lt; 0.001 fully opaque</span>
+        <span style={swatchStyle}><i style={{ background: "rgba(210,55,35,0.9)", "border-radius": "2px", display: "inline-block", width: "10px", height: "10px" }} />{t("reg.warming")}</span>
+        <span style={swatchStyle}><i style={{ background: "rgba(35,90,210,0.9)", "border-radius": "2px", display: "inline-block", width: "10px", height: "10px" }} />{t("reg.cooling")}</span>
+        <span style={{ ...panelSubStyle, "margin-left": "auto" }}>{t("reg.year_round_footer")}</span>
       </div>
 
       <Show when={s.meta.strings?.explain_cal}>

--- a/code/ali-je-vroce-era5/components/SectionError.tsx
+++ b/code/ali-je-vroce-era5/components/SectionError.tsx
@@ -1,5 +1,6 @@
 import { Show } from "solid-js";
 import type { JSXElement } from "solid-js";
+import { t } from "../i18n/format.ts";
 
 // T-5.1 — the ONE visible error state for a failed section fetch, reused at every
 // section boundary. Before this, a failed section fetch either vanished (the
@@ -34,7 +35,7 @@ export function SectionError(props: { onRetry?: (() => void) | undefined; minHei
         "line-height":     "1.5",
       }}
     >
-      <span>Tega razdelka trenutno ni bilo mogoče naložiti.</span>
+      <span>{t("error.section")}</span>
       <Show when={props.onRetry}>
         <button
           type="button"
@@ -52,7 +53,7 @@ export function SectionError(props: { onRetry?: (() => void) | undefined; minHei
             cursor:          "pointer",
           }}
         >
-          Poskusi znova
+          {t("error.retry")}
         </button>
       </Show>
     </div>

--- a/code/ali-je-vroce-era5/components/StationMap.tsx
+++ b/code/ali-je-vroce-era5/components/StationMap.tsx
@@ -1,6 +1,7 @@
 import { onMount, onCleanup, createEffect } from "solid-js";
 import { enableChartA11y } from "../charts/highcharts-a11y.ts";
 import type { SiteMeta } from "../types.ts";
+import { t } from "../i18n/format.ts";
 
 interface Props {
   meta:     SiteMeta;
@@ -64,7 +65,7 @@ export function StationMap(props: Props) {
       // T-5.4a — screen-reader summary (Slovenian copy awaiting operator review)
       accessibility: {
         enabled: true,
-        description: "Zemljevid Slovenije z merilnimi postajami; barva točke označuje višinski pas postaje. Postajo lahko izberete tudi s spustnim seznamom v analizi trendov.",
+        description: t("map.a11y"),
       },
       mapNavigation: {
         enabled: true,

--- a/code/ali-je-vroce-era5/components/TodayCard.tsx
+++ b/code/ali-je-vroce-era5/components/TodayCard.tsx
@@ -4,46 +4,33 @@ import { isArsoLoc } from "../api.ts";
 import { todayYear } from "../clock.ts";
 import { TodayFlag } from "./TodayFlag.tsx";
 import { TodayGauge } from "../charts/TodayGauge.tsx";
+import { t, fmtNum, fmtInt, fmtMonthDay } from "../i18n/format.ts";
 
 const TodayLast7Chart = lazy(() => import("./TodayLast7Chart.tsx").then(m => ({ default: m.TodayLast7Chart })));
 
 const CATEGORIES: Record<string, string> = {
-  freezing: "Zmrzujoče",
-  cold:     "Hladno",
-  nope:     "Normalno",
-  hot:      "Vroče",
-  hell:     "Peklensko",
+  freezing: t("today.cat_freezing"),
+  cold:     t("today.cat_cold"),
+  nope:     t("today.cat_nope"),
+  hot:      t("today.cat_hot"),
+  hell:     t("today.cat_hell"),
 };
 
-const CAT_DESCS: Record<string, string> = {
-  freezing: "Med najhladnejšimi {d} v naših zapisih ARSO.",
-  cold:     "Hladneje od večine izmerjenih {d}.",
-  nope:     "Točno takšno, kot {d} v {country} ponavadi je.",
-  hot:      "Med najtoplejšimi {d} v naših zapisih.",
-  hell:     "Izjemna vročina — vrh 5 % vseh {d} glede na meritve ARSO.",
-};
-
-const CAT_DESCS_ERA5: Record<string, string> = {
-  freezing: "Med najhladnejšimi {d} v naših {record_years} letih zapisov.",
-  cold:     "Hladneje od večine izmerjenih {d}.",
-  nope:     "Točno takšno, kot {d} v {country} ponavadi je.",
-  hot:      "Med najtoplejšimi {d} v naših zapisih.",
-  hell:     "Izjemna vročina — vrh 5 % vseh {d} od {year_min}.",
-};
-
+// T-5.5 — category descriptions live in the catalogue (today.desc_{arso,era5}_*),
+// parameterised on {d} / {country} / {record_years} / {year_min}.
 function catDesc(catKey: string, r: TodayStatus): string {
   const isArso = r.loc ? isArsoLoc(r.loc) : false;
-  const tpl = (isArso ? CAT_DESCS : CAT_DESCS_ERA5)[catKey] ?? "";
   const d = fmtDayLabel(r.day_label ?? "");
   const yearMin = r.year_min ?? 1950;
   // Fallback path only (r.year_max is present in every recorded response), but it
   // feeds {record_years} in visible copy, so it goes through the same clock.
   const yearMax = r.year_max ?? todayYear();
-  return tpl
-    .replace("{d}", d)
-    .replace("{year_min}", String(yearMin))
-    .replace("{country}", "Slovenija")
-    .replace("{record_years}", String(yearMax - yearMin + 1));
+  return t(`today.desc_${isArso ? "arso" : "era5"}_${catKey}`, {
+    d,
+    country: "Slovenija",
+    year_min: yearMin,
+    record_years: yearMax - yearMin + 1,
+  });
 }
 
 // National/default view = unweighted mean of the ERA5 stations (D-7,
@@ -57,21 +44,26 @@ function nationalExplain(stations: SiteMeta["stations"], yearMin: number): strin
   const elevs = era5.map(s => s.elevation);
   const elMin = Math.min(...elevs);
   const elMax = Math.max(...elevs);
-  return `Povprečje najvišjih dnevnih temperatur ${era5.length} slovenskih postaj (nadmorska višina ${elMin}–${elMax} m), razvrščeno glede na zapise ERA5-Land od leta ${yearMin} za isto ±7-dnevno okno.`;
+  return t("today.national_explain", {
+    count: era5.length, elMin: fmtInt(elMin), elMax: fmtInt(elMax), yearMin,
+  });
 }
 
-function fmtDate(dateStr: string): string {
-  const parts = dateStr.split("-");
-  return `${parts[2]}.${parts[1]}.`;
-}
-
-const EN_MONTHS: Record<string, string> = {
-  Jan:"01", Feb:"02", Mar:"03", Apr:"04", May:"05", Jun:"06",
-  Jul:"07", Aug:"08", Sep:"09", Oct:"10", Nov:"11", Dec:"12",
+// T-5.5 — the datasette `day_label` is an internal "Mon D" key (api.ts:dayLabel);
+// map its month to a number and render the Slovenian short date via the formatter,
+// so no month name or date is built by hand.
+const EN_MONTHS: Record<string, number> = {
+  Jan:1, Feb:2, Mar:3, Apr:4, May:5, Jun:6,
+  Jul:7, Aug:8, Sep:9, Oct:10, Nov:11, Dec:12,
 };
 function fmtDayLabel(dl: string): string {
   const [mon, day] = dl.split(" ");
-  return `${(day ?? "").padStart(2, "0")}.${EN_MONTHS[mon ?? ""] ?? "??"}`;
+  const m = EN_MONTHS[mon ?? ""] ?? 0;
+  return m ? fmtMonthDay(m, Number(day)) : "??";
+}
+function fmtDate(dateStr: string): string {
+  const [, mm, dd] = dateStr.split("-");
+  return fmtMonthDay(Number(mm), Number(dd));
 }
 
 function addDays(dateStr: string, n: number): string {
@@ -103,7 +95,7 @@ export function TodayCard(props: Props) {
       <div class="today-date-control">
         <button
           class="today-nav-btn"
-          aria-label="Previous day"
+          aria-label={t("today.prev_day")}
           disabled={props.date <= "1950-01-01"}
           onClick={() => props.onDateChange(addDays(props.date, -1))}
         >
@@ -114,7 +106,7 @@ export function TodayCard(props: Props) {
         <div class="today-date-badge">{fmtDate(props.date)}</div>
         <button
           class="today-nav-btn"
-          aria-label="Next day"
+          aria-label={t("today.next_day")}
           disabled={props.date >= props.today}
           onClick={() => props.onDateChange(addDays(props.date, 1))}
         >
@@ -127,16 +119,16 @@ export function TodayCard(props: Props) {
           value={r().loc === props.nationalLoc ? (props.nationalLoc ?? "") : r().loc ?? ""}
           onChange={(e) => props.onLocChange(e.currentTarget.value)}
         >
-          <option value={props.nationalLoc ?? ""}>Slovenija — povprečje {props.meta.stations.filter(s => s.source === "era5").length} postaj</option>
+          <option value={props.nationalLoc ?? ""}>{t("today.loc_national", { count: props.meta.stations.filter(s => s.source === "era5").length })}</option>
           <Show when={props.meta.stations.some(s => s.source === "arso")}>
-            <optgroup label="ARSO postaje">
+            <optgroup label={t("today.arso_group")}>
               <For each={props.meta.stations.filter(s => s.source === "arso")}>
                 {(s) => <option value={s.name}>{s.label}</option>}
               </For>
             </optgroup>
           </Show>
           <Show when={props.meta.stations.some(s => s.source === "era5")}>
-            <optgroup label="ERA5 postaje">
+            <optgroup label={t("today.era5_group")}>
               <For each={props.meta.stations.filter(s => s.source === "era5")}>
                 {(s) => <option value={s.name}>{s.label ?? s.name}</option>}
               </For>
@@ -174,14 +166,14 @@ export function TodayCard(props: Props) {
             <div class="today-divider" />
 
             <div class="today-pct-wrap">
-              <span class="today-pct-num">{(r().percentile ?? 0).toFixed(0)}</span>
-              <span class="today-pct-label">percentil</span>
+              <span class="today-pct-num">{fmtInt(r().percentile ?? 0)}</span>
+              <span class="today-pct-label">{t("today.pct_label")}</span>
               <Show when={r().loc && isArsoLoc(r().loc!)}>
-                <span class="today-pct-samples">ARSO meritve</span>
+                <span class="today-pct-samples">{t("today.pct_samples_arso")}</span>
               </Show>
               <Show when={!r().loc || !isArsoLoc(r().loc ?? "")}>
                 <Show when={(r().n_samples ?? 0) > 0}>
-                  <span class="today-pct-samples">{(r().n_samples ?? 0).toLocaleString()} vzorcev</span>
+                  <span class="today-pct-samples">{t("today.pct_samples", { count: r().n_samples ?? 0 })}</span>
                 </Show>
               </Show>
               {/* is_preliminary is true iff the value came from the live
@@ -200,7 +192,7 @@ export function TodayCard(props: Props) {
                   "border-radius": "4px", padding: "2px 6px",
                   "margin-top": "4px", display: "inline-block",
                 }}>
-                  napoved
+                  {t("today.badge_forecast")}
                 </span>
               </Show>
             </div>
@@ -213,22 +205,22 @@ export function TodayCard(props: Props) {
               ? r().loc === props.nationalLoc
                 ? nationalExplain(props.meta.stations, r().year_min ?? 1950)
                 : isArsoLoc(r().loc!)
-                  ? `Temperatura na ARSO postaji ${props.meta.stations.find(s => s.name === r().loc)?.label ?? r().loc!.replace("arso:", "")}, razvrstena glede na percentilne zapise ARSO meritev.`
-                  : `Temperatura na postaji ${r().loc!.replace(/_/g, " ")}, razvrstena glede na zapise ERA5-Land od leta ${r().year_min} za isto ±7-dnevno okno.`
-              : `Današnji vrh je najvišja napovedana temperatura, razvrstena glede na zapise ERA5-Land od leta ${r().year_min} za isto ±7-dnevno okno.`
+                  ? t("today.explain_arso", { label: props.meta.stations.find(s => s.name === r().loc)?.label ?? r().loc!.replace("arso:", "") })
+                  : t("today.explain_station", { station: r().loc!.replace(/_/g, " "), year_min: r().year_min ?? 1950 })
+              : t("today.explain_national", { year_min: r().year_min ?? 1950 })
             }
           </p>
 
           {/* Climate context */}
           <p class="today-context">
-            Slovenija leži na stičišču štirih podnebnih con — alpske, sredozemske, celinsko in panonske — stisnjenih v eno izmed podnebno najbolj raznolikih držav v Evropi. Srednja Evropa se segreva približno 1,5-krat hitreje od svetovnega povprečja. Temperature so v zadnjih 70 letih narasle za skoraj 2 °C. Pomlad v Alpah prihaja vse prej, sredozemske suše segajo vse globlje v notranjost, severovzhodni panonski del pa se sooča z vedno hujšimi vročinskimi vali. Kar je bilo leta 1980 tipično poletje, danes sodi med hladnejšo polovico nedavnih desetletij.
+            {t("today.context")}
           </p>
 
           {/* Last 7 days */}
           <Show when={props.last7?.available && (props.last7?.days.length ?? 0) > 0}>
             <div class="today-last7-row">
               <div class="today-last7-card">
-                <div class="today-chart-title">Zadnjih 7 dni</div>
+                <div class="today-chart-title">{t("today.last7_title")}</div>
                 <Suspense fallback={<div style={{ height: "190px" }} class="animate-pulse bg-[var(--color-paper-2)] rounded" />}>
                   <TodayLast7Chart days={props.last7!.days} />
                 </Suspense>
@@ -238,13 +230,16 @@ export function TodayCard(props: Props) {
 
           {/* Footer */}
           <div class="today-foot">
-            {(r().today_temp ?? 0).toFixed(1)} °C · {(r().percentile ?? 0).toFixed(0)}. percentil
-            {r().loc && isArsoLoc(r().loc!)
-              ? ` · ${(r().n_samples ?? 0).toLocaleString()} vzorcev (${r().year_min}–${r().year_max}) · vir: ARSO`
-              : (r().n_samples ?? 0) > 0
-                ? ` · ${(r().n_samples ?? 0).toLocaleString()} vzorcev (${r().year_min}–${r().year_max})`
-                : ""
-            }
+            {t("today.foot", {
+              temp: fmtNum(r().today_temp ?? 0, 1),
+              pct: fmtInt(r().percentile ?? 0),
+              suffix:
+                r().loc && isArsoLoc(r().loc!)
+                  ? t("today.foot_suffix_arso", { count: r().n_samples ?? 0, year_min: r().year_min ?? 0, year_max: r().year_max ?? 0 })
+                  : (r().n_samples ?? 0) > 0
+                    ? t("today.foot_suffix", { count: r().n_samples ?? 0, year_min: r().year_min ?? 0, year_max: r().year_max ?? 0 })
+                    : "",
+            })}
           </div>
 
         </div>
@@ -261,8 +256,8 @@ function RankBadge(props: { info: RankInfo; dayLabel: string }) {
 
   const label = () =>
     isHot()
-      ? `#${props.info.rank} najtoplejši ${props.dayLabel}`
-      : `#${props.info.rank} najhladnejši ${props.dayLabel}`;
+      ? t("today.rank_hot", { rank: props.info.rank, d: props.dayLabel })
+      : t("today.rank_cold", { rank: props.info.rank, d: props.dayLabel });
 
   return (
     <div class="relative">
@@ -277,7 +272,7 @@ function RankBadge(props: { info: RankInfo; dayLabel: string }) {
         <div class="fixed inset-0 z-10" onClick={() => setOpen(false)} />
         <div class="absolute top-full mt-2 left-0 z-20 bg-[var(--color-card)] border border-[var(--color-rule)] rounded-xl shadow-lg p-4 min-w-[220px]">
           <div class="text-[10px] font-semibold uppercase tracking-widest text-[var(--color-ink-soft)] mb-3">
-            {isHot() ? `Najtoplejši ${props.dayLabel}` : `Najhladnejši ${props.dayLabel}`}
+            {isHot() ? t("today.rank_top5_hot", { d: props.dayLabel }) : t("today.rank_top5_cold", { d: props.dayLabel })}
           </div>
           <div class="space-y-2">
             <For each={props.info.top5}>
@@ -290,10 +285,10 @@ function RankBadge(props: { info: RankInfo; dayLabel: string }) {
                     {entry.date.slice(0, 4)}
                     <Show when={entry.is_today}>
                       {" "}
-                      <span class="text-[10px] font-normal text-[var(--color-accent)]">danes</span>
+                      <span class="text-[10px] font-normal text-[var(--color-accent)]">{t("common.today")}</span>
                     </Show>
                   </span>
-                  <span class="font-mono text-[var(--color-ink)]">{entry.temp.toFixed(1)} °C</span>
+                  <span class="font-mono text-[var(--color-ink)]">{t("common.temp_c", { temp: fmtNum(entry.temp, 1) })}</span>
                 </div>
               )}
             </For>
@@ -307,7 +302,7 @@ function RankBadge(props: { info: RankInfo; dayLabel: string }) {
 function UnavailableCard() {
   return (
     <div class="today-card">
-      <p class="today-explain">Podatki za ta dan niso na voljo.</p>
+      <p class="today-explain">{t("today.unavailable")}</p>
     </div>
   );
 }

--- a/code/ali-je-vroce-era5/components/TodayLast7Chart.tsx
+++ b/code/ali-je-vroce-era5/components/TodayLast7Chart.tsx
@@ -1,10 +1,14 @@
 import { onMount, onCleanup, createEffect } from "solid-js";
 import type { Last7 } from "../types.ts";
 import { enableChartA11y } from "../charts/highcharts-a11y.ts";
+import { t, fmtNum, fmtInt } from "../i18n/format.ts";
 
 const CAT_ORDER  = ["freezing", "cold", "nope", "hot", "hell"];
 const CAT_COLORS = ["#3a5a8a", "#6c8fb6", "#e7d9b8", "#c25a2c", "#962c1a"];
-const CAT_LABELS = ["Zmrzujoče", "Hladno", "Normalno", "Vroče", "Peklensko"];
+const CAT_LABELS = [
+  t("last7.cat_freezing"), t("last7.cat_cold"), t("last7.cat_nope"),
+  t("last7.cat_hot"), t("last7.cat_hell"),
+];
 
 const INK      = "#0E0E0C";
 const MONO     = { fontFamily: "'JetBrains Mono', monospace", fontSize: "11px", fontWeight: "600" };
@@ -48,12 +52,12 @@ export function TodayLast7Chart(props: Props) {
       // T-5.4a — screen-reader summary (Slovenian copy awaiting operator review)
       accessibility: {
         enabled: true,
-        description: "Gibanje toplotne kategorije v zadnjih sedmih dneh — vsaka točka je en dan, uvrščen od zmrzujoče do peklensko glede na zgodovinske percentile.",
+        description: t("last7.a11y"),
       },
       tooltip: {
         formatter(this: any) {
           const p = this.point as any;
-          return `<b>${p.label}</b>: ${p.catName} · ${p.temp.toFixed(1)} °C (${p.pct.toFixed(0)}th pct)`;
+          return t("last7.tooltip", { label: p.label, cat: p.catName, temp: fmtNum(p.temp, 1), pct: fmtInt(p.pct) });
         },
       },
       xAxis: {

--- a/code/ali-je-vroce-era5/components/TodayTrendChart.tsx
+++ b/code/ali-je-vroce-era5/components/TodayTrendChart.tsx
@@ -3,6 +3,7 @@ import { fetchAnnualTrend, ERA5_NATIONAL } from "../api.ts";
 import { todayYear } from "../clock.ts";
 import { sectionErrorFallback } from "./SectionError.tsx";
 import { enableChartA11y } from "../charts/highcharts-a11y.ts";
+import { t, fmtNum, fmtSigned, fmtMonthDay } from "../i18n/format.ts";
 import type { AnnualTrend } from "../types.ts";
 
 const INK      = "#0E0E0C";
@@ -63,12 +64,12 @@ function TrendHighchart(props: ChartProps) {
       // T-5.4a — screen-reader summary (Slovenian copy awaiting operator review)
       accessibility: {
         enabled: true,
-        description: "Letni trend najvišjih temperatur okoli izbranega datuma z linijo Theil-Sen, 95-odstotnim intervalom zaupanja in projekcijo do leta 2050. Vsaka pika je vrednost enega leta.",
+        description: t("trend.a11y"),
       },
       tooltip: {
         formatter(this: any) {
-          if (this.series.name === "Annual value") return `<b>${Math.round(this.x)}</b>: ${this.y.toFixed(1)} °C`;
-          if (this.series.name === "Milestones")   return `<b>${this.x}</b>: ${this.y.toFixed(1)} °C <em>(projection)</em>`;
+          if (this.series.name === "Annual value") return t("trend.tooltip_annual", { x: Math.round(this.x), y: fmtNum(this.y, 1) });
+          if (this.series.name === "Milestones")   return t("trend.tooltip_milestone", { x: this.x, y: fmtNum(this.y, 1) });
           return false;
         },
       },
@@ -162,17 +163,16 @@ export function TodayTrendChart(props: Props) {
     <div class="today-chart">
       <ErrorBoundary fallback={sectionErrorFallback(refetch, "240px")}>
       <Show when={trendDisplay()}>
-        {(t) => {
-          const d = () => t();
-          const sign     = () => d().trend10 >= 0 ? "+" : "";
-          const sig      = () => { const p = d().pVal; return p < 0.001 ? "p < 0.001" : p < 0.01 ? "p < 0.01" : p < 0.05 ? `p = ${p}` : `p = ${p} (ns)`; };
+        {(tr) => {
+          const d = () => tr();
+          const sig      = () => { const p = d().pVal; return p < 0.001 ? "p < 0,001" : p < 0.01 ? "p < 0,01" : p < 0.05 ? `p = ${fmtNum(p, 3)}` : `p = ${fmtNum(p, 3)} (ns)`; };
           const proj2050 = () => {
             const y = d().projLine.y;
             const lastY = y[y.length - 1];
             if (lastY === undefined) throw new Error("projLine.y is empty");
-            return lastY.toFixed(1);
+            return fmtNum(lastY, 1);
           };
-          const trendStr = () => `${sign()}${d().trend10.toFixed(2)}`;
+          const trendStr = () => fmtSigned(d().trend10, 2);
           // National (loc === ERA5_NATIONAL, or null) is NOT a station: return null so
           // both the title and explain take their national branch. Testing bare
           // truthiness printed the raw "era5:national" key (T-4.20); the `&&` narrows
@@ -182,14 +182,24 @@ export function TodayTrendChart(props: Props) {
           return (
             <>
               <div class="today-chart-title">
-                Najvišje temperature {stationLabel() ? `na postaji ${stationLabel()}` : "v Sloveniji"} okoli {d().dayLabel} · {d().yearMin}–{d().yearMax} · trend s projekcijo do 2050
+                {stationLabel()
+                  ? t("trend.title_station", { station: stationLabel()!, day: fmtMonthDay(d().monthNum, d().dayNum), yearMin: d().yearMin, yearMax: d().yearMax })
+                  : t("trend.title_nat", { day: fmtMonthDay(d().monthNum, d().dayNum), yearMin: d().yearMin, yearMax: d().yearMax })}
               </div>
               <TrendHighchart trend={d()} />
               <p class="today-explain" style={{ padding: "4px 0 2px" }}>
-                Vsaka pika je 90. percentil {stationLabel() ? `lapsno popravljene dnevne najvišje temperature na postaji ${stationLabel()}` : `nacionalne povprečne dnevne najvišje temperature vseh ${props.stationCount} postaj`} v ±30-dnevnem oknu okoli tega datuma za vsako leto od {d().yearMin}. Trend Theil-Sen je {trendStr()} °C/desetletje ({sig()}). Po tem tempu projekcija kaže {proj2050()} °C do leta 2050. Zasenčeni pas je 95% interval zaupanja za nagib.
+                {t("trend.explain", {
+                  source: stationLabel()
+                    ? t("trend.explain_source_station", { station: stationLabel()! })
+                    : t("trend.explain_source_nat", { count: props.stationCount }),
+                  yearMin: d().yearMin,
+                  trend: trendStr(),
+                  sig: sig(),
+                  proj2050: proj2050(),
+                })}
               </p>
               <div class="today-foot">
-                Theil-Sen + TFPW MK: {trendStr()} °C/desetletje · {sig()} · τ = {d().tau.toFixed(3)} · 95% CI · {d().nYears} let
+                {t("trend.foot", { trend: trendStr(), sig: sig(), tau: fmtNum(d().tau, 3), count: d().nYears })}
               </div>
             </>
           );

--- a/code/ali-je-vroce-era5/i18n/format.ts
+++ b/code/ali-je-vroce-era5/i18n/format.ts
@@ -1,0 +1,169 @@
+// T-5.5 (D-8) — minimal, dependency-free i18n runtime for the Slovenian-only v1.
+//
+// D-8 is "Slovenian only for v1: extract strings to a parameterised catalogue; NO
+// switcher, NO /en/ routing, NO hreflang". So this is deliberately NOT an i18n
+// framework — it is one locale, one catalogue, and the three things the operator
+// required for T-5.5: catalogue lookup with parameter interpolation, proper
+// Slovenian plurals, and Slovenian number/date formatting so that no inflected
+// form, number or date is ever built by string concatenation.
+//
+// No dependency is added: the plural categories come from the platform's own
+// `Intl.PluralRules("sl")` (CLDR: one / two / few / other — the 1 / 2 / 3–4 / 5+
+// paradigm), and numbers/dates from `Intl.NumberFormat`/`Intl.DateTimeFormat`
+// under the `sl-SI` locale (decimal COMMA, "." thousands — operator decision,
+// T-5.5).
+//
+// The message syntax is an ICU subset:
+//   • "{name}"                                     → interpolate a parameter
+//   • "{count, plural, one{…} two{…} few{…} other{…}}" → plural-select on `count`;
+//     "#" inside a form renders the grouped integer. Forms may nest "{name}".
+
+import { sl } from "./sl.ts";
+
+export const LOCALE = "sl-SI";
+
+const PR = new Intl.PluralRules("sl");
+
+type Params = Record<string, string | number>;
+
+// ── Number / date formatters ────────────────────────────────────────────────────
+
+const nfCache = new Map<string, Intl.NumberFormat>();
+function nf(opts: Intl.NumberFormatOptions): Intl.NumberFormat {
+  const key = JSON.stringify(opts);
+  let f = nfCache.get(key);
+  if (!f) { f = new Intl.NumberFormat(LOCALE, opts); nfCache.set(key, f); }
+  return f;
+}
+
+// The values these format are ALL currently published via `Number.prototype
+// .toFixed`. `Intl.NumberFormat` rounds off the number's shortest decimal string
+// and so can disagree with toFixed on the final digit (e.g. a 0.3549…-valued
+// trend: toFixed(2) → "0.35", Intl → "0,36"). Pre-rounding through toFixed and
+// then formatting the already-rounded value makes the switch to Slovenian
+// separators VALUE-NEUTRAL — only the decimal comma, "." grouping and "−" glyph
+// change, never a rounded figure (T-5.5; CLAUDE.md ground rule 2).
+const preRound = (n: number, digits: number) => Number(n.toFixed(digits));
+
+/** Fixed-decimal number in Slovenian formatting (decimal comma). */
+export function fmtNum(n: number, digits = 1): string {
+  return nf({ minimumFractionDigits: digits, maximumFractionDigits: digits }).format(preRound(n, digits));
+}
+
+/** Integer with Slovenian grouping (e.g. 18432 → "18.432"). */
+export function fmtInt(n: number): string {
+  return nf({ maximumFractionDigits: 0 }).format(preRound(n, 0));
+}
+
+/**
+ * Signed fixed-decimal. `signDisplay:"always"` reproduces the old
+ * `${n >= 0 ? "+" : ""}${n.toFixed(d)}` intent (a leading "+" on non-negative,
+ * zero included) while the minus on negatives becomes the locale glyph — no sign
+ * is ever concatenated by hand.
+ */
+export function fmtSigned(n: number, digits = 2): string {
+  return nf({ minimumFractionDigits: digits, maximumFractionDigits: digits, signDisplay: "always" }).format(preRound(n, digits));
+}
+
+const dtMonthShort = new Intl.DateTimeFormat(LOCALE, { month: "short" });
+
+/** Slovenian short month name for a 1..12 month, e.g. 7 → "jul.". */
+export function fmtMonthShort(month: number): string {
+  return dtMonthShort.format(new Date(2001, month - 1, 1));
+}
+
+const dtShort = new Intl.DateTimeFormat(LOCALE, { day: "numeric", month: "short" });
+
+/** Slovenian short date for a (month, day) pair, e.g. (7, 27) → "27. jul.". */
+export function fmtMonthDay(month: number, day: number): string {
+  // Year is arbitrary (2001, non-leap) — only month/day are rendered.
+  return dtShort.format(new Date(2001, month - 1, day));
+}
+
+/** Slovenian short date for a day-of-year (1..365 on the 2001 non-leap calendar). */
+export function fmtDoy(doy: number): string {
+  const d = new Date(Date.UTC(2001, 0, 1));
+  d.setUTCDate(d.getUTCDate() + doy - 1);
+  return fmtMonthDay(d.getUTCMonth() + 1, d.getUTCDate());
+}
+
+// ── Message formatting (ICU subset) ─────────────────────────────────────────────
+
+function readArg(str: string, start: number): { body: string; end: number } {
+  let depth = 0;
+  for (let i = start; i < str.length; i++) {
+    if (str[i] === "{") depth++;
+    else if (str[i] === "}") { depth--; if (depth === 0) return { body: str.slice(start + 1, i), end: i }; }
+  }
+  throw new Error("i18n: unbalanced braces in message");
+}
+
+function parseForms(s: string): Record<string, string> {
+  const forms: Record<string, string> = {};
+  let i = 0;
+  while (i < s.length) {
+    while (i < s.length && /\s/.test(s[i]!)) i++;
+    let j = i;
+    while (j < s.length && s[j] !== "{") j++;
+    if (j >= s.length) break;
+    const kw = s.slice(i, j).trim();
+    const { body, end } = readArg(s, j);
+    if (kw) forms[kw] = body;
+    i = end + 1;
+  }
+  return forms;
+}
+
+function renderArg(body: string, params: Params): string {
+  const comma = body.indexOf(",");
+  if (comma !== -1 && body.slice(comma + 1).trim().startsWith("plural")) {
+    const name = body.slice(0, comma).trim();
+    const formsStr = body.slice(comma + 1).trim().slice("plural".length).replace(/^\s*,\s*/, "");
+    const n = Number(params[name] ?? 0);
+    const forms = parseForms(formsStr);
+    const chosen = forms[PR.select(n)] ?? forms.other ?? "";
+    return interpolate(chosen.replace(/#/g, fmtInt(n)), params);
+  }
+  const key = body.trim();
+  const v = params[key];
+  return v === undefined ? `{${key}}` : String(v);
+}
+
+function interpolate(tpl: string, params: Params): string {
+  let out = "", i = 0;
+  while (i < tpl.length) {
+    if (tpl[i] === "{") {
+      const { body, end } = readArg(tpl, i);
+      out += renderArg(body, params);
+      i = end + 1;
+    } else {
+      out += tpl[i];
+      i++;
+    }
+  }
+  return out;
+}
+
+function lookup(key: string): string | undefined {
+  let cur: unknown = sl;
+  for (const part of key.split(".")) {
+    if (cur == null || typeof cur !== "object") return undefined;
+    cur = (cur as Record<string, unknown>)[part];
+  }
+  return typeof cur === "string" ? cur : undefined;
+}
+
+/**
+ * Translate a catalogue `key` (dotted path into `sl`), interpolating `params`.
+ * Numbers meant for display must be pre-formatted with `fmtNum`/`fmtInt`/
+ * `fmtSigned` by the caller (so precision is explicit); `{count, plural, …}`
+ * blocks take the raw number as the parameter and render "#" via `fmtInt`.
+ */
+export function t(key: string, params: Params = {}): string {
+  const tpl = lookup(key);
+  if (tpl === undefined) {
+    if (import.meta.env?.DEV) console.warn(`i18n: missing key "${key}"`);
+    return key;
+  }
+  return interpolate(tpl, params);
+}

--- a/code/ali-je-vroce-era5/i18n/hero-content.ts
+++ b/code/ali-je-vroce-era5/i18n/hero-content.ts
@@ -1,0 +1,158 @@
+// T-5.5 (D-8) — per-location HeroCards content, MOVED VERBATIM from HeroCards.tsx.
+//
+// These two tables are single-locale editorial CONTENT (18 stations × the climate
+// risk line + 5 trend-category descriptions). They were relocated here unchanged so
+// the catalogue is the single source, WITHOUT retyping the prose — the exact bytes
+// from HeroCards.tsx were preserved to keep the rendered output byte-identical.
+// Wording is content-provider territory and is FLAGGED for review (PROGRESS T-5.5),
+// e.g. "stletni"/"stletni poplavni viški" and other typos live in the source prose.
+
+export const climateRisks: Record<string, string> = {
+  Ljubljana:        "Mestni toplotni otok — poletni vročinski stres in tveganje hudourniških poplav v Ljubljanski kotlini",
+  Maribor:          "Sušni stres v vinogradništvu — zgodnejše trgatve in premik vinskih sort",
+  Celje:            "Okrepitev poplav Savinje v kombinaciji z naraščajočo poletno sušo",
+  Kranj:            "Izguba alpske snežne odeje, ki zmanjšuje poletni pretok Save",
+  Koper:            "Podaljšanje sredozemske suše — tveganje vdora slane vode in dviga morske gladine",
+  Novo_Mesto:       "Suša reke Krke ogroža pridelavo hmelja in sadja",
+  Murska_Sobota:    "Panonska vročina in suša — najtoplejše temperaturne razlike v Sloveniji",
+  Nova_Gorica:      "Sredozemsko sušenje — ekosistem hladnovodne Soče in kraško vinogradništvo v nevarnosti",
+  Postojna:         "Suša kraškega vodonosnika — jamski ekosistem in endemska favna pod toplotnim stresom",
+  Ptuj:             "Nizki vodostaji Drave — vodni stres v vinogradništvu in zmanjšanje hidroenergetskih zmogljivosti",
+  Velenje:          "Upravljanje z vodo po izkopavanju premoga ob stopnjevanju suše in poplav",
+  Trbovlje:         "Ojačanje vročine v savski soteski in naraščajoče tveganje poplav",
+  Tolmin:           "Stopnjevanje ekstremnih poplav Soče — krčenje ekosistema hladnovodnih rib",
+  Kocevje:          "Propad pragozdov pod napadom lubadarja — izguba habitata velikih zveri",
+  Ilirska_Bistrica: "Izčrpavanje kraških izvirov — motnja podzemnega rečnega sistema Pivke",
+  Domzale:          "Mestni toplotni otok v kotlini — kombinirani vročinski in sušni stres za Ljubljansko regijo",
+  Ratece:           "Izguba alpske snežne odeje — grožnja smučarskemu gospodarstvu in nestabilnost permafrost pobočij",
+  Kredarica:        "Izguba Triglavskega ledenika — izsušitev izvirnih vod za Slovenijo reke",
+};
+
+export const heroContext: Record<string, Record<string, string>> = {
+  Ljubljana: {
+    baseline:     "Glavno mesto v Ljubljanski kotlini, ki jo obkrožajo hribi in pozimi pastuje hladen zrak. Celinsko podnebje s toplimi poletji in hladnimi zimami, okrepljeno z mestnim toplotnim otokom.",
+    moderate:     "Segrevanje skrajšuje zimsko megleno sezono, a povečuje poletni toplotni stres. Mestno tkivo zadržuje toploto, ponoči postaja vse toplejše po vsej metropolitanski regiji.",
+    bad:          "Vročinski valovi presegajo 35 °C več zaporednih dni. Smrtnost starejših narašča. Kotlinska lega kopiči toploto; poraba klimatskih naprav se poveča in preobremeni omrežje.",
+    extreme:      "Podaljšane vročinske izredne razmere postanejo letni pojav. Reka Ljubljanica poleti splahni, kar ogroža vodooskrbo. Mestna zelenjava trpi pod hudim sušnim stresom.",
+    catastrophic: "Podaljšani poletni vročinski valovi presegajo hladilne zmogljivosti mesta. Hudourniške poplave iz okrepljenih alpskih padavin večkrat ogrozijo nizko ležečo kotlino.",
+  },
+  Maribor: {
+    baseline:     "Drugo največje mesto, dolina reke Drave, severovzhodna Slovenija. Celinsko podnebje z vročimi poletji. Pomembna vinorodna regija — segrevanje že pomika datume trgatve naprej.",
+    moderate:     "Podaljšana rastna sezona kratkoročno koristi vinu, a naraščajoč sušni stres in tveganje poznih zmrzali po zgodnji brstovitvi začenjata ogrožati pridelke.",
+    bad:          "Datumi trgatve se premaknejo 3–4 tedne naprej. Tradicionalne štajerske sorte trpijo pod vročinskim stresom. Fitosanitarni problemi se bistveno okrepijo.",
+    extreme:      "Tradicionalne štajerske vinogradniške sorte postanejo ekonomsko neobstojne. Povpraševanje po namakanju iz Drave se spopada z ekološkimi zahtevami pretoka.",
+    catastrophic: "Ponavljajoča se huda sušna leta sesedejo štajersko vinsko gospodarstvo. Ekstremno nizki vodostaji Drave ogrožajo vodooskrbo doline in obrečne ekosisteme.",
+  },
+  Celje: {
+    baseline:     "Dolina reke Savinje, zgodovinsko podvržena hudim poplavam. Celinsko podnebje. Zaprta dolina ustvarja temperaturne inverzije in zmrzalne žepe pozimi.",
+    moderate:     "Segrevanje zmanjšuje zmrzalne dni, a krepi konvektivne padavine, ki sprožajo poplave Savinje, po katerih je mesto že znano.",
+    bad:          "Dogodki, ki so bili prej stletni poplavni viški, se ponavljajo v desetletjih. Protipoplavna infrastruktura, zgrajena za zgodovinske povratne dobe, je sistematično prekoračena.",
+    extreme:      "Kombinirani poletni sušni in zimski poplavni ekstremi hkrati destabilizirajo kmetijstvo in infrastrukturo v dolini Savinje.",
+    catastrophic: "Pogostejši ekstremni poplavni dogodki preplavljajo staro protipoplavno infrastrukturo. Izmenjava suša–poplava destabilizira kmetijsko savinjsko ravnino.",
+  },
+  Kranj: {
+    baseline:     "Ob vznožju Kamniško-Savinjskih Alp, dolina reke Save, 387 m. Alpski vpliv ohranja razmeroma hladna poletja. Vhod v Triglavski narodni park.",
+    moderate:     "Upadanje alpske snežne odeje zmanjšuje poletni pretok Save, kar vpliva na vodooskrbo za odvodne uporabnike, vključno z Ljubljano.",
+    bad:          "Poletni nizki vodostaji Save postanejo hudi. Hidroelektrična proizvodnja na savski verigi elektrarn v sušnih letih občutno pade.",
+    extreme:      "Umikanje ledenikov v Kamniško-Savinjskih Alpah se pospeši. Kamenje iz destabilizirajočih se pobočij ogroža infrastrukturo v dolini.",
+    catastrophic: "Izguba zanesljive poletne savenice, ki jo napaja snežna odeja, ogroža hidroelektrično hrbtenico slovenskega elektroenergetskega sistema.",
+  },
+  Koper: {
+    baseline:     "Edino slovensko morsko pristanišče, Jadransko morje, 10 m nadmorske višine. Sredozemsko podnebje: mile zime, suha poletja, burjni vetrovi.",
+    moderate:     "Segrevanje morske gladine podaljšuje kopalno sezono. Tveganje suše se poleti povečuje z naraščajočim sredozemskim sušnim signalom.",
+    bad:          "Vdor slane vode v obalne vodonosnike se krepi. Mediteranske invazivne vrste se ustanavljajo v slovenskih obalnih vodah.",
+    extreme:      "Pogostost in resnost neviht s sodro narašča. Obalno kmetijsko zemljišče se sooča s slanostjo od morskih razpršilcev in vdorov podzemne vode.",
+    catastrophic: "Dvig gladine Jadranskega morja ogroža pristaniško infrastrukturo in obalno kmetijstvo. Ekstremni burjni dogodki se krepijo z naraščajočimi temperaturnimi gradienti.",
+  },
+  Novo_Mesto: {
+    baseline:     "Dolina reke Krke, jugovzhodna Slovenija, 220 m. Celinsko s ponekod panonskim vplivom. Pomembna regija za sadje — jabolka, hruške in hmelj.",
+    moderate:     "Segrevanje podaljšuje brezzmrzalno rastno sezono, a povečuje poletni sušni stres na povodju reke Krke.",
+    bad:          "Osnovni pretok reke Krke poleti občutno upade. Pridelava hmelja se sooča z vročinskim in sušnim stresom, ki zahteva drago namakanje.",
+    extreme:      "Večletne suše izčrpavajo reko Krko in podzemno vodo. Sadjarstvo in hmeljarstvo zahtevata temeljito prestrukturiranje.",
+    catastrophic: "Ponavljajoča se sušna leta izčrpavajo osnovni pretok reke Krke. Hmeljarsko in sadjarsko gospodarstvo Dolenjske se sooča s temeljitim prestrukturiranjem.",
+  },
+  Murska_Sobota: {
+    baseline:     "Severovzhodna panonska ravnina, 189 m. Najbolj celinsko postaja — najtoplejša poletja, najhladnejše zime, najmanj padavin. Intenzivno kmetijstvo: koruza, sončnice, pšenica.",
+    moderate:     "Že najbolj sušno izpostavljena regija v Sloveniji. Dni z vročinskim stresom nad 35 °C naraščajo najhitreje. Primanjkljaj kmetijske vode je že občuten.",
+    bad:          "Pridelki koruze in sončnic v sušnih letih padejo za 20–30 %. Poletni ekstremi nad 38 °C postanejo redni.",
+    extreme:      "Večletna sušna zaporedja sesedejo tradicionalno kmetijstvo brez namakanja. Povpraševanje po namakanju preseže trajnostni donos reke Mure.",
+    catastrophic: "Panonsko kmetijsko gospodarstvo se sooča s propadom pod trajnimi večletnimi sušami. Izčrpavanje podzemne vode se pospeši.",
+  },
+  Nova_Gorica: {
+    baseline:     "Zahodna Slovenija, spodnja dolina Soče, 94 m. Sredozemsko-alpski prehod. Toplo in sončno z burjnimi vetrovi. Pomembna vinorodna regija.",
+    moderate:     "Segrevanje pospešuje sredozemski trend sušenja. Burjni dogodki se morda okrepijo. Kakovost vin se preoblikuje z naraščanjem rastnih stopenj.",
+    bad:          "Poletna suša naredi tradicionalno kraško vinogradništvo vse bolj odvisno od namakanja. Nizki poletni pretoki Soče ogrožajo ekologijo.",
+    extreme:      "Hladnovodni ribolov Soče se sooča s toplotnim izumrtjem v spodnjih dosegih, ko poletne temperature presegajo toleranče.",
+    catastrophic: "Ekstremna poletna suša naredi tradiconalno kraško in brdiško vinogradništvo neobstojno brez namakanja.",
+  },
+  Postojna: {
+    baseline:     "Kraška planota, 549 m. Znana po temperaturnih inverzijah — hladen zrak se kopiči v kraški depresiji. Temperature v jamskem ekosistemu so stabilne pri 10 °C.",
+    moderate:     "Segrevanje slabi temperaturne inverzije in zmanjšuje ekstremno hlajenje. Temperature v jamskem ekosistemu se začnejo premikati.",
+    bad:          "Notranje jame začnejo izmerljivo naraščati. Pretok kraških izvirov poleti v sušah upada.",
+    extreme:      "Endemska favna Postojnske jame — človeška ribica in jamski hrošči — se sooča s toplotnim in hidrološkim stresom.",
+    catastrophic: "Napajanje kraškega vodonosnika popusti pod podaljšano sušo. Endemska favna Postojnske jame se sooča s toplotnim stresom brez poti pobega.",
+  },
+  Ptuj: {
+    baseline:     "Najstarejše stalno poseljeno mesto v Sloveniji, dolina reke Drave, 228 m. Severovzhodna celinska cona. Vino, hmelj in žitno kmetijstvo.",
+    moderate:     "Dogodki nizkih vodostajev Drave se pogostijo, kar vpliva na hladilno vodo za hidroelektrarno Formin nizvodno.",
+    bad:          "Datumi trgatve se bistveno premaknejo naprej. Kmetijsko povpraševanje po vodi vse bolj nasprotuje ekološkim zahtevam pretoka.",
+    extreme:      "Ekstremno nizki vodostaji Drave postanejo redni. Hidroelektrarna Formin se v sušnih letih sooča z obveznim omejevanjem.",
+    catastrophic: "Kombinirani sušni in vročinski ekstremi destabilizirajo kmetijsko gospodarstvo v dravski dolini.",
+  },
+  Velenje: {
+    baseline:     "Šaleška dolina, 405 m, osrednja Slovenija. Zgrajena okoli premogovništva. Gorska celinska mikroklima pod vplivom Šaleških jezer.",
+    moderate:     "Ko premogovništvo upada, podnebni vplivi vključujejo povečano tveganje poplav v posedninskih conah.",
+    bad:          "Šaleška jezera se soočajo z naraščajočim izhlapevanjem in cvetenjem alg. Upravljanje z vodo postane kompleksno.",
+    extreme:      "Prehod po premogu oteži podnebne ekstreme. Načrtovani prehod na obnovljivo energijo se sooča s konflikti rabe tal.",
+    catastrophic: "Upravljanje z vodo v posedninskih jezerih postane kritično z naraščajočim izhlapevanjem.",
+  },
+  Trbovlje: {
+    baseline:     "Zasavje, savska soteska, 230 m. Najožja poseljena dolina v Sloveniji. Kotlinska lega ustvarja značilne temperaturne inverzije.",
+    moderate:     "Segrevanje zmanjšuje zimske inverzije, ki kopičijo onesnaženost zraka, a povečuje poletni toplotni stres v zaprti dolini.",
+    bad:          "Poletni vročinski valovi v soteski so okrepljeni z njeno geometrijo in industrijskimi toplotnimi viri.",
+    extreme:      "Ekstremni padavinski dogodki nad Trbovljami povečujejo katastrofalno tveganje poplav v soteski.",
+    catastrophic: "Ekstremni vročinski valovi v soteski so okrepljeni z njeno geometrijo. Tveganje poplav Save narašča z naraščajočimi alpskimi padavinami.",
+  },
+  Tolmin: {
+    baseline:     "Dolina Soče/Isonzo, 194 m. Najtoplejša dolina v Sloveniji kljub alpski legi. Ekstremni padavinski dogodki naredijo to območje najdežnejše v Evropi.",
+    moderate:     "Segrevanje krepi že tako ekstremne padavinske dogodke. Izjemna biotska raznovrstnost doline se sooča z naraščajočim toplotnim pritiskom.",
+    bad:          "Poletni pretoki Soče občutno upadejo. Hladnovodni habitat marmornega postrva se krči navzgor po toku.",
+    extreme:      "Ekstremni poplavni dogodki na sistemu Soča–Idrijca se ponavljajo pogosteje. Smaragdna barva Soče zbledi z umikanjem ledenikov.",
+    catastrophic: "Katastrofalni poplavni dogodki na Soči postanejo pogostejši. Hladnovodni ribolov in naravni turizem sta temeljno ogrožena.",
+  },
+  Kocevje: {
+    baseline:     "Regija Kočevski Rog, 467 m, pokrita z največjim ostankom pragozdov v Srednji Evropi. Medvedi, risi in volkovi v največji gostoti v Evropi.",
+    moderate:     "Segrevanje premakne sestavo gozda k termofilnim vrstam. Izbruhi lubadarja se pospešijo v toplejših, sušnejših poletjih.",
+    bad:          "Pragozd se sooča s strukturno preobrazbo pod kombiniranim pritiskom suše in lubadarja.",
+    extreme:      "Obsežno odmiranje gozda odpre pragozd tveganju požarov, ki je bilo prej zanemarljivo.",
+    catastrophic: "Kočevski pragozd se sooča z nepopravljivo strukturno spremembo. Habitat velikih zveri se krči z upadanjem gozda.",
+  },
+  Ilirska_Bistrica: {
+    baseline:     "Pivška kotlina, 440 m. Prehodno območje med sredozemskim in celinskim podnebjem. Reka Pivka izgine pod zemljo v največji jamski sistem na svetu.",
+    moderate:     "Segrevanje zmanjšuje zimsko snežno odejo, ki napaja kraške izvire Pivke.",
+    bad:          "Površinski pretok reke Pivke izgine zgodaj v sezoni, ko upadejo kraški izviri.",
+    extreme:      "Jamski sistem Postojna–Planina se sooča z zmanjšanim pretokom in naraščajočimi temperaturami vode.",
+    catastrophic: "Kraški izviri, ki napajajo reko Pivko, poleti presahnejo. Edinstveni hidrološki sistem je moten s kaskadnimi učinki.",
+  },
+  Domzale: {
+    baseline:     "Ljubljanska kotlina, 301 m. Primestno in lahko industrijsko. Celinsko podnebje z nekoliko manjšim mestnim toplotnim otokom kot Ljubljana.",
+    moderate:     "Z razširjanjem metropolitanske regije se mestni toplotni otoški učinki krepijo.",
+    bad:          "Poletni toplotni otok po kotlini ustvarja trajen vročinski stres za 400.000 prebivalcev regije.",
+    extreme:      "Kombinirani vročinski in sušni dogodki bistveno zmanjšajo kakovost življenja in povečajo smrtnost.",
+    catastrophic: "Urbanizacija v kombinaciji s podnebnim segrevanjem ustvari trajen toplotni otok s kumulativnimi učinki na javno zdravje.",
+  },
+  Ratece: {
+    baseline:     "Tarbizijska kotlina, Julijske Alpe, 864 m. Eno najsušnejših mest v Sloveniji kljub alpski legi. Ekstremno hladne zime, obilna snežna odeja.",
+    moderate:     "Globina in trajanje snežne odeje se opazno zmanjšujeta. Čas spomladanskega odtajanja se premika naprej.",
+    bad:          "Smučarsko letovišče Kranjska Gora se sooča z ekonomsko neobstojnimi snežnimi sezonami.",
+    extreme:      "Taljenje permafrosta v Julijskih Alpah sproži naraščajoče kamenje in nestabilnost pobočij.",
+    catastrophic: "Izguba zanesljive zimske snežne odeje konča smučarsko gospodarstvo v dolini Kranjske Gore.",
+  },
+  Kredarica: {
+    baseline:     "Vrh masiva Triglava, 2514 m — najvišja meteorološka postaja v Sloveniji. Stalni sneg, ostanki ledenikov, ekstremni vetrovi.",
+    moderate:     "Triglavski ledenik — zadnji ledenik v Sloveniji — se vidno umika. Segrevanje je tukaj dvojno od nižinskega.",
+    bad:          "Triglavski ledenik izgubi več kot polovico preostalega volumna. Ikonična silhueta se sooča s trajno spremembo.",
+    extreme:      "Triglavski ledenik popolnoma izgine. Visokogorski ekosistem nad gozdno mejo propade.",
+    catastrophic: "Popolna izguba Triglavskega ledenika — narodni simbol in vir savinjskih rek. Propad alpskega ekosistema sproži kaskadne učinke.",
+  },
+};

--- a/code/ali-je-vroce-era5/i18n/sl.ts
+++ b/code/ali-je-vroce-era5/i18n/sl.ts
@@ -1,0 +1,429 @@
+import { climateRisks, heroContext } from "./hero-content.ts";
+
+// T-5.5 (D-8) — Slovenian message catalogue for the "Ali je vroče" ERA5 island.
+//
+// Slovenian only for v1 (D-8): one locale, one file. Seeded from the salvaged
+// `docs/i18n/sl_default.json` (T-2.4) where the wording matched what the page
+// actually renders; where they diverged, the LIVE inline string was kept so the
+// rendered output stays byte-identical (the sl_default.json prose was an older,
+// longer draft — see PROGRESS T-5.5).
+//
+// Message syntax is the ICU subset implemented in ./format.ts:
+//   "{name}"                                       — interpolate a parameter
+//   "{count, plural, one{…} two{…} few{…} other{…}}" — Slovenian plural on `count`
+// Numbers destined for display are pre-formatted by the caller (fmtNum/fmtInt/
+// fmtSigned); "#" inside a plural form renders the grouped integer.
+//
+// ── FLAGGED FOR CONTENT REVIEW (not resolved here) ────────────────────────────
+//  • Register/wording: "Peklensko" / "Izjemna vročina" (today.cat_hell), the
+//    "stoletni"/"Sto let" verdict framing (hero.verdict_*) overstating the ~76-yr
+//    record — both deferred from T-5.4a.
+//  • The governed-genitive numeral agreement in "povprečje/vseh {N} postaj" is
+//    subtler than the CLDR one/two/few/other paradigm; the forms below are the
+//    nominative-count forms, correct for the only value that occurs (18 → "postaj")
+//    and a reasonable default otherwise. A native pass should confirm N=1,2.
+//  • Phrase-level English that was translated mechanically but may want polish:
+//    reg.no_data, reg.year_round_footer, hc.* (Highcharts lang, kept English AS-IS).
+
+export const sl = {
+  common: {
+    unit_c: "°C",
+    unit_mm: "mm",
+    unit_cm: "cm",
+    today: "danes",
+    ci95: "95% CI",
+    temp_c: "{temp} °C",
+  },
+
+  loading: "Nalaganje…",
+
+  error: {
+    section: "Tega razdelka trenutno ni bilo mogoče naložiti.",
+    retry: "Poskusi znova",
+  },
+
+  sections: {
+    today_title: "ERA5 — Ali je vroče?",
+    today_subtitle: "reanaliza ERA5-Land v primerjavi z zgodovinskimi percentili",
+    trends_analysis: "Analiza trendov · ERA5-Land reanaliza",
+    location_details: "Podrobnosti lokacije",
+    season_overview: "Sezonski pregled",
+    season_overview_sub: "Povprečna najvišja temperatura po sezonah · ERA5-Land · barve glede na referenčno obdobje {baseline}",
+    spei: "Sezonski sušni indeks (SPEI)",
+    spei_trend: "Sušni trend po postaji — SPEI",
+    spei_trend_sub: "Sezonski (SPEI-3) in mesečni (SPEI-30) indeks vodne bilance · Theil-Sen · ERA5-Land",
+    tropical_days: "Tropski dnevi",
+    tropical_days_sub: "Število dni z najvišjo temperaturo nad pragom · ERA5-Land · lapsna korekcija nadmorske višine",
+    tropical_nights: "Tropske noči",
+    tropical_nights_sub: "Število noči z najnižjo temperaturo nad pragom · ERA5-Land · lapsna korekcija nadmorske višine",
+    sea_level: "Dvig morske gladine — Koper",
+    sea_level_sub: "Projekcije dviga morske gladine po scenarijih IPCC AR6 z viharnimi nalivi · severni Jadran",
+  },
+
+  today: {
+    prev_day: "Prejšnji dan",
+    next_day: "Naslednji dan",
+    loc_national: "Slovenija — povprečje {count, plural, one{# postaja} two{# postaji} few{# postaje} other{# postaj}}",
+    arso_group: "ARSO postaje",
+    era5_group: "ERA5 postaje",
+
+    cat_freezing: "Zmrzujoče",
+    cat_cold: "Hladno",
+    cat_nope: "Normalno",
+    cat_hot: "Vroče",
+    cat_hell: "Peklensko",
+
+    // ARSO cutoffs vs ERA5 record — kept as separate templates as in TodayCard.
+    desc_arso_freezing: "Med najhladnejšimi {d} v naših zapisih ARSO.",
+    desc_arso_cold: "Hladneje od večine izmerjenih {d}.",
+    desc_arso_nope: "Točno takšno, kot {d} v {country} ponavadi je.",
+    desc_arso_hot: "Med najtoplejšimi {d} v naših zapisih.",
+    desc_arso_hell: "Izjemna vročina — vrh 5 % vseh {d} glede na meritve ARSO.",
+    desc_era5_freezing: "Med najhladnejšimi {d} v naših {record_years} letih zapisov.",
+    desc_era5_cold: "Hladneje od večine izmerjenih {d}.",
+    desc_era5_nope: "Točno takšno, kot {d} v {country} ponavadi je.",
+    desc_era5_hot: "Med najtoplejšimi {d} v naših zapisih.",
+    desc_era5_hell: "Izjemna vročina — vrh 5 % vseh {d} od {year_min}.",
+
+    national_explain: "Povprečje najvišjih dnevnih temperatur {count, plural, one{# slovenske postaje} two{# slovenskih postaj} few{# slovenskih postaj} other{# slovenskih postaj}} (nadmorska višina {elMin}–{elMax} m), razvrščeno glede na zapise ERA5-Land od leta {yearMin} za isto ±7-dnevno okno.",
+    explain_arso: "Temperatura na ARSO postaji {label}, razvrstena glede na percentilne zapise ARSO meritev.",
+    explain_station: "Temperatura na postaji {station}, razvrstena glede na zapise ERA5-Land od leta {year_min} za isto ±7-dnevno okno.",
+    explain_national: "Današnji vrh je najvišja napovedana temperatura, razvrstena glede na zapise ERA5-Land od leta {year_min} za isto ±7-dnevno okno.",
+
+    context: "Slovenija leži na stičišču štirih podnebnih con — alpske, sredozemske, celinsko in panonske — stisnjenih v eno izmed podnebno najbolj raznolikih držav v Evropi. Srednja Evropa se segreva približno 1,5-krat hitreje od svetovnega povprečja. Temperature so v zadnjih 70 letih narasle za skoraj 2 °C. Pomlad v Alpah prihaja vse prej, sredozemske suše segajo vse globlje v notranjost, severovzhodni panonski del pa se sooča z vedno hujšimi vročinskimi vali. Kar je bilo leta 1980 tipično poletje, danes sodi med hladnejšo polovico nedavnih desetletij.",
+
+    last7_title: "Zadnjih 7 dni",
+    pct_label: "percentil",
+    pct_samples_arso: "ARSO meritve",
+    pct_samples: "{count, plural, one{# vzorec} two{# vzorca} few{# vzorci} other{# vzorcev}}",
+    badge_forecast: "napoved",
+    unavailable: "Podatki za ta dan niso na voljo.",
+
+    // Footer under the today card. {suffix} is one of foot_suffix_* below (or "").
+    foot: "{temp} °C · {pct}. percentil{suffix}",
+    foot_suffix_arso: " · {count, plural, one{# vzorec} two{# vzorca} few{# vzorci} other{# vzorcev}} ({year_min}–{year_max}) · vir: ARSO",
+    foot_suffix: " · {count, plural, one{# vzorec} two{# vzorca} few{# vzorci} other{# vzorcev}} ({year_min}–{year_max})",
+
+    rank_hot: "#{rank} najtoplejši {d}",
+    rank_cold: "#{rank} najhladnejši {d}",
+    rank_top5_hot: "Najtoplejši {d}",
+    rank_top5_cold: "Najhladnejši {d}",
+
+    chart_title_nat: "Dnevne najvišje temperature v Sloveniji za dva tedna okoli {day} od {year_min}",
+    chart_title_station: "Dnevne najvišje temperature na postaji {station} za dva tedna okoli {day} od {year_min}",
+    chart_explain: "Krivulja prikazuje, kako pogosto se je pojavila vsaka vrhunska temperatura na dneve, kot je danes, v vseh letih. Barve označujejo klimatološke cone — od hladne modre prek tipičnega bežastega pasu do ekstremne rdeče.",
+    // {region} = "Slovenija" | "Danes"
+    foot2: "{region}: {temp} °C · {pct}. percentil · mediana {median} °C · {count, plural, one{# opazovanje} two{# opazovanji} few{# opazovanja} other{# opazovanj}} · {year_min}–{year_max}",
+    foot2_region_nat: "Slovenija",
+    foot2_region_day: "Danes",
+  },
+
+  // DistributionChart
+  dist: {
+    zone_cold: "Hladno",
+    zone_cool: "Sveže",
+    zone_normal: "Normalno",
+    zone_hot: "Vroče",
+    zone_extreme: "Ekstremno",
+    tooltip: "{temp} °C · {zone}",
+    today_line: "DANES: {temp} °C",
+    band_below: "< {p}°C",
+    band_range: "{a}–{b}°C",
+    band_above: "> {p}°C",
+    a11y: "Porazdelitev najvišjih dnevnih temperatur na dneve okoli izbranega datuma v vseh letih zabeleženega obdobja. Navpična črta označuje današnjo vrednost; barvni pasovi ločijo klimatološke cone od hladne do ekstremne.",
+  },
+
+  // TodayLast7Chart
+  last7: {
+    cat_freezing: "Zmrzujoče",
+    cat_cold: "Hladno",
+    cat_nope: "Normalno",
+    cat_hot: "Vroče",
+    cat_hell: "Peklensko",
+    tooltip: "{label}: {cat} · {temp} °C ({pct}. percentil)",
+    a11y: "Gibanje toplotne kategorije v zadnjih sedmih dneh — vsaka točka je en dan, uvrščen od zmrzujoče do peklensko glede na zgodovinske percentile.",
+  },
+
+  // TodayTrendChart (annual trend + projection)
+  trend: {
+    title_station: "Najvišje temperature na postaji {station} okoli {day} · {yearMin}–{yearMax} · trend s projekcijo do 2050",
+    title_nat: "Najvišje temperature v Sloveniji okoli {day} · {yearMin}–{yearMax} · trend s projekcijo do 2050",
+    explain: "Vsaka pika je 90. percentil {source} v ±30-dnevnem oknu okoli tega datuma za vsako leto od {yearMin}. Trend Theil-Sen je {trend} °C/desetletje ({sig}). Po tem tempu projekcija kaže {proj2050} °C do leta 2050. Zasenčeni pas je 95% interval zaupanja za nagib.",
+    explain_source_station: "lapsno popravljene dnevne najvišje temperature na postaji {station}",
+    explain_source_nat: "nacionalne povprečne dnevne najvišje temperature vseh {count, plural, one{# postaje} two{# postaj} few{# postaj} other{# postaj}}",
+    foot: "Theil-Sen + TFPW MK: {trend} °C/desetletje · {sig} · τ = {tau} · 95% CI · {count, plural, one{# leto} two{# leti} few{# leta} other{# let}}",
+    tooltip_annual: "<b>{x}</b>: {y} °C",
+    tooltip_milestone: "<b>{x}</b>: {y} °C <em>(projekcija)</em>",
+    a11y: "Letni trend najvišjih temperatur okoli izbranega datuma z linijo Theil-Sen, 95-odstotnim intervalom zaupanja in projekcijo do leta 2050. Vsaka pika je vrednost enega leta.",
+  },
+
+  // RegressionPanel toolbar + cards
+  reg: {
+    var_temperature_max: "Najvišja temperatura (°C)",
+    var_temperature_min: "Najnižja temperatura (°C)",
+    var_temperature_mean: "Povprečna temperatura (°C)",
+    var_precipitation_sum: "Padavine (mm)",
+    var_et0: "ET₀ (mm)",
+
+    location: "Lokacija",
+    select_locations: "Izberite lokacije (največ 6)",
+    variable: "Spremenljivka",
+    day: "Dan",
+    locations_multi: "{count, plural, one{# lokacija} two{# lokaciji} few{# lokacije} other{# lokacij}}",
+
+    years_sig: "{count, plural, one{# leto} two{# leti} few{# leta} other{# let}} · {sig}",
+    change_over_record: "sprememba v celotnem obdobju",
+    under_mean: "Pod povprečjem",
+    over_mean: "Nad povprečjem",
+    trend_line: "Trendna linija",
+    no_data: "Ni podatkov za izbrani dan in lokacijo.",
+
+    year_round_title: "Celoletni trend · {station}",
+    year_round_sub: "trend na desetletje za vsak dan v letu · rdeča črta = izbrani dan",
+    warming: "Segrevanje",
+    cooling: "Ohlajanje",
+    year_round_footer: "prosojnost = značilnost · p < 0,001 povsem neprosojno",
+
+    explain_reg: "Theil-Sen regresija + Yue-Wang TFPW Mann-Kendall test · ERA5-Land · nadmorska korekcija",
+    explain_cal: "Trend na desetletje za vsak dan v letu · rdeča = ogrevanje · modra = ohlajanje · prosojnost = statistična značilnost",
+  },
+
+  // RegressionChart (Highcharts)
+  regchart: {
+    tooltip: "<b>{loc}</b><br/>{x}: <b>{y}</b> {unit}",
+    tooltip_anomaly: "<br/>anomalija: {a}",
+    baseline_label: "POVPREČJE {count, plural, one{# leta} two{# let} few{# let} other{# let}}: {baseline}",
+    a11y: "Razsevni diagram letnih vrednosti izbrane spremenljivke z regresijsko linijo trenda in 95-odstotnim intervalom zaupanja; črtkana črta označuje povprečje referenčnega obdobja.",
+  },
+
+  // YearRoundChart (Highcharts)
+  yearround: {
+    tooltip: "<b>{label}</b><br>Trend: {trend} {unit}/desetletje<br>p = {p}",
+    a11y: "Trend spremembe po dnevih v letu čez celotno koledarsko leto — vsak stolpec je en dan, višina je trend na desetletje, navpična črta pa označuje izbrani datum.",
+  },
+
+  // HeroCards
+  hero: {
+    verdict_warming: "Sto let segrevanja za <em>{t100} {unit}</em> – pri trenutnem tempu vsaka <em>{yrs} let</em> doda eno stopinjo.",
+    verdict_cooling: "Sto let ohlajanja za <em>{t100} {unit}</em> – pri trenutnem tempu vsaka <em>{yrs} let</em> odšteje eno stopinjo.",
+    verdict_none: "Na ta dan v letu ni zaznati trenda.",
+    method_theilsen: "Theil-Sen + TFPW Mann-Kendall",
+
+    cat_catastrophic: "Katastrofalno",
+    cat_extreme: "Ekstremno",
+    cat_bad: "Slabo",
+    cat_moderate: "Zmerno",
+    cat_baseline: "Izhodiščno",
+
+    eyebrow_var: "najvišja temperatura",
+    unit_decade: "°C / desetletje",
+    risk_label: "Tveganje vpliva:",
+    stat_significance: "Značilnost",
+    stat_sample: "Vzorec",
+    stat_autocorrelation: "Avtokorelacija",
+    sample_full: "{count, plural, one{# opazovanje} two{# opazovanji} few{# opazovanja} other{# opazovanj}} · {count2, plural, one{# leto} two{# leti} few{# leta} other{# let}}",
+    sample_years: "{count, plural, one{# leto} two{# leti} few{# leta} other{# let}}",
+    ar1: "AR(1) = {ar1} · {strength}",
+    ar1_negligible: "zanemarljiva",
+    ar1_weak: "šibka",
+    ar1_moderate: "zmerna",
+    group_a11y: "Podrobnosti lokacije {station}: stoletni temperaturni trend, kategorija tveganja in vpliv podnebne spremembe.",
+  },
+
+  // Per-location content tables, moved VERBATIM from HeroCards.tsx (T-5.5) so the
+  // rendered prose stays byte-identical. Looked up as climate_risks.<Loc> and
+  // hero_context.<Loc>.<category>. Wording is content-provider territory (FLAGGED).
+  climate_risks: climateRisks,
+  hero_context: heroContext,
+
+  // Season heatmap
+  season: {
+    label_Autumn: "Jesen",
+    label_Summer: "Poletje",
+    label_Spring: "Pomlad",
+    label_Winter: "Zima",
+    cat_cold: "Hladno (<10. pct)",
+    cat_cool: "Sveže (10–20. pct)",
+    cat_normal: "Normalno (20–80. pct)",
+    cat_hot: "Vroče (80–95. pct)",
+    cat_extreme: "Ekstremno (>95. pct)",
+    mode_all: "Vse letne čase",
+    mode_extremes: "Samo ekstremi",
+    anim_stop: "⏹ Ustavi",
+    anim_play: "▶ Animacija",
+    stat_extreme: "Ekstremne sezone",
+    stat_cold: "Hladne sezone",
+    stat_extreme_since: "Ekstremne od 2010",
+    stat_hot_recent: "Vroče ali ekstremne ({from}–{to})",
+    tooltip_avg_label: "Povprečni maks:",
+    tooltip_rank: "{rank}. najtoplejša {season} od {count, plural, one{# leta} two{# let} few{# let} other{# let}}",
+    grid_a11y: "Toplotna karta letnih časov po letih od {from} do {to}: vsak stolpec je eno leto, vsaka vrstica en letni čas, barva pa uvršča povprečno najvišjo temperaturo od hladne do ekstremne glede na referenčno obdobje. Celotni podatki so v tabeli pod grafom.",
+    table_caption: "Podatki toplotne karte letnih časov po letih",
+    th_season: "Letni čas",
+    th_year: "Leto",
+    th_category: "Kategorija",
+    th_avg: "Povprečni maksimum (°C)",
+    th_rank: "Uvrstitev",
+    rank_of: "{rank}. od {total}",
+  },
+
+  // SPEI heatmap
+  spei: {
+    label_Autumn: "Jesen",
+    label_Summer: "Poletje",
+    label_Spring: "Pomlad",
+    label_Winter: "Zima",
+    cat_extreme_dry: "Huda suša (SPEI < −1,5)",
+    cat_dry: "Suho (SPEI −1,5 do −1,0)",
+    cat_normal: "Normalno (SPEI −1,0 do 1,0)",
+    cat_wet: "Mokro (SPEI 1,0 do 1,5)",
+    cat_extreme_wet: "Zelo mokro (SPEI > 1,5)",
+    mode_all: "Vse letne čase",
+    mode_extremes: "Samo ekstremi",
+    anim_stop: "⏹ Ustavi",
+    anim_play: "▶ Animacija",
+    stat_extreme_dry: "Sezone hude suše (SPEI < −1,5)",
+    stat_extreme_wet: "Izjemno mokre sezone (SPEI > 1,5)",
+    stat_extreme_dry_since: "Sezone hude suše od 2000",
+    stat_dry_recent: "Suho ali suša ({from}–{to})",
+    tooltip_spei: "SPEI: ",
+    tooltip_balance: "Vodni bilans: ",
+    tooltip_balance_unit: " mm P−ET₀",
+    tooltip_rank: "{rank}. najsušnejša {season} od {count, plural, one{# leta} two{# let} few{# let} other{# let}}",
+    grid_a11y: "Toplotna karta sušnega indeksa SPEI po letnih časih in letih od {from} do {to}: vsak stolpec je eno leto, vsaka vrstica en letni čas, barva pa označuje razmere od hude suše do zelo mokrega. Celotni podatki so v tabeli pod grafom.",
+    table_caption: "Podatki toplotne karte sušnega indeksa SPEI po letnih časih in letih",
+    th_season: "Letni čas",
+    th_year: "Leto",
+    th_category: "Kategorija",
+    th_spei: "SPEI",
+    th_balance: "Vodna bilanca (mm)",
+    th_rank: "Uvrstitev",
+    rank_of: "{rank}. od {total}",
+  },
+
+  // SPEI trend per station
+  speitrend: {
+    season_Annual: "Letno",
+    season_Winter: "Zima",
+    season_Spring: "Pomlad",
+    season_Summer: "Poletje",
+    season_Autumn: "Jesen",
+    tooltip_cat_huda: "Huda suša",
+    tooltip_cat_suho: "Suho",
+    tooltip_cat_normalno: "Normalno",
+    tooltip_cat_mokro: "Mokro",
+    tooltip_cat_zelo_mokro: "Zelo mokro",
+    tooltip: "<b>{season} {x}</b><br>{scale}: <b>{v}</b><br>{cat}",
+    threshold_dry: "huda suša",
+    threshold_wet: "zelo mokro",
+    header_count: "{count, plural, one{# {unit1}} two{# {unit2}} few{# {unit2}} other{# {unit2}}} · {y0}–{y1}",
+    unit_months_one: "mesec",
+    unit_months_other: "mesecev",
+    unit_seasons_one: "sezona",
+    unit_seasons_other: "sezon",
+    slope_unit: "SPEI / desetletje",
+    sig_significant: "statistično značilen (p < 0,05)",
+    sig_not: "ni statistično značilen (p = {p})",
+    threshold_crossed_dry: "Trendna linija je že prečkala prag hude suše (SPEI −1,5).",
+    threshold_reach_dry: "Pri tem trendu doseže hudo sušo (SPEI −1,5) okoli leta {year}.",
+    threshold_crossed_wet: "Trendna linija je že prečkala prag zelo mokrega (SPEI +1,5).",
+    threshold_reach_wet: "Pri tem trendu doseže zelo mokro (SPEI +1,5) okoli leta {year}.",
+    tech: "Theil-Sen naklon: {slope} SPEI/desetletje · Mann-Kendall: {mk} · {sig}. Negativen trend pomeni, da razmere postajajo sušnejše glede na osnovno obdobje {baseline}.{threshold}",
+    too_little: "Premalo podatkov za izračun trenda.",
+    a11y: "Razsevni diagram sušnega indeksa SPEI po letih za izbrano postajo in obdobje, z linijo trenda Theil-Sen ter pragovoma hude suše (−1,5) in zelo mokrega (+1,5).",
+  },
+
+  // Tropical days / nights
+  tropical: {
+    unit_days: "dni",
+    unit_nights: "noči",
+    noun_days: "Tropski dnevi",
+    noun_nights: "Tropske noči",
+    plain_noun_days: "tropski dan",
+    plain_noun_nights: "tropska noč",
+    ctrl_threshold: "Prag:",
+    ctrl_streak_days: "Min. zap. dni:",
+    ctrl_streak_nights: "Min. zap. noči:",
+    header_count: "{count, plural, one{# leto} two{# leti} few{# leta} other{# let}} · {nonzero} z vrednostjo > 0",
+    year_legend: "Zadnji stolpec — leto v teku",
+    year_in_progress: "(leto v teku)",
+    trend_label: "trend do {year}",
+    tooltip_trend: "<b>{x}</b><br>Trend: <b>{y}</b> {unit}",
+    tooltip_bar: "<b>{x}</b>{partial}<br>{noun}: <b>{y}</b>",
+    nb_fit: "NB fit ({dpd} {unit}/des · {p})",
+    plain_desc_days: "Tropski dan — ko dnevna temperatura preseže {th} °C — povečuje toplotni stres in zdravstvena tveganja.",
+    plain_desc_nights: "Tropska noč — ko temperatura čez noč ostane nad {th} °C — preprečuje telesu okrevanje po dnevni vročini.",
+    tech: "NB GLM: {rate}%/leto · {dpd} {unit}/desetletje · 95% CI · {sigphrase} · AIC {aic} · α={alpha}.",
+    sig_yes: "statistično značilen ({p})",
+    sig_no: "ni značilen ({p})",
+    forward_yes: "Če trend nadaljuje, bi bilo do 2050 tipičnih okoli {proj2050} {unit} na leto.",
+    forward_no: "Podatki ne kažejo jasnega signala, a smer spremembe je vredna pozornosti.",
+    sig_trend_yes: "statistično značilen trend",
+    sig_trend_no: "trend, ki še ni statistično značilen",
+    dir_more: "več",
+    dir_less: "manj",
+    plain: "{plainDesc} Postaja {station} kaže {sig}: grobe {dpd} {dir} {unit} na desetletje. {forward}",
+    no_trend: "Premalo let z {plainNoun}i za izračun trenda ({count, plural, one{# leto} two{# leti} few{# leta} other{# let}} z vrednostjo > 0). Potrebnih je vsaj 10.",
+    a11y: "Stolpčni prikaz letnega števila — {noun}, torej koliko {unit} na leto preseže izbrani temperaturni prag — z modelom trenda negativne binomske regresije in intervalom zaupanja; zadnji stolpec je leto v teku.",
+  },
+
+  // StationMap + map legend
+  map: {
+    a11y: "Zemljevid Slovenije z merilnimi postajami; barva točke označuje višinski pas postaje. Postajo lahko izberete tudi s spustnim seznamom v analizi trendov.",
+    panel_title_all: "Slovenija — vseh {count, plural, one{# postaja} two{# postaji} few{# postaje} other{# postaj}}",
+    panel_sub_count: "{count, plural, one{# postaja} two{# postaji} few{# postaje} other{# postaj}} · ERA5",
+    legend_alpine: "Alpska (>1500m)",
+    legend_mountain: "Gorska (800–1500m)",
+    legend_foothill: "Predgorska (400–800m)",
+    legend_lowland: "Nižinska (<400m)",
+  },
+
+  // Sea level widget
+  sea: {
+    a11y: "Interaktivni prikaz dviga morske gladine v Kopru po scenarijih IPCC AR6; gumbi izberejo scenarij in verjetnost, drsnik leto, ločnica pa primerja sedanjost s projekcijo.",
+    scenario: "Scenarij",
+    scn_mid: "Srednja pot",
+    scn_highway: "Vožnja po avtocesti",
+    prob: "Verjetnost ekstremov",
+    prob_common: "pogost (70 %)",
+    prob_rare: "redek (20 %)",
+    prob_extreme: "ekstrem (1 %)",
+    year: "Leto:",
+    buildings_short: "stavb",
+    play: "Predvajaj",
+    pause: "Ustavi",
+    move_divider: "Premakni ločnico",
+    today: "DANES",
+    total_rise: "Skupni dvig gladine",
+    mean_sub: "srednja vrednost · {scn}",
+    impact_ha: "ha poplavljenih",
+    impact_build: "ogroženih stavb",
+    legend_today: "Danes in prihodnost",
+    legend_future: "Novo v prihodnosti",
+    sources: "Viri podatkov",
+    src_proj: "Projekcije: IPCC AR6 (Fox-Kemper et al. 2021), lokalizirano za severni Jadran — DRSV 2023.",
+    src_impact: "Posledice: Kovačič et al. 2016/2019.",
+    src_map: "Karta:",
+    src_warn: "⚠ Poplavne cone so shematske — zamenjava z LIDAR DEM poligoni sledi.",
+  },
+
+  // Site meta (fallbacks)
+  meta: {
+    name: "Slovenija",
+    site_title: "Podnebnik · Ali je vroče?",
+  },
+
+  // ── Highcharts `lang` — extracted AS-IS (English library defaults). D-8 is
+  // Slovenian-only, so these want translation, but the operator instruction for
+  // T-5.5 was to CENTRALISE them here without re-wording. FLAGGED for a Highcharts
+  // a11y-lang translation pass. Only the export-data "view as data table" affordance
+  // (exporting hidden, T-5.4a) surfaces these to a screen-reader today.
+  hc: {
+    viewData: "View data table",
+    hideData: "Hide data table",
+    downloadCSV: "Download CSV",
+    downloadXLS: "Download XLS",
+  },
+} as const;
+
+export type Catalogue = typeof sl;

--- a/data/climate-si/sources/si.yaml
+++ b/data/climate-si/sources/si.yaml
@@ -6,7 +6,8 @@ code: si
 name: Slovenia
 timezone: Europe/Ljubljana
 default_location: Ljubljana
-languages: [en, sl]
+# D-8 / T-5.5 — Slovenian only for v1 (no switcher, /en/ routing or hreflang yet).
+languages: [sl]
 default_language: sl
 
 data_start_date: "1950-01-01"

--- a/scripts/snapshot/main.mjs
+++ b/scripts/snapshot/main.mjs
@@ -172,47 +172,47 @@ const { sections } = assertSections();
  * tolerated and a changed STRING is not.
  */
 const MIRRORED = [
+  // T-5.5 — the raw JSX now renders through the i18n catalogue; the mirrored
+  // fragments are the catalogue-key call sites, and the harness reproduces them
+  // by calling the SAME t()/formatters.
   {
     file: PAGE_SRC,
-    cite: "AliJeVroceERA5.tsx:102",
+    cite: "AliJeVroceERA5.tsx:108",
     mirror: "harness.tsx TodayChartCopy — title, national branch",
     fragment:
-      "`Dnevne najvišje temperature v Sloveniji za dva tedna okoli ${fmtDayLabel(todayData()!.day_label ?? \"\")} od ${todayData()!.year_min}`",
+      't("today.chart_title_nat", { day: fmtDayLabel(todayData()!.day_label ?? ""), year_min: todayData()!.year_min ?? 0 })',
   },
   {
     file: PAGE_SRC,
-    cite: "AliJeVroceERA5.tsx:103",
+    cite: "AliJeVroceERA5.tsx:109",
     mirror: "harness.tsx TodayChartCopy — title, per-station branch",
     fragment:
-      "`Dnevne najvišje temperature na postaji ${todayData()!.loc!.replace(/_/g, \" \")} za dva tedna okoli ${fmtDayLabel(todayData()!.day_label ?? \"\")} od ${todayData()!.year_min}`",
+      't("today.chart_title_station", { station: todayData()!.loc!.replace(/_/g, " "), day: fmtDayLabel(todayData()!.day_label ?? ""), year_min: todayData()!.year_min ?? 0 })',
   },
   {
     file: PAGE_SRC,
-    cite: "AliJeVroceERA5.tsx:110",
+    cite: "AliJeVroceERA5.tsx:116",
     mirror: "harness.tsx TodayChartCopy — footer (median cutoff, sample count, record years)",
     fragment:
-      "`${isNat() ? \"Slovenija\" : \"Danes\"}: ${todayData()!.today_temp!.toFixed(1)} °C · ${todayData()!.percentile!.toFixed(0)}. percentil · mediana ${todayData()!.cutoffs!.p50.toFixed(1)} °C · ${(todayData()!.n_samples ?? 0).toLocaleString()} opazovanj · ${todayData()!.year_min}–${todayData()!.year_max}`",
+      'region: isNat() ? t("today.foot2_region_nat") : t("today.foot2_region_day"),',
   },
   {
     file: PAGE_SRC,
-    cite: "AliJeVroceERA5.tsx:107",
+    cite: "AliJeVroceERA5.tsx:113",
     mirror: "harness.tsx TodayChartCopy — explain paragraph",
-    // Anchored on the closing tag: a text node's fragment would otherwise still
-    // "appear in" a LONGER version of itself.
-    fragment:
-      "Krivulja prikazuje, kako pogosto se je pojavila vsaka vrhunska temperatura na dneve, kot je danes, v vseh letih. Barve označujejo klimatološke cone — od hladne modre prek tipičnega bežastega pasu do ekstremne rdeče. </p>",
+    fragment: 't("today.chart_explain")',
   },
   {
     file: PAGE_SRC,
-    cite: "AliJeVroceERA5.tsx:134",
+    cite: "AliJeVroceERA5.tsx:155",
     mirror: "harness.tsx MapPanelHeader — title",
-    fragment: '{mapLoc() ? mapLoc()!.replace(/_/g, " ") : `Slovenija — vseh ${era5Stations.length} postaj`}',
+    fragment: '{mapLoc() ? mapLoc()!.replace(/_/g, " ") : t("map.panel_title_all", { count: era5Stations.length })}',
   },
   {
     file: PAGE_SRC,
-    cite: "AliJeVroceERA5.tsx:143",
+    cite: "AliJeVroceERA5.tsx:158",
     mirror: "harness.tsx MapPanelHeader — station count",
-    fragment: "{era5Stations.length} postaj · ERA5 </div>",
+    fragment: 't("map.panel_sub_count", { count: era5Stations.length })',
   },
 ];
 

--- a/tests/fixtures/snapshot.json
+++ b/tests/fixtures/snapshot.json
@@ -78,9 +78,9 @@
       "name": "Slovenija",
       "default_location": "Ljubljana",
       "languages": [
-        "en"
+        "sl"
       ],
-      "default_language": "en",
+      "default_language": "sl",
       "map": {
         "center_lat": 46.1,
         "center_lon": 14.8,
@@ -3287,7 +3287,7 @@
         "station": "Celje",
         "period": "Summer",
         "rendered": [
-          "Theil-Sen naklon: -0.026 SPEI/desetletje · Mann-Kendall: no trend · ni statistično značilen (p = 0.204). Negativen trend pomeni, da razmere postajajo sušnejše glede na osnovno obdobje 1950–1980."
+          "Theil-Sen naklon: −0,026 SPEI/desetletje · Mann-Kendall: no trend · ni statistično značilen (p = 0,204). Negativen trend pomeni, da razmere postajajo sušnejše glede na osnovno obdobje 1950–1980."
         ]
       },
       "trends": {
@@ -17256,11 +17256,11 @@
           ]
         },
         "rendered": {
-          "title": "Year-round trend · Ljubljana",
+          "title": "Celoletni trend · Ljubljana",
           "legend": [
-            "Warming",
-            "Cooling",
-            "opacity = significance · p < 0.001 fully opaque"
+            "Segrevanje",
+            "Ohlajanje",
+            "prosojnost = značilnost · p < 0,001 povsem neprosojno"
           ]
         },
         "charts": [
@@ -20074,8 +20074,8 @@
           "header": "Tropski dnevi · Ljubljana",
           "coverage": "77 let · 48 z vrednostjo > 0",
           "paragraphs": [
-            "NB GLM: +3.32%/leto · +1.6 dni/desetletje · 95% CI · statistično značilen (p < 0.001) · AIC 387 · α=2.059.",
-            "Tropski dan — ko dnevna temperatura preseže 30 °C — povečuje toplotni stres in zdravstvena tveganja. Postaja Ljubljana kaže statistično značilen trend: grobe 1.6 več dni na desetletje. Če trend nadaljuje, bi bilo do 2050 tipičnih okoli 34 dni na leto."
+            "NB GLM: +3,32%/leto · +1,6 dni/desetletje · 95% CI · statistično značilen (p < 0,001) · AIC 387 · α=2.059.",
+            "Tropski dan — ko dnevna temperatura preseže 30 °C — povečuje toplotni stres in zdravstvena tveganja. Postaja Ljubljana kaže statistično značilen trend: grobe 1,6 več dni na desetletje. Če trend nadaljuje, bi bilo do 2050 tipičnih okoli 34 dni na leto."
           ]
         },
         "current_year_bar": {
@@ -21216,7 +21216,7 @@
                 ]
               },
               {
-                "name": "NB fit (+1.6 dni/des · p < 0.001)",
+                "name": "NB fit (+1,6 dni/des · p < 0,001)",
                 "type": "line",
                 "data": [
                   {
@@ -22107,8 +22107,8 @@
           "header": "Tropske noči · Ljubljana",
           "coverage": "77 let · 27 z vrednostjo > 0",
           "paragraphs": [
-            "NB GLM: +2.94%/leto · +0.4 noči/desetletje · 95% CI · statistično značilen (p < 0.01) · AIC 216 · α=3.5.",
-            "Tropska noč — ko temperatura čez noč ostane nad 20 °C — preprečuje telesu okrevanje po dnevni vročini. Postaja Ljubljana kaže statistično značilen trend: grobe 0.4 več noči na desetletje. Če trend nadaljuje, bi bilo do 2050 tipičnih okoli 7 noči na leto."
+            "NB GLM: +2,94%/leto · +0,4 noči/desetletje · 95% CI · statistično značilen (p < 0,01) · AIC 216 · α=3.5.",
+            "Tropska noč — ko temperatura čez noč ostane nad 20 °C — preprečuje telesu okrevanje po dnevni vročini. Postaja Ljubljana kaže statistično značilen trend: grobe 0,4 več noči na desetletje. Če trend nadaljuje, bi bilo do 2050 tipičnih okoli 7 noči na leto."
           ]
         },
         "current_year_bar": {
@@ -23249,7 +23249,7 @@
                 ]
               },
               {
-                "name": "NB fit (+0.4 noči/des · p < 0.01)",
+                "name": "NB fit (+0,4 noči/des · p < 0,01)",
                 "type": "line",
                 "data": [
                   {
@@ -27839,11 +27839,11 @@
           ]
         },
         "rendered": {
-          "title": "Year-round trend · Kredarica",
+          "title": "Celoletni trend · Kredarica",
           "legend": [
-            "Warming",
-            "Cooling",
-            "opacity = significance · p < 0.001 fully opaque"
+            "Segrevanje",
+            "Ohlajanje",
+            "prosojnost = značilnost · p < 0,001 povsem neprosojno"
           ]
         },
         "charts": [
@@ -31856,7 +31856,7 @@
           }
         },
         "rendered": {
-          "date_badge": "21.07.",
+          "date_badge": "21. jul.",
           "loc_select": {
             "selected": "era5:national",
             "options": [
@@ -31883,13 +31883,13 @@
           },
           "category_label": "Normalno",
           "category_color": "rgb(231, 217, 184)",
-          "description": "Točno takšno, kot 21.07 v Slovenija ponavadi je.",
+          "description": "Točno takšno, kot 21. jul. v Slovenija ponavadi je.",
           "percentile": "46",
           "percentile_label": "percentil",
-          "samples": "20,520 vzorcev",
+          "samples": "20.520 vzorcev",
           "preliminary_badge": "napoved",
           "explain": "Povprečje najvišjih dnevnih temperatur 18 slovenskih postaj (nadmorska višina 10–2514 m), razvrščeno glede na zapise ERA5-Land od leta 1950 za isto ±7-dnevno okno.",
-          "footer": "24.6 °C · 46. percentil · 20,520 vzorcev (1950–2026)",
+          "footer": "24,6 °C · 46. percentil · 20.520 vzorcev (1950–2026)",
           "unavailable_message": null
         },
         "last7": {
@@ -31974,7 +31974,7 @@
                 {
                   "id": null,
                   "value": 24.6,
-                  "label": "DANES: 24.6 °C",
+                  "label": "DANES: 24,6 °C",
                   "dash_style": null
                 }
               ],
@@ -31982,27 +31982,27 @@
                 {
                   "from": -2.80558,
                   "to": 19.805,
-                  "label": "< 19.8°C"
+                  "label": "< 19,8°C"
                 },
                 {
                   "from": 19.805,
                   "to": 21.371111111111112,
-                  "label": "19.8–21.4°C"
+                  "label": "19,8–21,4°C"
                 },
                 {
                   "from": 21.371111111111112,
                   "to": 27.54055555555556,
-                  "label": "21.4–27.5°C"
+                  "label": "21,4–27,5°C"
                 },
                 {
                   "from": 27.54055555555556,
                   "to": 30.17666666666667,
-                  "label": "27.5–30.2°C"
+                  "label": "27,5–30,2°C"
                 },
                 {
                   "from": 30.17666666666667,
                   "to": 41.87458,
-                  "label": "> 30.2°C"
+                  "label": "> 30,2°C"
                 }
               ]
             },
@@ -32840,9 +32840,9 @@
       },
       "today_chart_copy": {
         "_note": "Raw JSX in AliJeVroceERA5.tsx:99-112, mirrored by TodayChartCopy in harness.tsx and checked against the source by main.mjs assertMirroredCopy.",
-        "title": "Dnevne najvišje temperature v Sloveniji za dva tedna okoli 21.07 od 1950",
+        "title": "Dnevne najvišje temperature v Sloveniji za dva tedna okoli 21. jul. od 1950",
         "explain": "Krivulja prikazuje, kako pogosto se je pojavila vsaka vrhunska temperatura na dneve, kot je danes, v vseh letih. Barve označujejo klimatološke cone — od hladne modre prek tipičnega bežastega pasu do ekstremne rdeče.",
-        "footer": "Slovenija: 24.6 °C · 46. percentil · mediana 24.5 °C · 20,520 opazovanj · 1950–2026"
+        "footer": "Slovenija: 24,6 °C · 46. percentil · mediana 24,5 °C · 20.520 opazovanj · 1950–2026"
       },
       "today_trend": {
         "api": {
@@ -33204,9 +33204,9 @@
           ]
         },
         "rendered": {
-          "title": "Najvišje temperature v Sloveniji okoli Jul 21 · 1950–2026 · trend s projekcijo do 2050",
-          "explain": "Vsaka pika je 90. percentil nacionalne povprečne dnevne najvišje temperature vseh 18 postaj v ±30-dnevnem oknu okoli tega datuma za vsako leto od 1950. Trend Theil-Sen je +0.45 °C/desetletje (p < 0.001). Po tem tempu projekcija kaže 26.7 °C do leta 2050. Zasenčeni pas je 95% interval zaupanja za nagib.",
-          "footer": "Theil-Sen + TFPW MK: +0.45 °C/desetletje · p < 0.001 · τ = 0.426 · 95% CI · 77 let",
+          "title": "Najvišje temperature v Sloveniji okoli 21. jul. · 1950–2026 · trend s projekcijo do 2050",
+          "explain": "Vsaka pika je 90. percentil nacionalne povprečne dnevne najvišje temperature vseh 18 postaj v ±30-dnevnem oknu okoli tega datuma za vsako leto od 1950. Trend Theil-Sen je +0,45 °C/desetletje (p < 0,001). Po tem tempu projekcija kaže 26,7 °C do leta 2050. Zasenčeni pas je 95% interval zaupanja za nagib.",
+          "footer": "Theil-Sen + TFPW MK: +0,45 °C/desetletje · p < 0,001 · τ = 0,426 · 95% CI · 77 let",
           "current_year_plotline": {
             "value": 2026,
             "label": "2026",
@@ -33644,25 +33644,25 @@
       "analysis": {
         "rendered": {
           "toolbar": [
-            "LocationLjubljana",
-            "VariableMax temperature (°C)Min temperature (°C)Mean temperature (°C)Precipitation (mm)ET₀ (mm)",
-            "Day21 Jul◀▶"
+            "LokacijaLjubljana",
+            "SpremenljivkaNajvišja temperatura (°C)Najnižja temperatura (°C)Povprečna temperatura (°C)Padavine (mm)ET₀ (mm)",
+            "Dan21. jul.◀▶"
           ],
           "variable_select": {
             "selected": "temperature_max",
             "options": [
-              "Max temperature (°C)",
-              "Min temperature (°C)",
-              "Mean temperature (°C)",
-              "Precipitation (mm)",
+              "Najvišja temperatura (°C)",
+              "Najnižja temperatura (°C)",
+              "Povprečna temperatura (°C)",
+              "Padavine (mm)",
               "ET₀ (mm)"
             ]
           },
-          "day_label": "21 Jul",
-          "title": "Max temperature · 21 Jul",
+          "day_label": "21. jul.",
+          "title": "Najvišja temperatura · 21. jul.",
           "subtitle": "Ljubljana",
-          "stats_badge": "Theil-Sen + TFPW MK · τ = 0.46",
-          "total_change": "+4.25°C",
+          "stats_badge": "Theil-Sen + TFPW MK · τ = 0,46",
+          "total_change": "+4,25°C",
           "total_change_color": "rgb(204, 34, 34)",
           "footer": [
             "Theil-Sen regresija + Yue-Wang TFPW Mann-Kendall test · ERA5-Land · nadmorska korekcija"
@@ -33682,7 +33682,7 @@
               "plot_bands": []
             },
             "y_axis": {
-              "title": "Max temperature (°C)",
+              "title": "Najvišja temperatura (°C)",
               "min": null,
               "max": null,
               "categories": null,
@@ -33690,7 +33690,7 @@
                 {
                   "id": "baseline-Ljubljana",
                   "value": 25.39366666666667,
-                  "label": "77-YR MEAN 25.4",
+                  "label": "POVPREČJE 77 let: 25,4",
                   "dash_style": "Dash"
                 }
               ],
@@ -34359,18 +34359,18 @@
       },
       "hero_cards": {
         "rendered": {
-          "headline": "+0.552",
+          "headline": "+0,552",
           "headline_color": "rgb(194, 90, 44)",
           "category": "Katastrofalno",
           "paragraphs": [
             "Podaljšani poletni vročinski valovi presegajo hladilne zmogljivosti mesta. Hudourniške poplave iz okrepljenih alpskih padavin večkrat ogrozijo nizko ležečo kotlino.",
-            "Sto let segrevanja za +5.52 °C – pri trenutnem tempu vsaka 18.1 let doda eno stopinjo.",
+            "Sto let segrevanja za +5,52 °C – pri trenutnem tempu vsaka 18,1 let doda eno stopinjo.",
             "Theil-Sen + TFPW Mann-Kendall"
           ],
           "stats": [
             "Mestni toplotni otok — poletni vročinski stres in tveganje hudourniških poplav v Ljubljanski kotlini",
-            "★★★ p < 0.001",
-            "0.5520",
+            "★★★ p < 0,001",
+            "0,5520",
             "77 let",
             "—"
           ]
@@ -35214,7 +35214,7 @@
           }
         },
         "rendered": {
-          "date_badge": "21.07.",
+          "date_badge": "21. jul.",
           "loc_select": {
             "selected": "Ljubljana",
             "options": [
@@ -35241,13 +35241,13 @@
           },
           "category_label": "Normalno",
           "category_color": "rgb(231, 217, 184)",
-          "description": "Točno takšno, kot 21.07 v Slovenija ponavadi je.",
+          "description": "Točno takšno, kot 21. jul. v Slovenija ponavadi je.",
           "percentile": "61",
           "percentile_label": "percentil",
-          "samples": "1,140 vzorcev",
+          "samples": "1140 vzorcev",
           "preliminary_badge": "napoved",
           "explain": "Temperatura na postaji Ljubljana, razvrstena glede na zapise ERA5-Land od leta 1950 za isto ±7-dnevno okno.",
-          "footer": "26.0 °C · 61. percentil · 1,140 vzorcev (1950–2026)",
+          "footer": "26,0 °C · 61. percentil · 1140 vzorcev (1950–2026)",
           "unavailable_message": null
         },
         "last7": {
@@ -35523,7 +35523,7 @@
                 {
                   "id": null,
                   "value": 26,
-                  "label": "DANES: 26.0 °C",
+                  "label": "DANES: 26,0 °C",
                   "dash_style": null
                 }
               ],
@@ -35531,27 +35531,27 @@
                 {
                   "from": 11.18618,
                   "to": 20.24,
-                  "label": "< 20.2°C"
+                  "label": "< 20,2°C"
                 },
                 {
                   "from": 20.24,
                   "to": 21.78,
-                  "label": "20.2–21.8°C"
+                  "label": "20,2–21,8°C"
                 },
                 {
                   "from": 21.78,
                   "to": 28.16,
-                  "label": "21.8–28.2°C"
+                  "label": "21,8–28,2°C"
                 },
                 {
                   "from": 28.16,
                   "to": 31.19,
-                  "label": "28.2–31.2°C"
+                  "label": "28,2–31,2°C"
                 },
                 {
                   "from": 31.19,
                   "to": 39.91082,
-                  "label": "> 31.2°C"
+                  "label": "> 31,2°C"
                 }
               ]
             },
@@ -36389,9 +36389,9 @@
       },
       "today_chart_copy": {
         "_note": "Raw JSX in AliJeVroceERA5.tsx:99-112, mirrored by TodayChartCopy in harness.tsx and checked against the source by main.mjs assertMirroredCopy.",
-        "title": "Dnevne najvišje temperature na postaji Ljubljana za dva tedna okoli 21.07 od 1950",
+        "title": "Dnevne najvišje temperature na postaji Ljubljana za dva tedna okoli 21. jul. od 1950",
         "explain": "Krivulja prikazuje, kako pogosto se je pojavila vsaka vrhunska temperatura na dneve, kot je danes, v vseh letih. Barve označujejo klimatološke cone — od hladne modre prek tipičnega bežastega pasu do ekstremne rdeče.",
-        "footer": "Danes: 26.0 °C · 61. percentil · mediana 24.9 °C · 1,140 opazovanj · 1950–2026"
+        "footer": "Danes: 26,0 °C · 61. percentil · mediana 24,9 °C · 1140 opazovanj · 1950–2026"
       },
       "today_trend": {
         "api": {
@@ -36753,9 +36753,9 @@
           ]
         },
         "rendered": {
-          "title": "Najvišje temperature na postaji Ljubljana okoli Jul 21 · 1950–2026 · trend s projekcijo do 2050",
-          "explain": "Vsaka pika je 90. percentil lapsno popravljene dnevne najvišje temperature na postaji Ljubljana v ±30-dnevnem oknu okoli tega datuma za vsako leto od 1950. Trend Theil-Sen je +0.55 °C/desetletje (p < 0.001). Po tem tempu projekcija kaže 27.6 °C do leta 2050. Zasenčeni pas je 95% interval zaupanja za nagib.",
-          "footer": "Theil-Sen + TFPW MK: +0.55 °C/desetletje · p < 0.001 · τ = 0.457 · 95% CI · 77 let",
+          "title": "Najvišje temperature na postaji Ljubljana okoli 21. jul. · 1950–2026 · trend s projekcijo do 2050",
+          "explain": "Vsaka pika je 90. percentil lapsno popravljene dnevne najvišje temperature na postaji Ljubljana v ±30-dnevnem oknu okoli tega datuma za vsako leto od 1950. Trend Theil-Sen je +0,55 °C/desetletje (p < 0,001). Po tem tempu projekcija kaže 27,6 °C do leta 2050. Zasenčeni pas je 95% interval zaupanja za nagib.",
+          "footer": "Theil-Sen + TFPW MK: +0,55 °C/desetletje · p < 0,001 · τ = 0,457 · 95% CI · 77 let",
           "current_year_plotline": {
             "value": 2026,
             "label": "2026",
@@ -37193,25 +37193,25 @@
       "analysis": {
         "rendered": {
           "toolbar": [
-            "LocationLjubljana",
-            "VariableMax temperature (°C)Min temperature (°C)Mean temperature (°C)Precipitation (mm)ET₀ (mm)",
-            "Day21 Jul◀▶"
+            "LokacijaLjubljana",
+            "SpremenljivkaNajvišja temperatura (°C)Najnižja temperatura (°C)Povprečna temperatura (°C)Padavine (mm)ET₀ (mm)",
+            "Dan21. jul.◀▶"
           ],
           "variable_select": {
             "selected": "temperature_max",
             "options": [
-              "Max temperature (°C)",
-              "Min temperature (°C)",
-              "Mean temperature (°C)",
-              "Precipitation (mm)",
+              "Najvišja temperatura (°C)",
+              "Najnižja temperatura (°C)",
+              "Povprečna temperatura (°C)",
+              "Padavine (mm)",
               "ET₀ (mm)"
             ]
           },
-          "day_label": "21 Jul",
-          "title": "Max temperature · 21 Jul",
+          "day_label": "21. jul.",
+          "title": "Najvišja temperatura · 21. jul.",
           "subtitle": "Ljubljana",
-          "stats_badge": "Theil-Sen + TFPW MK · τ = 0.46",
-          "total_change": "+4.25°C",
+          "stats_badge": "Theil-Sen + TFPW MK · τ = 0,46",
+          "total_change": "+4,25°C",
           "total_change_color": "rgb(204, 34, 34)",
           "footer": [
             "Theil-Sen regresija + Yue-Wang TFPW Mann-Kendall test · ERA5-Land · nadmorska korekcija"
@@ -37231,7 +37231,7 @@
               "plot_bands": []
             },
             "y_axis": {
-              "title": "Max temperature (°C)",
+              "title": "Najvišja temperatura (°C)",
               "min": null,
               "max": null,
               "categories": null,
@@ -37239,7 +37239,7 @@
                 {
                   "id": "baseline-Ljubljana",
                   "value": 25.39366666666667,
-                  "label": "77-YR MEAN 25.4",
+                  "label": "POVPREČJE 77 let: 25,4",
                   "dash_style": "Dash"
                 }
               ],
@@ -37908,18 +37908,18 @@
       },
       "hero_cards": {
         "rendered": {
-          "headline": "+0.552",
+          "headline": "+0,552",
           "headline_color": "rgb(194, 90, 44)",
           "category": "Katastrofalno",
           "paragraphs": [
             "Podaljšani poletni vročinski valovi presegajo hladilne zmogljivosti mesta. Hudourniške poplave iz okrepljenih alpskih padavin večkrat ogrozijo nizko ležečo kotlino.",
-            "Sto let segrevanja za +5.52 °C – pri trenutnem tempu vsaka 18.1 let doda eno stopinjo.",
+            "Sto let segrevanja za +5,52 °C – pri trenutnem tempu vsaka 18,1 let doda eno stopinjo.",
             "Theil-Sen + TFPW Mann-Kendall"
           ],
           "stats": [
             "Mestni toplotni otok — poletni vročinski stres in tveganje hudourniških poplav v Ljubljanski kotlini",
-            "★★★ p < 0.001",
-            "0.5520",
+            "★★★ p < 0,001",
+            "0,5520",
             "77 let",
             "—"
           ]
@@ -38763,7 +38763,7 @@
           }
         },
         "rendered": {
-          "date_badge": "21.07.",
+          "date_badge": "21. jul.",
           "loc_select": {
             "selected": "Kredarica",
             "options": [
@@ -38790,13 +38790,13 @@
           },
           "category_label": "Hladno",
           "category_color": "rgb(108, 143, 182)",
-          "description": "Hladneje od večine izmerjenih 21.07.",
+          "description": "Hladneje od večine izmerjenih 21. jul..",
           "percentile": "14",
           "percentile_label": "percentil",
-          "samples": "1,140 vzorcev",
+          "samples": "1140 vzorcev",
           "preliminary_badge": "napoved",
           "explain": "Temperatura na postaji Kredarica, razvrstena glede na zapise ERA5-Land od leta 1950 za isto ±7-dnevno okno.",
-          "footer": "7.1 °C · 14. percentil · 1,140 vzorcev (1950–2026)",
+          "footer": "7,1 °C · 14. percentil · 1140 vzorcev (1950–2026)",
           "unavailable_message": null
         },
         "last7": {
@@ -39072,7 +39072,7 @@
                 {
                   "id": null,
                   "value": 7.1,
-                  "label": "DANES: 7.1 °C",
+                  "label": "DANES: 7,1 °C",
                   "dash_style": null
                 }
               ],
@@ -39080,27 +39080,27 @@
                 {
                   "from": -1.8705999999999998,
                   "to": 6.34,
-                  "label": "< 6.3°C"
+                  "label": "< 6,3°C"
                 },
                 {
                   "from": 6.34,
                   "to": 8.04,
-                  "label": "6.3–8.0°C"
+                  "label": "6,3–8,0°C"
                 },
                 {
                   "from": 8.04,
                   "to": 13.99,
-                  "label": "8.0–14.0°C"
+                  "label": "8,0–14,0°C"
                 },
                 {
                   "from": 13.99,
                   "to": 16.55,
-                  "label": "14.0–16.6°C"
+                  "label": "14,0–16,6°C"
                 },
                 {
                   "from": 16.55,
                   "to": 25.3566,
-                  "label": "> 16.6°C"
+                  "label": "> 16,6°C"
                 }
               ]
             },
@@ -39938,9 +39938,9 @@
       },
       "today_chart_copy": {
         "_note": "Raw JSX in AliJeVroceERA5.tsx:99-112, mirrored by TodayChartCopy in harness.tsx and checked against the source by main.mjs assertMirroredCopy.",
-        "title": "Dnevne najvišje temperature na postaji Kredarica za dva tedna okoli 21.07 od 1950",
+        "title": "Dnevne najvišje temperature na postaji Kredarica za dva tedna okoli 21. jul. od 1950",
         "explain": "Krivulja prikazuje, kako pogosto se je pojavila vsaka vrhunska temperatura na dneve, kot je danes, v vseh letih. Barve označujejo klimatološke cone — od hladne modre prek tipičnega bežastega pasu do ekstremne rdeče.",
-        "footer": "Danes: 7.1 °C · 14. percentil · mediana 11.2 °C · 1,140 opazovanj · 1950–2026"
+        "footer": "Danes: 7,1 °C · 14. percentil · mediana 11,2 °C · 1140 opazovanj · 1950–2026"
       },
       "today_trend": {
         "api": {
@@ -40302,9 +40302,9 @@
           ]
         },
         "rendered": {
-          "title": "Najvišje temperature na postaji Kredarica okoli Jul 21 · 1950–2026 · trend s projekcijo do 2050",
-          "explain": "Vsaka pika je 90. percentil lapsno popravljene dnevne najvišje temperature na postaji Kredarica v ±30-dnevnem oknu okoli tega datuma za vsako leto od 1950. Trend Theil-Sen je +0.35 °C/desetletje (p < 0.001). Po tem tempu projekcija kaže 13.0 °C do leta 2050. Zasenčeni pas je 95% interval zaupanja za nagib.",
-          "footer": "Theil-Sen + TFPW MK: +0.35 °C/desetletje · p < 0.001 · τ = 0.403 · 95% CI · 77 let",
+          "title": "Najvišje temperature na postaji Kredarica okoli 21. jul. · 1950–2026 · trend s projekcijo do 2050",
+          "explain": "Vsaka pika je 90. percentil lapsno popravljene dnevne najvišje temperature na postaji Kredarica v ±30-dnevnem oknu okoli tega datuma za vsako leto od 1950. Trend Theil-Sen je +0,35 °C/desetletje (p < 0,001). Po tem tempu projekcija kaže 13,0 °C do leta 2050. Zasenčeni pas je 95% interval zaupanja za nagib.",
+          "footer": "Theil-Sen + TFPW MK: +0,35 °C/desetletje · p < 0,001 · τ = 0,403 · 95% CI · 77 let",
           "current_year_plotline": {
             "value": 2026,
             "label": "2026",
@@ -40742,25 +40742,25 @@
       "analysis": {
         "rendered": {
           "toolbar": [
-            "LocationKredarica",
-            "VariableMax temperature (°C)Min temperature (°C)Mean temperature (°C)Precipitation (mm)ET₀ (mm)",
-            "Day21 Jul◀▶"
+            "LokacijaKredarica",
+            "SpremenljivkaNajvišja temperatura (°C)Najnižja temperatura (°C)Povprečna temperatura (°C)Padavine (mm)ET₀ (mm)",
+            "Dan21. jul.◀▶"
           ],
           "variable_select": {
             "selected": "temperature_max",
             "options": [
-              "Max temperature (°C)",
-              "Min temperature (°C)",
-              "Mean temperature (°C)",
-              "Precipitation (mm)",
+              "Najvišja temperatura (°C)",
+              "Najnižja temperatura (°C)",
+              "Povprečna temperatura (°C)",
+              "Padavine (mm)",
               "ET₀ (mm)"
             ]
           },
-          "day_label": "21 Jul",
-          "title": "Max temperature · 21 Jul",
+          "day_label": "21. jul.",
+          "title": "Najvišja temperatura · 21. jul.",
           "subtitle": "Kredarica",
-          "stats_badge": "Theil-Sen + TFPW MK · τ = 0.40",
-          "total_change": "+2.73°C",
+          "stats_badge": "Theil-Sen + TFPW MK · τ = 0,40",
+          "total_change": "+2,73°C",
           "total_change_color": "rgb(204, 34, 34)",
           "footer": [
             "Theil-Sen regresija + Yue-Wang TFPW Mann-Kendall test · ERA5-Land · nadmorska korekcija"
@@ -40780,7 +40780,7 @@
               "plot_bands": []
             },
             "y_axis": {
-              "title": "Max temperature (°C)",
+              "title": "Najvišja temperatura (°C)",
               "min": null,
               "max": null,
               "categories": null,
@@ -40788,7 +40788,7 @@
                 {
                   "id": "baseline-Kredarica",
                   "value": 11.395,
-                  "label": "77-YR MEAN 11.4",
+                  "label": "POVPREČJE 77 let: 11,4",
                   "dash_style": "Dash"
                 }
               ],
@@ -41457,18 +41457,18 @@
       },
       "hero_cards": {
         "rendered": {
-          "headline": "+0.355",
+          "headline": "+0,355",
           "headline_color": "rgb(194, 90, 44)",
           "category": "Katastrofalno",
           "paragraphs": [
             "Popolna izguba Triglavskega ledenika — narodni simbol in vir savinjskih rek. Propad alpskega ekosistema sproži kaskadne učinke.",
-            "Sto let segrevanja za +3.55 °C – pri trenutnem tempu vsaka 28.2 let doda eno stopinjo.",
+            "Sto let segrevanja za +3,55 °C – pri trenutnem tempu vsaka 28,2 let doda eno stopinjo.",
             "Theil-Sen + TFPW Mann-Kendall"
           ],
           "stats": [
             "Izguba Triglavskega ledenika — izsušitev izvirnih vod za Slovenijo reke",
-            "★★★ p < 0.001",
-            "0.3550",
+            "★★★ p < 0,001",
+            "0,3550",
             "77 let",
             "—"
           ]
@@ -42312,7 +42312,7 @@
           }
         },
         "rendered": {
-          "date_badge": "15.07.",
+          "date_badge": "15. jul.",
           "loc_select": {
             "selected": "era5:national",
             "options": [
@@ -42339,13 +42339,13 @@
           },
           "category_label": "Vroče",
           "category_color": "rgb(194, 90, 44)",
-          "description": "Med najtoplejšimi 15.07 v naših zapisih.",
+          "description": "Med najtoplejšimi 15. jul. v naših zapisih.",
           "percentile": "79",
           "percentile_label": "percentil",
-          "samples": "20,520 vzorcev",
+          "samples": "20.520 vzorcev",
           "preliminary_badge": null,
           "explain": "Povprečje najvišjih dnevnih temperatur 18 slovenskih postaj (nadmorska višina 10–2514 m), razvrščeno glede na zapise ERA5-Land od leta 1950 za isto ±7-dnevno okno.",
-          "footer": "28.0 °C · 79. percentil · 20,520 vzorcev (1950–2026)",
+          "footer": "28,0 °C · 79. percentil · 20.520 vzorcev (1950–2026)",
           "unavailable_message": null
         },
         "last7": {
@@ -42430,7 +42430,7 @@
                 {
                   "id": null,
                   "value": 28,
-                  "label": "DANES: 28.0 °C",
+                  "label": "DANES: 28,0 °C",
                   "dash_style": null
                 }
               ],
@@ -42438,27 +42438,27 @@
                 {
                   "from": -3.23102,
                   "to": 19.623888888888885,
-                  "label": "< 19.6°C"
+                  "label": "< 19,6°C"
                 },
                 {
                   "from": 19.623888888888885,
                   "to": 21.18555555555556,
-                  "label": "19.6–21.2°C"
+                  "label": "19,6–21,2°C"
                 },
                 {
                   "from": 21.18555555555556,
                   "to": 27.19,
-                  "label": "21.2–27.2°C"
+                  "label": "21,2–27,2°C"
                 },
                 {
                   "from": 27.19,
                   "to": 29.877777777777776,
-                  "label": "27.2–29.9°C"
+                  "label": "27,2–29,9°C"
                 },
                 {
                   "from": 29.877777777777776,
                   "to": 40.46802,
-                  "label": "> 29.9°C"
+                  "label": "> 29,9°C"
                 }
               ]
             },
@@ -43296,9 +43296,9 @@
       },
       "today_chart_copy": {
         "_note": "Raw JSX in AliJeVroceERA5.tsx:99-112, mirrored by TodayChartCopy in harness.tsx and checked against the source by main.mjs assertMirroredCopy.",
-        "title": "Dnevne najvišje temperature v Sloveniji za dva tedna okoli 15.07 od 1950",
+        "title": "Dnevne najvišje temperature v Sloveniji za dva tedna okoli 15. jul. od 1950",
         "explain": "Krivulja prikazuje, kako pogosto se je pojavila vsaka vrhunska temperatura na dneve, kot je danes, v vseh letih. Barve označujejo klimatološke cone — od hladne modre prek tipičnega bežastega pasu do ekstremne rdeče.",
-        "footer": "Slovenija: 28.0 °C · 79. percentil · mediana 24.2 °C · 20,520 opazovanj · 1950–2026"
+        "footer": "Slovenija: 28,0 °C · 79. percentil · mediana 24,2 °C · 20.520 opazovanj · 1950–2026"
       },
       "today_trend": {
         "api": {
@@ -43660,9 +43660,9 @@
           ]
         },
         "rendered": {
-          "title": "Najvišje temperature v Sloveniji okoli Jul 15 · 1950–2026 · trend s projekcijo do 2050",
-          "explain": "Vsaka pika je 90. percentil nacionalne povprečne dnevne najvišje temperature vseh 18 postaj v ±30-dnevnem oknu okoli tega datuma za vsako leto od 1950. Trend Theil-Sen je +0.42 °C/desetletje (p < 0.001). Po tem tempu projekcija kaže 26.3 °C do leta 2050. Zasenčeni pas je 95% interval zaupanja za nagib.",
-          "footer": "Theil-Sen + TFPW MK: +0.42 °C/desetletje · p < 0.001 · τ = 0.401 · 95% CI · 77 let",
+          "title": "Najvišje temperature v Sloveniji okoli 15. jul. · 1950–2026 · trend s projekcijo do 2050",
+          "explain": "Vsaka pika je 90. percentil nacionalne povprečne dnevne najvišje temperature vseh 18 postaj v ±30-dnevnem oknu okoli tega datuma za vsako leto od 1950. Trend Theil-Sen je +0,42 °C/desetletje (p < 0,001). Po tem tempu projekcija kaže 26,3 °C do leta 2050. Zasenčeni pas je 95% interval zaupanja za nagib.",
+          "footer": "Theil-Sen + TFPW MK: +0,42 °C/desetletje · p < 0,001 · τ = 0,401 · 95% CI · 77 let",
           "current_year_plotline": {
             "value": 2026,
             "label": "2026",
@@ -44100,25 +44100,25 @@
       "analysis": {
         "rendered": {
           "toolbar": [
-            "LocationLjubljana",
-            "VariableMax temperature (°C)Min temperature (°C)Mean temperature (°C)Precipitation (mm)ET₀ (mm)",
-            "Day15 Jul◀▶"
+            "LokacijaLjubljana",
+            "SpremenljivkaNajvišja temperatura (°C)Najnižja temperatura (°C)Povprečna temperatura (°C)Padavine (mm)ET₀ (mm)",
+            "Dan15. jul.◀▶"
           ],
           "variable_select": {
             "selected": "temperature_max",
             "options": [
-              "Max temperature (°C)",
-              "Min temperature (°C)",
-              "Mean temperature (°C)",
-              "Precipitation (mm)",
+              "Najvišja temperatura (°C)",
+              "Najnižja temperatura (°C)",
+              "Povprečna temperatura (°C)",
+              "Padavine (mm)",
               "ET₀ (mm)"
             ]
           },
-          "day_label": "15 Jul",
-          "title": "Max temperature · 15 Jul",
+          "day_label": "15. jul.",
+          "title": "Najvišja temperatura · 15. jul.",
           "subtitle": "Ljubljana",
-          "stats_badge": "Theil-Sen + TFPW MK · τ = 0.43",
-          "total_change": "+3.83°C",
+          "stats_badge": "Theil-Sen + TFPW MK · τ = 0,43",
+          "total_change": "+3,83°C",
           "total_change_color": "rgb(204, 34, 34)",
           "footer": [
             "Theil-Sen regresija + Yue-Wang TFPW Mann-Kendall test · ERA5-Land · nadmorska korekcija"
@@ -44138,7 +44138,7 @@
               "plot_bands": []
             },
             "y_axis": {
-              "title": "Max temperature (°C)",
+              "title": "Najvišja temperatura (°C)",
               "min": null,
               "max": null,
               "categories": null,
@@ -44146,7 +44146,7 @@
                 {
                   "id": "baseline-Ljubljana",
                   "value": 25.18466666666667,
-                  "label": "77-YR MEAN 25.2",
+                  "label": "POVPREČJE 77 let: 25,2",
                   "dash_style": "Dash"
                 }
               ],
@@ -44815,18 +44815,18 @@
       },
       "hero_cards": {
         "rendered": {
-          "headline": "+0.497",
+          "headline": "+0,497",
           "headline_color": "rgb(194, 90, 44)",
           "category": "Katastrofalno",
           "paragraphs": [
             "Podaljšani poletni vročinski valovi presegajo hladilne zmogljivosti mesta. Hudourniške poplave iz okrepljenih alpskih padavin večkrat ogrozijo nizko ležečo kotlino.",
-            "Sto let segrevanja za +4.97 °C – pri trenutnem tempu vsaka 20.1 let doda eno stopinjo.",
+            "Sto let segrevanja za +4,97 °C – pri trenutnem tempu vsaka 20,1 let doda eno stopinjo.",
             "Theil-Sen + TFPW Mann-Kendall"
           ],
           "stats": [
             "Mestni toplotni otok — poletni vročinski stres in tveganje hudourniških poplav v Ljubljanski kotlini",
-            "★★★ p < 0.001",
-            "0.4970",
+            "★★★ p < 0,001",
+            "0,4970",
             "77 let",
             "—"
           ]
@@ -45670,7 +45670,7 @@
           }
         },
         "rendered": {
-          "date_badge": "15.07.",
+          "date_badge": "15. jul.",
           "loc_select": {
             "selected": "Ljubljana",
             "options": [
@@ -45697,13 +45697,13 @@
           },
           "category_label": "Vroče",
           "category_color": "rgb(194, 90, 44)",
-          "description": "Med najtoplejšimi 15.07 v naših zapisih.",
+          "description": "Med najtoplejšimi 15. jul. v naših zapisih.",
           "percentile": "91",
           "percentile_label": "percentil",
-          "samples": "1,140 vzorcev",
+          "samples": "1140 vzorcev",
           "preliminary_badge": null,
           "explain": "Temperatura na postaji Ljubljana, razvrstena glede na zapise ERA5-Land od leta 1950 za isto ±7-dnevno okno.",
-          "footer": "29.7 °C · 91. percentil · 1,140 vzorcev (1950–2026)",
+          "footer": "29,7 °C · 91. percentil · 1140 vzorcev (1950–2026)",
           "unavailable_message": null
         },
         "last7": {
@@ -45979,7 +45979,7 @@
                 {
                   "id": null,
                   "value": 29.656,
-                  "label": "DANES: 29.7 °C",
+                  "label": "DANES: 29,7 °C",
                   "dash_style": null
                 }
               ],
@@ -45987,27 +45987,27 @@
                 {
                   "from": 10.78698,
                   "to": 20.03,
-                  "label": "< 20.0°C"
+                  "label": "< 20,0°C"
                 },
                 {
                   "from": 20.03,
                   "to": 21.58,
-                  "label": "20.0–21.6°C"
+                  "label": "20,0–21,6°C"
                 },
                 {
                   "from": 21.58,
                   "to": 27.7,
-                  "label": "21.6–27.7°C"
+                  "label": "21,6–27,7°C"
                 },
                 {
                   "from": 27.7,
                   "to": 30.96,
-                  "label": "27.7–31.0°C"
+                  "label": "27,7–31,0°C"
                 },
                 {
                   "from": 30.96,
                   "to": 37.91002,
-                  "label": "> 31.0°C"
+                  "label": "> 31,0°C"
                 }
               ]
             },
@@ -46845,9 +46845,9 @@
       },
       "today_chart_copy": {
         "_note": "Raw JSX in AliJeVroceERA5.tsx:99-112, mirrored by TodayChartCopy in harness.tsx and checked against the source by main.mjs assertMirroredCopy.",
-        "title": "Dnevne najvišje temperature na postaji Ljubljana za dva tedna okoli 15.07 od 1950",
+        "title": "Dnevne najvišje temperature na postaji Ljubljana za dva tedna okoli 15. jul. od 1950",
         "explain": "Krivulja prikazuje, kako pogosto se je pojavila vsaka vrhunska temperatura na dneve, kot je danes, v vseh letih. Barve označujejo klimatološke cone — od hladne modre prek tipičnega bežastega pasu do ekstremne rdeče.",
-        "footer": "Danes: 29.7 °C · 91. percentil · mediana 24.6 °C · 1,140 opazovanj · 1950–2026"
+        "footer": "Danes: 29,7 °C · 91. percentil · mediana 24,6 °C · 1140 opazovanj · 1950–2026"
       },
       "today_trend": {
         "api": {
@@ -47209,9 +47209,9 @@
           ]
         },
         "rendered": {
-          "title": "Najvišje temperature na postaji Ljubljana okoli Jul 15 · 1950–2026 · trend s projekcijo do 2050",
-          "explain": "Vsaka pika je 90. percentil lapsno popravljene dnevne najvišje temperature na postaji Ljubljana v ±30-dnevnem oknu okoli tega datuma za vsako leto od 1950. Trend Theil-Sen je +0.50 °C/desetletje (p < 0.001). Po tem tempu projekcija kaže 27.2 °C do leta 2050. Zasenčeni pas je 95% interval zaupanja za nagib.",
-          "footer": "Theil-Sen + TFPW MK: +0.50 °C/desetletje · p < 0.001 · τ = 0.431 · 95% CI · 77 let",
+          "title": "Najvišje temperature na postaji Ljubljana okoli 15. jul. · 1950–2026 · trend s projekcijo do 2050",
+          "explain": "Vsaka pika je 90. percentil lapsno popravljene dnevne najvišje temperature na postaji Ljubljana v ±30-dnevnem oknu okoli tega datuma za vsako leto od 1950. Trend Theil-Sen je +0,50 °C/desetletje (p < 0,001). Po tem tempu projekcija kaže 27,2 °C do leta 2050. Zasenčeni pas je 95% interval zaupanja za nagib.",
+          "footer": "Theil-Sen + TFPW MK: +0,50 °C/desetletje · p < 0,001 · τ = 0,431 · 95% CI · 77 let",
           "current_year_plotline": {
             "value": 2026,
             "label": "2026",
@@ -47649,25 +47649,25 @@
       "analysis": {
         "rendered": {
           "toolbar": [
-            "LocationLjubljana",
-            "VariableMax temperature (°C)Min temperature (°C)Mean temperature (°C)Precipitation (mm)ET₀ (mm)",
-            "Day15 Jul◀▶"
+            "LokacijaLjubljana",
+            "SpremenljivkaNajvišja temperatura (°C)Najnižja temperatura (°C)Povprečna temperatura (°C)Padavine (mm)ET₀ (mm)",
+            "Dan15. jul.◀▶"
           ],
           "variable_select": {
             "selected": "temperature_max",
             "options": [
-              "Max temperature (°C)",
-              "Min temperature (°C)",
-              "Mean temperature (°C)",
-              "Precipitation (mm)",
+              "Najvišja temperatura (°C)",
+              "Najnižja temperatura (°C)",
+              "Povprečna temperatura (°C)",
+              "Padavine (mm)",
               "ET₀ (mm)"
             ]
           },
-          "day_label": "15 Jul",
-          "title": "Max temperature · 15 Jul",
+          "day_label": "15. jul.",
+          "title": "Najvišja temperatura · 15. jul.",
           "subtitle": "Ljubljana",
-          "stats_badge": "Theil-Sen + TFPW MK · τ = 0.43",
-          "total_change": "+3.83°C",
+          "stats_badge": "Theil-Sen + TFPW MK · τ = 0,43",
+          "total_change": "+3,83°C",
           "total_change_color": "rgb(204, 34, 34)",
           "footer": [
             "Theil-Sen regresija + Yue-Wang TFPW Mann-Kendall test · ERA5-Land · nadmorska korekcija"
@@ -47687,7 +47687,7 @@
               "plot_bands": []
             },
             "y_axis": {
-              "title": "Max temperature (°C)",
+              "title": "Najvišja temperatura (°C)",
               "min": null,
               "max": null,
               "categories": null,
@@ -47695,7 +47695,7 @@
                 {
                   "id": "baseline-Ljubljana",
                   "value": 25.18466666666667,
-                  "label": "77-YR MEAN 25.2",
+                  "label": "POVPREČJE 77 let: 25,2",
                   "dash_style": "Dash"
                 }
               ],
@@ -48364,18 +48364,18 @@
       },
       "hero_cards": {
         "rendered": {
-          "headline": "+0.497",
+          "headline": "+0,497",
           "headline_color": "rgb(194, 90, 44)",
           "category": "Katastrofalno",
           "paragraphs": [
             "Podaljšani poletni vročinski valovi presegajo hladilne zmogljivosti mesta. Hudourniške poplave iz okrepljenih alpskih padavin večkrat ogrozijo nizko ležečo kotlino.",
-            "Sto let segrevanja za +4.97 °C – pri trenutnem tempu vsaka 20.1 let doda eno stopinjo.",
+            "Sto let segrevanja za +4,97 °C – pri trenutnem tempu vsaka 20,1 let doda eno stopinjo.",
             "Theil-Sen + TFPW Mann-Kendall"
           ],
           "stats": [
             "Mestni toplotni otok — poletni vročinski stres in tveganje hudourniških poplav v Ljubljanski kotlini",
-            "★★★ p < 0.001",
-            "0.4970",
+            "★★★ p < 0,001",
+            "0,4970",
             "77 let",
             "—"
           ]
@@ -49219,7 +49219,7 @@
           }
         },
         "rendered": {
-          "date_badge": "15.07.",
+          "date_badge": "15. jul.",
           "loc_select": {
             "selected": "Kredarica",
             "options": [
@@ -49246,13 +49246,13 @@
           },
           "category_label": "Vroče",
           "category_color": "rgb(194, 90, 44)",
-          "description": "Med najtoplejšimi 15.07 v naših zapisih.",
+          "description": "Med najtoplejšimi 15. jul. v naših zapisih.",
           "percentile": "81",
           "percentile_label": "percentil",
-          "samples": "1,140 vzorcev",
+          "samples": "1140 vzorcev",
           "preliminary_badge": null,
           "explain": "Temperatura na postaji Kredarica, razvrstena glede na zapise ERA5-Land od leta 1950 za isto ±7-dnevno okno.",
-          "footer": "13.9 °C · 81. percentil · 1,140 vzorcev (1950–2026)",
+          "footer": "13,9 °C · 81. percentil · 1140 vzorcev (1950–2026)",
           "unavailable_message": null
         },
         "last7": {
@@ -49528,7 +49528,7 @@
                 {
                   "id": null,
                   "value": 13.904,
-                  "label": "DANES: 13.9 °C",
+                  "label": "DANES: 13,9 °C",
                   "dash_style": null
                 }
               ],
@@ -49536,27 +49536,27 @@
                 {
                   "from": -2.18696,
                   "to": 6.34,
-                  "label": "< 6.3°C"
+                  "label": "< 6,3°C"
                 },
                 {
                   "from": 6.34,
                   "to": 7.89,
-                  "label": "6.3–7.9°C"
+                  "label": "6,3–7,9°C"
                 },
                 {
                   "from": 7.89,
                   "to": 13.69,
-                  "label": "7.9–13.7°C"
+                  "label": "7,9–13,7°C"
                 },
                 {
                   "from": 13.69,
                   "to": 16.24,
-                  "label": "13.7–16.2°C"
+                  "label": "13,7–16,2°C"
                 },
                 {
                   "from": 16.24,
                   "to": 22.022959999999998,
-                  "label": "> 16.2°C"
+                  "label": "> 16,2°C"
                 }
               ]
             },
@@ -50394,9 +50394,9 @@
       },
       "today_chart_copy": {
         "_note": "Raw JSX in AliJeVroceERA5.tsx:99-112, mirrored by TodayChartCopy in harness.tsx and checked against the source by main.mjs assertMirroredCopy.",
-        "title": "Dnevne najvišje temperature na postaji Kredarica za dva tedna okoli 15.07 od 1950",
+        "title": "Dnevne najvišje temperature na postaji Kredarica za dva tedna okoli 15. jul. od 1950",
         "explain": "Krivulja prikazuje, kako pogosto se je pojavila vsaka vrhunska temperatura na dneve, kot je danes, v vseh letih. Barve označujejo klimatološke cone — od hladne modre prek tipičnega bežastega pasu do ekstremne rdeče.",
-        "footer": "Danes: 13.9 °C · 81. percentil · mediana 10.9 °C · 1,140 opazovanj · 1950–2026"
+        "footer": "Danes: 13,9 °C · 81. percentil · mediana 10,9 °C · 1140 opazovanj · 1950–2026"
       },
       "today_trend": {
         "api": {
@@ -50758,9 +50758,9 @@
           ]
         },
         "rendered": {
-          "title": "Najvišje temperature na postaji Kredarica okoli Jul 15 · 1950–2026 · trend s projekcijo do 2050",
-          "explain": "Vsaka pika je 90. percentil lapsno popravljene dnevne najvišje temperature na postaji Kredarica v ±30-dnevnem oknu okoli tega datuma za vsako leto od 1950. Trend Theil-Sen je +0.33 °C/desetletje (p < 0.001). Po tem tempu projekcija kaže 12.6 °C do leta 2050. Zasenčeni pas je 95% interval zaupanja za nagib.",
-          "footer": "Theil-Sen + TFPW MK: +0.33 °C/desetletje · p < 0.001 · τ = 0.363 · 95% CI · 77 let",
+          "title": "Najvišje temperature na postaji Kredarica okoli 15. jul. · 1950–2026 · trend s projekcijo do 2050",
+          "explain": "Vsaka pika je 90. percentil lapsno popravljene dnevne najvišje temperature na postaji Kredarica v ±30-dnevnem oknu okoli tega datuma za vsako leto od 1950. Trend Theil-Sen je +0,33 °C/desetletje (p < 0,001). Po tem tempu projekcija kaže 12,6 °C do leta 2050. Zasenčeni pas je 95% interval zaupanja za nagib.",
+          "footer": "Theil-Sen + TFPW MK: +0,33 °C/desetletje · p < 0,001 · τ = 0,363 · 95% CI · 77 let",
           "current_year_plotline": {
             "value": 2026,
             "label": "2026",
@@ -51198,25 +51198,25 @@
       "analysis": {
         "rendered": {
           "toolbar": [
-            "LocationKredarica",
-            "VariableMax temperature (°C)Min temperature (°C)Mean temperature (°C)Precipitation (mm)ET₀ (mm)",
-            "Day15 Jul◀▶"
+            "LokacijaKredarica",
+            "SpremenljivkaNajvišja temperatura (°C)Najnižja temperatura (°C)Povprečna temperatura (°C)Padavine (mm)ET₀ (mm)",
+            "Dan15. jul.◀▶"
           ],
           "variable_select": {
             "selected": "temperature_max",
             "options": [
-              "Max temperature (°C)",
-              "Min temperature (°C)",
-              "Mean temperature (°C)",
-              "Precipitation (mm)",
+              "Najvišja temperatura (°C)",
+              "Najnižja temperatura (°C)",
+              "Povprečna temperatura (°C)",
+              "Padavine (mm)",
               "ET₀ (mm)"
             ]
           },
-          "day_label": "15 Jul",
-          "title": "Max temperature · 15 Jul",
+          "day_label": "15. jul.",
+          "title": "Najvišja temperatura · 15. jul.",
           "subtitle": "Kredarica",
-          "stats_badge": "Theil-Sen + TFPW MK · τ = 0.36",
-          "total_change": "+2.51°C",
+          "stats_badge": "Theil-Sen + TFPW MK · τ = 0,36",
+          "total_change": "+2,51°C",
           "total_change_color": "rgb(204, 34, 34)",
           "footer": [
             "Theil-Sen regresija + Yue-Wang TFPW Mann-Kendall test · ERA5-Land · nadmorska korekcija"
@@ -51236,7 +51236,7 @@
               "plot_bands": []
             },
             "y_axis": {
-              "title": "Max temperature (°C)",
+              "title": "Najvišja temperatura (°C)",
               "min": null,
               "max": null,
               "categories": null,
@@ -51244,7 +51244,7 @@
                 {
                   "id": "baseline-Kredarica",
                   "value": 11.213333333333333,
-                  "label": "77-YR MEAN 11.2",
+                  "label": "POVPREČJE 77 let: 11,2",
                   "dash_style": "Dash"
                 }
               ],
@@ -51913,18 +51913,18 @@
       },
       "hero_cards": {
         "rendered": {
-          "headline": "+0.326",
+          "headline": "+0,326",
           "headline_color": "rgb(194, 90, 44)",
           "category": "Katastrofalno",
           "paragraphs": [
             "Popolna izguba Triglavskega ledenika — narodni simbol in vir savinjskih rek. Propad alpskega ekosistema sproži kaskadne učinke.",
-            "Sto let segrevanja za +3.26 °C – pri trenutnem tempu vsaka 30.7 let doda eno stopinjo.",
+            "Sto let segrevanja za +3,26 °C – pri trenutnem tempu vsaka 30,7 let doda eno stopinjo.",
             "Theil-Sen + TFPW Mann-Kendall"
           ],
           "stats": [
             "Izguba Triglavskega ledenika — izsušitev izvirnih vod za Slovenijo reke",
-            "★★★ p < 0.001",
-            "0.3260",
+            "★★★ p < 0,001",
+            "0,3260",
             "77 let",
             "—"
           ]
@@ -51960,7 +51960,7 @@
           }
         },
         "rendered": {
-          "date_badge": "29.02.",
+          "date_badge": "1. mar.",
           "loc_select": {
             "selected": "",
             "options": [
@@ -52066,25 +52066,25 @@
       "analysis": {
         "rendered": {
           "toolbar": [
-            "LocationLjubljana",
-            "VariableMax temperature (°C)Min temperature (°C)Mean temperature (°C)Precipitation (mm)ET₀ (mm)",
-            "Day28 Feb◀▶"
+            "LokacijaLjubljana",
+            "SpremenljivkaNajvišja temperatura (°C)Najnižja temperatura (°C)Povprečna temperatura (°C)Padavine (mm)ET₀ (mm)",
+            "Dan28. feb.◀▶"
           ],
           "variable_select": {
             "selected": "temperature_max",
             "options": [
-              "Max temperature (°C)",
-              "Min temperature (°C)",
-              "Mean temperature (°C)",
-              "Precipitation (mm)",
+              "Najvišja temperatura (°C)",
+              "Najnižja temperatura (°C)",
+              "Povprečna temperatura (°C)",
+              "Padavine (mm)",
               "ET₀ (mm)"
             ]
           },
-          "day_label": "28 Feb",
-          "title": "Max temperature · 28 Feb",
+          "day_label": "28. feb.",
+          "title": "Najvišja temperatura · 28. feb.",
           "subtitle": "Ljubljana",
-          "stats_badge": "Theil-Sen + TFPW MK · τ = 0.34",
-          "total_change": "+4.54°C",
+          "stats_badge": "Theil-Sen + TFPW MK · τ = 0,34",
+          "total_change": "+4,54°C",
           "total_change_color": "rgb(204, 34, 34)",
           "footer": [
             "Theil-Sen regresija + Yue-Wang TFPW Mann-Kendall test · ERA5-Land · nadmorska korekcija"
@@ -52104,7 +52104,7 @@
               "plot_bands": []
             },
             "y_axis": {
-              "title": "Max temperature (°C)",
+              "title": "Najvišja temperatura (°C)",
               "min": null,
               "max": null,
               "categories": null,
@@ -52112,7 +52112,7 @@
                 {
                   "id": "baseline-Ljubljana",
                   "value": 7.894333333333332,
-                  "label": "77-YR MEAN 7.9",
+                  "label": "POVPREČJE 77 let: 7,9",
                   "dash_style": "Dash"
                 }
               ],
@@ -52781,18 +52781,18 @@
       },
       "hero_cards": {
         "rendered": {
-          "headline": "+0.589",
+          "headline": "+0,589",
           "headline_color": "rgb(194, 90, 44)",
           "category": "Katastrofalno",
           "paragraphs": [
             "Podaljšani poletni vročinski valovi presegajo hladilne zmogljivosti mesta. Hudourniške poplave iz okrepljenih alpskih padavin večkrat ogrozijo nizko ležečo kotlino.",
-            "Sto let segrevanja za +5.89 °C – pri trenutnem tempu vsaka 17.0 let doda eno stopinjo.",
+            "Sto let segrevanja za +5,89 °C – pri trenutnem tempu vsaka 17,0 let doda eno stopinjo.",
             "Theil-Sen + TFPW Mann-Kendall"
           ],
           "stats": [
             "Mestni toplotni otok — poletni vročinski stres in tveganje hudourniških poplav v Ljubljanski kotlini",
-            "★★★ p < 0.001",
-            "0.5890",
+            "★★★ p < 0,001",
+            "0,5890",
             "77 let",
             "—"
           ]
@@ -52828,7 +52828,7 @@
           }
         },
         "rendered": {
-          "date_badge": "29.02.",
+          "date_badge": "1. mar.",
           "loc_select": {
             "selected": "",
             "options": [
@@ -52934,25 +52934,25 @@
       "analysis": {
         "rendered": {
           "toolbar": [
-            "LocationKredarica",
-            "VariableMax temperature (°C)Min temperature (°C)Mean temperature (°C)Precipitation (mm)ET₀ (mm)",
-            "Day28 Feb◀▶"
+            "LokacijaKredarica",
+            "SpremenljivkaNajvišja temperatura (°C)Najnižja temperatura (°C)Povprečna temperatura (°C)Padavine (mm)ET₀ (mm)",
+            "Dan28. feb.◀▶"
           ],
           "variable_select": {
             "selected": "temperature_max",
             "options": [
-              "Max temperature (°C)",
-              "Min temperature (°C)",
-              "Mean temperature (°C)",
-              "Precipitation (mm)",
+              "Najvišja temperatura (°C)",
+              "Najnižja temperatura (°C)",
+              "Povprečna temperatura (°C)",
+              "Padavine (mm)",
               "ET₀ (mm)"
             ]
           },
-          "day_label": "28 Feb",
-          "title": "Max temperature · 28 Feb",
+          "day_label": "28. feb.",
+          "title": "Najvišja temperatura · 28. feb.",
           "subtitle": "Kredarica",
-          "stats_badge": "Theil-Sen + TFPW MK · τ = 0.27",
-          "total_change": "+3.29°C",
+          "stats_badge": "Theil-Sen + TFPW MK · τ = 0,27",
+          "total_change": "+3,29°C",
           "total_change_color": "rgb(204, 34, 34)",
           "footer": [
             "Theil-Sen regresija + Yue-Wang TFPW Mann-Kendall test · ERA5-Land · nadmorska korekcija"
@@ -52972,7 +52972,7 @@
               "plot_bands": []
             },
             "y_axis": {
-              "title": "Max temperature (°C)",
+              "title": "Najvišja temperatura (°C)",
               "min": null,
               "max": null,
               "categories": null,
@@ -52980,7 +52980,7 @@
                 {
                   "id": "baseline-Kredarica",
                   "value": -5.116666666666666,
-                  "label": "77-YR MEAN -5.1",
+                  "label": "POVPREČJE 77 let: −5,1",
                   "dash_style": "Dash"
                 }
               ],
@@ -53649,18 +53649,18 @@
       },
       "hero_cards": {
         "rendered": {
-          "headline": "+0.427",
+          "headline": "+0,427",
           "headline_color": "rgb(194, 90, 44)",
           "category": "Katastrofalno",
           "paragraphs": [
             "Popolna izguba Triglavskega ledenika — narodni simbol in vir savinjskih rek. Propad alpskega ekosistema sproži kaskadne učinke.",
-            "Sto let segrevanja za +4.27 °C – pri trenutnem tempu vsaka 23.4 let doda eno stopinjo.",
+            "Sto let segrevanja za +4,27 °C – pri trenutnem tempu vsaka 23,4 let doda eno stopinjo.",
             "Theil-Sen + TFPW Mann-Kendall"
           ],
           "stats": [
             "Izguba Triglavskega ledenika — izsušitev izvirnih vod za Slovenijo reke",
-            "★★★ p < 0.001",
-            "0.4270",
+            "★★★ p < 0,001",
+            "0,4270",
             "77 let",
             "—"
           ]
@@ -53696,7 +53696,7 @@
           }
         },
         "rendered": {
-          "date_badge": "29.02.",
+          "date_badge": "1. mar.",
           "loc_select": {
             "selected": "",
             "options": [
@@ -53753,25 +53753,25 @@
       "analysis": {
         "rendered": {
           "toolbar": [
-            "LocationLjubljana",
-            "VariableMax temperature (°C)Min temperature (°C)Mean temperature (°C)Precipitation (mm)ET₀ (mm)",
-            "Day28 Feb◀▶"
+            "LokacijaLjubljana",
+            "SpremenljivkaNajvišja temperatura (°C)Najnižja temperatura (°C)Povprečna temperatura (°C)Padavine (mm)ET₀ (mm)",
+            "Dan28. feb.◀▶"
           ],
           "variable_select": {
             "selected": "temperature_max",
             "options": [
-              "Max temperature (°C)",
-              "Min temperature (°C)",
-              "Mean temperature (°C)",
-              "Precipitation (mm)",
+              "Najvišja temperatura (°C)",
+              "Najnižja temperatura (°C)",
+              "Povprečna temperatura (°C)",
+              "Padavine (mm)",
               "ET₀ (mm)"
             ]
           },
-          "day_label": "28 Feb",
-          "title": "Max temperature · 28 Feb",
+          "day_label": "28. feb.",
+          "title": "Najvišja temperatura · 28. feb.",
           "subtitle": "Ljubljana",
-          "stats_badge": "Theil-Sen + TFPW MK · τ = 0.34",
-          "total_change": "+4.54°C",
+          "stats_badge": "Theil-Sen + TFPW MK · τ = 0,34",
+          "total_change": "+4,54°C",
           "total_change_color": "rgb(204, 34, 34)",
           "footer": [
             "Theil-Sen regresija + Yue-Wang TFPW Mann-Kendall test · ERA5-Land · nadmorska korekcija"
@@ -53791,7 +53791,7 @@
               "plot_bands": []
             },
             "y_axis": {
-              "title": "Max temperature (°C)",
+              "title": "Najvišja temperatura (°C)",
               "min": null,
               "max": null,
               "categories": null,
@@ -53799,7 +53799,7 @@
                 {
                   "id": "baseline-Ljubljana",
                   "value": 7.894333333333332,
-                  "label": "77-YR MEAN 7.9",
+                  "label": "POVPREČJE 77 let: 7,9",
                   "dash_style": "Dash"
                 }
               ],
@@ -54468,18 +54468,18 @@
       },
       "hero_cards": {
         "rendered": {
-          "headline": "+0.589",
+          "headline": "+0,589",
           "headline_color": "rgb(194, 90, 44)",
           "category": "Katastrofalno",
           "paragraphs": [
             "Podaljšani poletni vročinski valovi presegajo hladilne zmogljivosti mesta. Hudourniške poplave iz okrepljenih alpskih padavin večkrat ogrozijo nizko ležečo kotlino.",
-            "Sto let segrevanja za +5.89 °C – pri trenutnem tempu vsaka 17.0 let doda eno stopinjo.",
+            "Sto let segrevanja za +5,89 °C – pri trenutnem tempu vsaka 17,0 let doda eno stopinjo.",
             "Theil-Sen + TFPW Mann-Kendall"
           ],
           "stats": [
             "Mestni toplotni otok — poletni vročinski stres in tveganje hudourniških poplav v Ljubljanski kotlini",
-            "★★★ p < 0.001",
-            "0.5890",
+            "★★★ p < 0,001",
+            "0,5890",
             "77 let",
             "—"
           ]
@@ -55323,7 +55323,7 @@
           }
         },
         "rendered": {
-          "date_badge": "01.03.",
+          "date_badge": "1. mar.",
           "loc_select": {
             "selected": "Ljubljana",
             "options": [
@@ -55350,13 +55350,13 @@
           },
           "category_label": "Normalno",
           "category_color": "rgb(231, 217, 184)",
-          "description": "Točno takšno, kot 01.03 v Slovenija ponavadi je.",
+          "description": "Točno takšno, kot 1. mar. v Slovenija ponavadi je.",
           "percentile": "78",
           "percentile_label": "percentil",
-          "samples": "1,155 vzorcev",
+          "samples": "1155 vzorcev",
           "preliminary_badge": null,
           "explain": "Temperatura na postaji Ljubljana, razvrstena glede na zapise ERA5-Land od leta 1950 za isto ±7-dnevno okno.",
-          "footer": "10.9 °C · 78. percentil · 1,155 vzorcev (1950–2026)",
+          "footer": "10,9 °C · 78. percentil · 1155 vzorcev (1950–2026)",
           "unavailable_message": null
         },
         "last7": {
@@ -55614,7 +55614,7 @@
                 {
                   "id": null,
                   "value": 10.907,
-                  "label": "DANES: 10.9 °C",
+                  "label": "DANES: 10,9 °C",
                   "dash_style": null
                 }
               ],
@@ -55622,27 +55622,27 @@
                 {
                   "from": -10.125,
                   "to": 1.19,
-                  "label": "< 1.2°C"
+                  "label": "< 1,2°C"
                 },
                 {
                   "from": 1.19,
                   "to": 2.79,
-                  "label": "1.2–2.8°C"
+                  "label": "1,2–2,8°C"
                 },
                 {
                   "from": 2.79,
                   "to": 11.14,
-                  "label": "2.8–11.1°C"
+                  "label": "2,8–11,1°C"
                 },
                 {
                   "from": 11.14,
                   "to": 14.42,
-                  "label": "11.1–14.4°C"
+                  "label": "11,1–14,4°C"
                 },
                 {
                   "from": 14.42,
                   "to": 21.907,
-                  "label": "> 14.4°C"
+                  "label": "> 14,4°C"
                 }
               ]
             },
@@ -56480,9 +56480,9 @@
       },
       "today_chart_copy": {
         "_note": "Raw JSX in AliJeVroceERA5.tsx:99-112, mirrored by TodayChartCopy in harness.tsx and checked against the source by main.mjs assertMirroredCopy.",
-        "title": "Dnevne najvišje temperature na postaji Ljubljana za dva tedna okoli 01.03 od 1950",
+        "title": "Dnevne najvišje temperature na postaji Ljubljana za dva tedna okoli 1. mar. od 1950",
         "explain": "Krivulja prikazuje, kako pogosto se je pojavila vsaka vrhunska temperatura na dneve, kot je danes, v vseh letih. Barve označujejo klimatološke cone — od hladne modre prek tipičnega bežastega pasu do ekstremne rdeče.",
-        "footer": "Danes: 10.9 °C · 78. percentil · mediana 7.2 °C · 1,155 opazovanj · 1950–2026"
+        "footer": "Danes: 10,9 °C · 78. percentil · mediana 7,2 °C · 1155 opazovanj · 1950–2026"
       },
       "today_trend": {
         "api": {
@@ -56844,9 +56844,9 @@
           ]
         },
         "rendered": {
-          "title": "Najvišje temperature na postaji Ljubljana okoli Mar 1 · 1950–2026 · trend s projekcijo do 2050",
-          "explain": "Vsaka pika je 90. percentil lapsno popravljene dnevne najvišje temperature na postaji Ljubljana v ±30-dnevnem oknu okoli tega datuma za vsako leto od 1950. Trend Theil-Sen je +0.58 °C/desetletje (p < 0.001). Po tem tempu projekcija kaže 11.0 °C do leta 2050. Zasenčeni pas je 95% interval zaupanja za nagib.",
-          "footer": "Theil-Sen + TFPW MK: +0.58 °C/desetletje · p < 0.001 · τ = 0.336 · 95% CI · 77 let",
+          "title": "Najvišje temperature na postaji Ljubljana okoli 1. mar. · 1950–2026 · trend s projekcijo do 2050",
+          "explain": "Vsaka pika je 90. percentil lapsno popravljene dnevne najvišje temperature na postaji Ljubljana v ±30-dnevnem oknu okoli tega datuma za vsako leto od 1950. Trend Theil-Sen je +0,58 °C/desetletje (p < 0,001). Po tem tempu projekcija kaže 11,0 °C do leta 2050. Zasenčeni pas je 95% interval zaupanja za nagib.",
+          "footer": "Theil-Sen + TFPW MK: +0,58 °C/desetletje · p < 0,001 · τ = 0,336 · 95% CI · 77 let",
           "current_year_plotline": {
             "value": 2026,
             "label": "2026",
@@ -57284,25 +57284,25 @@
       "analysis": {
         "rendered": {
           "toolbar": [
-            "LocationLjubljana",
-            "VariableMax temperature (°C)Min temperature (°C)Mean temperature (°C)Precipitation (mm)ET₀ (mm)",
-            "Day1 Mar◀▶"
+            "LokacijaLjubljana",
+            "SpremenljivkaNajvišja temperatura (°C)Najnižja temperatura (°C)Povprečna temperatura (°C)Padavine (mm)ET₀ (mm)",
+            "Dan1. mar.◀▶"
           ],
           "variable_select": {
             "selected": "temperature_max",
             "options": [
-              "Max temperature (°C)",
-              "Min temperature (°C)",
-              "Mean temperature (°C)",
-              "Precipitation (mm)",
+              "Najvišja temperatura (°C)",
+              "Najnižja temperatura (°C)",
+              "Povprečna temperatura (°C)",
+              "Padavine (mm)",
               "ET₀ (mm)"
             ]
           },
-          "day_label": "1 Mar",
-          "title": "Max temperature · 1 Mar",
+          "day_label": "1. mar.",
+          "title": "Najvišja temperatura · 1. mar.",
           "subtitle": "Ljubljana",
-          "stats_badge": "Theil-Sen + TFPW MK · τ = 0.34",
-          "total_change": "+4.50°C",
+          "stats_badge": "Theil-Sen + TFPW MK · τ = 0,34",
+          "total_change": "+4,50°C",
           "total_change_color": "rgb(204, 34, 34)",
           "footer": [
             "Theil-Sen regresija + Yue-Wang TFPW Mann-Kendall test · ERA5-Land · nadmorska korekcija"
@@ -57322,7 +57322,7 @@
               "plot_bands": []
             },
             "y_axis": {
-              "title": "Max temperature (°C)",
+              "title": "Najvišja temperatura (°C)",
               "min": null,
               "max": null,
               "categories": null,
@@ -57330,7 +57330,7 @@
                 {
                   "id": "baseline-Ljubljana",
                   "value": 8.039333333333335,
-                  "label": "77-YR MEAN 8.0",
+                  "label": "POVPREČJE 77 let: 8,0",
                   "dash_style": "Dash"
                 }
               ],
@@ -57999,18 +57999,18 @@
       },
       "hero_cards": {
         "rendered": {
-          "headline": "+0.585",
+          "headline": "+0,585",
           "headline_color": "rgb(194, 90, 44)",
           "category": "Katastrofalno",
           "paragraphs": [
             "Podaljšani poletni vročinski valovi presegajo hladilne zmogljivosti mesta. Hudourniške poplave iz okrepljenih alpskih padavin večkrat ogrozijo nizko ležečo kotlino.",
-            "Sto let segrevanja za +5.85 °C – pri trenutnem tempu vsaka 17.1 let doda eno stopinjo.",
+            "Sto let segrevanja za +5,85 °C – pri trenutnem tempu vsaka 17,1 let doda eno stopinjo.",
             "Theil-Sen + TFPW Mann-Kendall"
           ],
           "stats": [
             "Mestni toplotni otok — poletni vročinski stres in tveganje hudourniških poplav v Ljubljanski kotlini",
-            "★★★ p < 0.001",
-            "0.5850",
+            "★★★ p < 0,001",
+            "0,5850",
             "77 let",
             "—"
           ]
@@ -58854,7 +58854,7 @@
           }
         },
         "rendered": {
-          "date_badge": "28.02.",
+          "date_badge": "28. feb.",
           "loc_select": {
             "selected": "Ljubljana",
             "options": [
@@ -58881,13 +58881,13 @@
           },
           "category_label": "Normalno",
           "category_color": "rgb(231, 217, 184)",
-          "description": "Točno takšno, kot 28.02 v Slovenija ponavadi je.",
+          "description": "Točno takšno, kot 28. feb. v Slovenija ponavadi je.",
           "percentile": "69",
           "percentile_label": "percentil",
-          "samples": "1,155 vzorcev",
+          "samples": "1155 vzorcev",
           "preliminary_badge": null,
           "explain": "Temperatura na postaji Ljubljana, razvrstena glede na zapise ERA5-Land od leta 1950 za isto ±7-dnevno okno.",
-          "footer": "9.4 °C · 69. percentil · 1,155 vzorcev (1950–2026)",
+          "footer": "9,4 °C · 69. percentil · 1155 vzorcev (1950–2026)",
           "unavailable_message": null
         },
         "last7": {
@@ -59163,7 +59163,7 @@
                 {
                   "id": null,
                   "value": 9.356,
-                  "label": "DANES: 9.4 °C",
+                  "label": "DANES: 9,4 °C",
                   "dash_style": null
                 }
               ],
@@ -59171,27 +59171,27 @@
                 {
                   "from": -10.1134,
                   "to": 1.01,
-                  "label": "< 1.0°C"
+                  "label": "< 1,0°C"
                 },
                 {
                   "from": 1.01,
                   "to": 2.74,
-                  "label": "1.0–2.7°C"
+                  "label": "1,0–2,7°C"
                 },
                 {
                   "from": 2.74,
                   "to": 10.91,
-                  "label": "2.7–10.9°C"
+                  "label": "2,7–10,9°C"
                 },
                 {
                   "from": 10.91,
                   "to": 14.2,
-                  "label": "10.9–14.2°C"
+                  "label": "10,9–14,2°C"
                 },
                 {
                   "from": 14.2,
                   "to": 21.795399999999997,
-                  "label": "> 14.2°C"
+                  "label": "> 14,2°C"
                 }
               ]
             },
@@ -60029,9 +60029,9 @@
       },
       "today_chart_copy": {
         "_note": "Raw JSX in AliJeVroceERA5.tsx:99-112, mirrored by TodayChartCopy in harness.tsx and checked against the source by main.mjs assertMirroredCopy.",
-        "title": "Dnevne najvišje temperature na postaji Ljubljana za dva tedna okoli 28.02 od 1950",
+        "title": "Dnevne najvišje temperature na postaji Ljubljana za dva tedna okoli 28. feb. od 1950",
         "explain": "Krivulja prikazuje, kako pogosto se je pojavila vsaka vrhunska temperatura na dneve, kot je danes, v vseh letih. Barve označujejo klimatološke cone — od hladne modre prek tipičnega bežastega pasu do ekstremne rdeče.",
-        "footer": "Danes: 9.4 °C · 69. percentil · mediana 7.1 °C · 1,155 opazovanj · 1950–2026"
+        "footer": "Danes: 9,4 °C · 69. percentil · mediana 7,1 °C · 1155 opazovanj · 1950–2026"
       },
       "today_trend": {
         "api": {
@@ -60393,9 +60393,9 @@
           ]
         },
         "rendered": {
-          "title": "Najvišje temperature na postaji Ljubljana okoli Feb 28 · 1950–2026 · trend s projekcijo do 2050",
-          "explain": "Vsaka pika je 90. percentil lapsno popravljene dnevne najvišje temperature na postaji Ljubljana v ±30-dnevnem oknu okoli tega datuma za vsako leto od 1950. Trend Theil-Sen je +0.59 °C/desetletje (p < 0.001). Po tem tempu projekcija kaže 10.9 °C do leta 2050. Zasenčeni pas je 95% interval zaupanja za nagib.",
-          "footer": "Theil-Sen + TFPW MK: +0.59 °C/desetletje · p < 0.001 · τ = 0.337 · 95% CI · 77 let",
+          "title": "Najvišje temperature na postaji Ljubljana okoli 28. feb. · 1950–2026 · trend s projekcijo do 2050",
+          "explain": "Vsaka pika je 90. percentil lapsno popravljene dnevne najvišje temperature na postaji Ljubljana v ±30-dnevnem oknu okoli tega datuma za vsako leto od 1950. Trend Theil-Sen je +0,59 °C/desetletje (p < 0,001). Po tem tempu projekcija kaže 10,9 °C do leta 2050. Zasenčeni pas je 95% interval zaupanja za nagib.",
+          "footer": "Theil-Sen + TFPW MK: +0,59 °C/desetletje · p < 0,001 · τ = 0,337 · 95% CI · 77 let",
           "current_year_plotline": {
             "value": 2026,
             "label": "2026",
@@ -60833,25 +60833,25 @@
       "analysis": {
         "rendered": {
           "toolbar": [
-            "LocationLjubljana",
-            "VariableMax temperature (°C)Min temperature (°C)Mean temperature (°C)Precipitation (mm)ET₀ (mm)",
-            "Day28 Feb◀▶"
+            "LokacijaLjubljana",
+            "SpremenljivkaNajvišja temperatura (°C)Najnižja temperatura (°C)Povprečna temperatura (°C)Padavine (mm)ET₀ (mm)",
+            "Dan28. feb.◀▶"
           ],
           "variable_select": {
             "selected": "temperature_max",
             "options": [
-              "Max temperature (°C)",
-              "Min temperature (°C)",
-              "Mean temperature (°C)",
-              "Precipitation (mm)",
+              "Najvišja temperatura (°C)",
+              "Najnižja temperatura (°C)",
+              "Povprečna temperatura (°C)",
+              "Padavine (mm)",
               "ET₀ (mm)"
             ]
           },
-          "day_label": "28 Feb",
-          "title": "Max temperature · 28 Feb",
+          "day_label": "28. feb.",
+          "title": "Najvišja temperatura · 28. feb.",
           "subtitle": "Ljubljana",
-          "stats_badge": "Theil-Sen + TFPW MK · τ = 0.34",
-          "total_change": "+4.54°C",
+          "stats_badge": "Theil-Sen + TFPW MK · τ = 0,34",
+          "total_change": "+4,54°C",
           "total_change_color": "rgb(204, 34, 34)",
           "footer": [
             "Theil-Sen regresija + Yue-Wang TFPW Mann-Kendall test · ERA5-Land · nadmorska korekcija"
@@ -60871,7 +60871,7 @@
               "plot_bands": []
             },
             "y_axis": {
-              "title": "Max temperature (°C)",
+              "title": "Najvišja temperatura (°C)",
               "min": null,
               "max": null,
               "categories": null,
@@ -60879,7 +60879,7 @@
                 {
                   "id": "baseline-Ljubljana",
                   "value": 7.894333333333332,
-                  "label": "77-YR MEAN 7.9",
+                  "label": "POVPREČJE 77 let: 7,9",
                   "dash_style": "Dash"
                 }
               ],
@@ -61548,18 +61548,18 @@
       },
       "hero_cards": {
         "rendered": {
-          "headline": "+0.589",
+          "headline": "+0,589",
           "headline_color": "rgb(194, 90, 44)",
           "category": "Katastrofalno",
           "paragraphs": [
             "Podaljšani poletni vročinski valovi presegajo hladilne zmogljivosti mesta. Hudourniške poplave iz okrepljenih alpskih padavin večkrat ogrozijo nizko ležečo kotlino.",
-            "Sto let segrevanja za +5.89 °C – pri trenutnem tempu vsaka 17.0 let doda eno stopinjo.",
+            "Sto let segrevanja za +5,89 °C – pri trenutnem tempu vsaka 17,0 let doda eno stopinjo.",
             "Theil-Sen + TFPW Mann-Kendall"
           ],
           "stats": [
             "Mestni toplotni otok — poletni vročinski stres in tveganje hudourniških poplav v Ljubljanski kotlini",
-            "★★★ p < 0.001",
-            "0.5890",
+            "★★★ p < 0,001",
+            "0,5890",
             "77 let",
             "—"
           ]
@@ -62403,7 +62403,7 @@
           }
         },
         "rendered": {
-          "date_badge": "01.03.",
+          "date_badge": "1. mar.",
           "loc_select": {
             "selected": "Ljubljana",
             "options": [
@@ -62430,13 +62430,13 @@
           },
           "category_label": "Normalno",
           "category_color": "rgb(231, 217, 184)",
-          "description": "Točno takšno, kot 01.03 v Slovenija ponavadi je.",
+          "description": "Točno takšno, kot 1. mar. v Slovenija ponavadi je.",
           "percentile": "68",
           "percentile_label": "percentil",
-          "samples": "1,155 vzorcev",
+          "samples": "1155 vzorcev",
           "preliminary_badge": null,
           "explain": "Temperatura na postaji Ljubljana, razvrstena glede na zapise ERA5-Land od leta 1950 za isto ±7-dnevno okno.",
-          "footer": "9.4 °C · 68. percentil · 1,155 vzorcev (1950–2026)",
+          "footer": "9,4 °C · 68. percentil · 1155 vzorcev (1950–2026)",
           "unavailable_message": null
         },
         "last7": {
@@ -62712,7 +62712,7 @@
                 {
                   "id": null,
                   "value": 9.356,
-                  "label": "DANES: 9.4 °C",
+                  "label": "DANES: 9,4 °C",
                   "dash_style": null
                 }
               ],
@@ -62720,27 +62720,27 @@
                 {
                   "from": -10.125,
                   "to": 1.19,
-                  "label": "< 1.2°C"
+                  "label": "< 1,2°C"
                 },
                 {
                   "from": 1.19,
                   "to": 2.79,
-                  "label": "1.2–2.8°C"
+                  "label": "1,2–2,8°C"
                 },
                 {
                   "from": 2.79,
                   "to": 11.14,
-                  "label": "2.8–11.1°C"
+                  "label": "2,8–11,1°C"
                 },
                 {
                   "from": 11.14,
                   "to": 14.42,
-                  "label": "11.1–14.4°C"
+                  "label": "11,1–14,4°C"
                 },
                 {
                   "from": 14.42,
                   "to": 21.907,
-                  "label": "> 14.4°C"
+                  "label": "> 14,4°C"
                 }
               ]
             },
@@ -63578,9 +63578,9 @@
       },
       "today_chart_copy": {
         "_note": "Raw JSX in AliJeVroceERA5.tsx:99-112, mirrored by TodayChartCopy in harness.tsx and checked against the source by main.mjs assertMirroredCopy.",
-        "title": "Dnevne najvišje temperature na postaji Ljubljana za dva tedna okoli 01.03 od 1950",
+        "title": "Dnevne najvišje temperature na postaji Ljubljana za dva tedna okoli 1. mar. od 1950",
         "explain": "Krivulja prikazuje, kako pogosto se je pojavila vsaka vrhunska temperatura na dneve, kot je danes, v vseh letih. Barve označujejo klimatološke cone — od hladne modre prek tipičnega bežastega pasu do ekstremne rdeče.",
-        "footer": "Danes: 9.4 °C · 68. percentil · mediana 7.2 °C · 1,155 opazovanj · 1950–2026"
+        "footer": "Danes: 9,4 °C · 68. percentil · mediana 7,2 °C · 1155 opazovanj · 1950–2026"
       },
       "today_trend": {
         "api": {
@@ -63942,9 +63942,9 @@
           ]
         },
         "rendered": {
-          "title": "Najvišje temperature na postaji Ljubljana okoli Mar 1 · 1950–2026 · trend s projekcijo do 2050",
-          "explain": "Vsaka pika je 90. percentil lapsno popravljene dnevne najvišje temperature na postaji Ljubljana v ±30-dnevnem oknu okoli tega datuma za vsako leto od 1950. Trend Theil-Sen je +0.58 °C/desetletje (p < 0.001). Po tem tempu projekcija kaže 11.0 °C do leta 2050. Zasenčeni pas je 95% interval zaupanja za nagib.",
-          "footer": "Theil-Sen + TFPW MK: +0.58 °C/desetletje · p < 0.001 · τ = 0.336 · 95% CI · 77 let",
+          "title": "Najvišje temperature na postaji Ljubljana okoli 1. mar. · 1950–2026 · trend s projekcijo do 2050",
+          "explain": "Vsaka pika je 90. percentil lapsno popravljene dnevne najvišje temperature na postaji Ljubljana v ±30-dnevnem oknu okoli tega datuma za vsako leto od 1950. Trend Theil-Sen je +0,58 °C/desetletje (p < 0,001). Po tem tempu projekcija kaže 11,0 °C do leta 2050. Zasenčeni pas je 95% interval zaupanja za nagib.",
+          "footer": "Theil-Sen + TFPW MK: +0,58 °C/desetletje · p < 0,001 · τ = 0,336 · 95% CI · 77 let",
           "current_year_plotline": {
             "value": 2026,
             "label": "2026",
@@ -64382,25 +64382,25 @@
       "analysis": {
         "rendered": {
           "toolbar": [
-            "LocationLjubljana",
-            "VariableMax temperature (°C)Min temperature (°C)Mean temperature (°C)Precipitation (mm)ET₀ (mm)",
-            "Day1 Mar◀▶"
+            "LokacijaLjubljana",
+            "SpremenljivkaNajvišja temperatura (°C)Najnižja temperatura (°C)Povprečna temperatura (°C)Padavine (mm)ET₀ (mm)",
+            "Dan1. mar.◀▶"
           ],
           "variable_select": {
             "selected": "temperature_max",
             "options": [
-              "Max temperature (°C)",
-              "Min temperature (°C)",
-              "Mean temperature (°C)",
-              "Precipitation (mm)",
+              "Najvišja temperatura (°C)",
+              "Najnižja temperatura (°C)",
+              "Povprečna temperatura (°C)",
+              "Padavine (mm)",
               "ET₀ (mm)"
             ]
           },
-          "day_label": "1 Mar",
-          "title": "Max temperature · 1 Mar",
+          "day_label": "1. mar.",
+          "title": "Najvišja temperatura · 1. mar.",
           "subtitle": "Ljubljana",
-          "stats_badge": "Theil-Sen + TFPW MK · τ = 0.34",
-          "total_change": "+4.50°C",
+          "stats_badge": "Theil-Sen + TFPW MK · τ = 0,34",
+          "total_change": "+4,50°C",
           "total_change_color": "rgb(204, 34, 34)",
           "footer": [
             "Theil-Sen regresija + Yue-Wang TFPW Mann-Kendall test · ERA5-Land · nadmorska korekcija"
@@ -64420,7 +64420,7 @@
               "plot_bands": []
             },
             "y_axis": {
-              "title": "Max temperature (°C)",
+              "title": "Najvišja temperatura (°C)",
               "min": null,
               "max": null,
               "categories": null,
@@ -64428,7 +64428,7 @@
                 {
                   "id": "baseline-Ljubljana",
                   "value": 8.039333333333335,
-                  "label": "77-YR MEAN 8.0",
+                  "label": "POVPREČJE 77 let: 8,0",
                   "dash_style": "Dash"
                 }
               ],
@@ -65097,18 +65097,18 @@
       },
       "hero_cards": {
         "rendered": {
-          "headline": "+0.585",
+          "headline": "+0,585",
           "headline_color": "rgb(194, 90, 44)",
           "category": "Katastrofalno",
           "paragraphs": [
             "Podaljšani poletni vročinski valovi presegajo hladilne zmogljivosti mesta. Hudourniške poplave iz okrepljenih alpskih padavin večkrat ogrozijo nizko ležečo kotlino.",
-            "Sto let segrevanja za +5.85 °C – pri trenutnem tempu vsaka 17.1 let doda eno stopinjo.",
+            "Sto let segrevanja za +5,85 °C – pri trenutnem tempu vsaka 17,1 let doda eno stopinjo.",
             "Theil-Sen + TFPW Mann-Kendall"
           ],
           "stats": [
             "Mestni toplotni otok — poletni vročinski stres in tveganje hudourniških poplav v Ljubljanski kotlini",
-            "★★★ p < 0.001",
-            "0.5850",
+            "★★★ p < 0,001",
+            "0,5850",
             "77 let",
             "—"
           ]
@@ -65952,7 +65952,7 @@
           }
         },
         "rendered": {
-          "date_badge": "01.01.",
+          "date_badge": "1. jan.",
           "loc_select": {
             "selected": "Ljubljana",
             "options": [
@@ -65979,13 +65979,13 @@
           },
           "category_label": "Vroče",
           "category_color": "rgb(194, 90, 44)",
-          "description": "Med najtoplejšimi 01.01 v naših zapisih.",
+          "description": "Med najtoplejšimi 1. jan. v naših zapisih.",
           "percentile": "91",
           "percentile_label": "percentil",
-          "samples": "1,167 vzorcev",
+          "samples": "1167 vzorcev",
           "preliminary_badge": null,
           "explain": "Temperatura na postaji Ljubljana, razvrstena glede na zapise ERA5-Land od leta 1950 za isto ±7-dnevno okno.",
-          "footer": "8.4 °C · 91. percentil · 1,167 vzorcev (1950–2026)",
+          "footer": "8,4 °C · 91. percentil · 1167 vzorcev (1950–2026)",
           "unavailable_message": null
         },
         "last7": {
@@ -66261,7 +66261,7 @@
                 {
                   "id": null,
                   "value": 8.407,
-                  "label": "DANES: 8.4 °C",
+                  "label": "DANES: 8,4 °C",
                   "dash_style": null
                 }
               ],
@@ -66269,27 +66269,27 @@
                 {
                   "from": -14.74752,
                   "to": -2.56,
-                  "label": "< -2.6°C"
+                  "label": "< −2,6°C"
                 },
                 {
                   "from": -2.56,
                   "to": -0.41,
-                  "label": "-2.6–-0.4°C"
+                  "label": "−2,6–−0,4°C"
                 },
                 {
                   "from": -0.41,
                   "to": 6.43,
-                  "label": "-0.4–6.4°C"
+                  "label": "−0,4–6,4°C"
                 },
                 {
                   "from": 6.43,
                   "to": 9.33,
-                  "label": "6.4–9.3°C"
+                  "label": "6,4–9,3°C"
                 },
                 {
                   "from": 9.33,
                   "to": 16.99552,
-                  "label": "> 9.3°C"
+                  "label": "> 9,3°C"
                 }
               ]
             },
@@ -67127,9 +67127,9 @@
       },
       "today_chart_copy": {
         "_note": "Raw JSX in AliJeVroceERA5.tsx:99-112, mirrored by TodayChartCopy in harness.tsx and checked against the source by main.mjs assertMirroredCopy.",
-        "title": "Dnevne najvišje temperature na postaji Ljubljana za dva tedna okoli 01.01 od 1950",
+        "title": "Dnevne najvišje temperature na postaji Ljubljana za dva tedna okoli 1. jan. od 1950",
         "explain": "Krivulja prikazuje, kako pogosto se je pojavila vsaka vrhunska temperatura na dneve, kot je danes, v vseh letih. Barve označujejo klimatološke cone — od hladne modre prek tipičnega bežastega pasu do ekstremne rdeče.",
-        "footer": "Danes: 8.4 °C · 91. percentil · mediana 3.3 °C · 1,167 opazovanj · 1950–2026"
+        "footer": "Danes: 8,4 °C · 91. percentil · mediana 3,3 °C · 1167 opazovanj · 1950–2026"
       },
       "today_trend": {
         "api": {
@@ -67491,9 +67491,9 @@
           ]
         },
         "rendered": {
-          "title": "Najvišje temperature na postaji Ljubljana okoli Jan 1 · 1950–2026 · trend s projekcijo do 2050",
-          "explain": "Vsaka pika je 90. percentil lapsno popravljene dnevne najvišje temperature na postaji Ljubljana v ±30-dnevnem oknu okoli tega datuma za vsako leto od 1950. Trend Theil-Sen je +0.47 °C/desetletje (p < 0.001). Po tem tempu projekcija kaže 5.9 °C do leta 2050. Zasenčeni pas je 95% interval zaupanja za nagib.",
-          "footer": "Theil-Sen + TFPW MK: +0.47 °C/desetletje · p < 0.001 · τ = 0.355 · 95% CI · 77 let",
+          "title": "Najvišje temperature na postaji Ljubljana okoli 1. jan. · 1950–2026 · trend s projekcijo do 2050",
+          "explain": "Vsaka pika je 90. percentil lapsno popravljene dnevne najvišje temperature na postaji Ljubljana v ±30-dnevnem oknu okoli tega datuma za vsako leto od 1950. Trend Theil-Sen je +0,47 °C/desetletje (p < 0,001). Po tem tempu projekcija kaže 5,9 °C do leta 2050. Zasenčeni pas je 95% interval zaupanja za nagib.",
+          "footer": "Theil-Sen + TFPW MK: +0,47 °C/desetletje · p < 0,001 · τ = 0,355 · 95% CI · 77 let",
           "current_year_plotline": {
             "value": 2026,
             "label": "2026",
@@ -67931,25 +67931,25 @@
       "analysis": {
         "rendered": {
           "toolbar": [
-            "LocationLjubljana",
-            "VariableMax temperature (°C)Min temperature (°C)Mean temperature (°C)Precipitation (mm)ET₀ (mm)",
-            "Day1 Jan◀▶"
+            "LokacijaLjubljana",
+            "SpremenljivkaNajvišja temperatura (°C)Najnižja temperatura (°C)Povprečna temperatura (°C)Padavine (mm)ET₀ (mm)",
+            "Dan1. jan.◀▶"
           ],
           "variable_select": {
             "selected": "temperature_max",
             "options": [
-              "Max temperature (°C)",
-              "Min temperature (°C)",
-              "Mean temperature (°C)",
-              "Precipitation (mm)",
+              "Najvišja temperatura (°C)",
+              "Najnižja temperatura (°C)",
+              "Povprečna temperatura (°C)",
+              "Padavine (mm)",
               "ET₀ (mm)"
             ]
           },
-          "day_label": "1 Jan",
-          "title": "Max temperature · 1 Jan",
+          "day_label": "1. jan.",
+          "title": "Najvišja temperatura · 1. jan.",
           "subtitle": "Ljubljana",
-          "stats_badge": "Theil-Sen + TFPW MK · τ = 0.35",
-          "total_change": "+3.64°C",
+          "stats_badge": "Theil-Sen + TFPW MK · τ = 0,35",
+          "total_change": "+3,64°C",
           "total_change_color": "rgb(204, 34, 34)",
           "footer": [
             "Theil-Sen regresija + Yue-Wang TFPW Mann-Kendall test · ERA5-Land · nadmorska korekcija"
@@ -67969,7 +67969,7 @@
               "plot_bands": []
             },
             "y_axis": {
-              "title": "Max temperature (°C)",
+              "title": "Najvišja temperatura (°C)",
               "min": null,
               "max": null,
               "categories": null,
@@ -67977,7 +67977,7 @@
                 {
                   "id": "baseline-Ljubljana",
                   "value": 3.972666666666667,
-                  "label": "77-YR MEAN 4.0",
+                  "label": "POVPREČJE 77 let: 4,0",
                   "dash_style": "Dash"
                 }
               ],
@@ -68646,18 +68646,18 @@
       },
       "hero_cards": {
         "rendered": {
-          "headline": "+0.473",
+          "headline": "+0,473",
           "headline_color": "rgb(194, 90, 44)",
           "category": "Katastrofalno",
           "paragraphs": [
             "Podaljšani poletni vročinski valovi presegajo hladilne zmogljivosti mesta. Hudourniške poplave iz okrepljenih alpskih padavin večkrat ogrozijo nizko ležečo kotlino.",
-            "Sto let segrevanja za +4.73 °C – pri trenutnem tempu vsaka 21.1 let doda eno stopinjo.",
+            "Sto let segrevanja za +4,73 °C – pri trenutnem tempu vsaka 21,1 let doda eno stopinjo.",
             "Theil-Sen + TFPW Mann-Kendall"
           ],
           "stats": [
             "Mestni toplotni otok — poletni vročinski stres in tveganje hudourniških poplav v Ljubljanski kotlini",
-            "★★★ p < 0.001",
-            "0.4730",
+            "★★★ p < 0,001",
+            "0,4730",
             "77 let",
             "—"
           ]
@@ -69501,7 +69501,7 @@
           }
         },
         "rendered": {
-          "date_badge": "31.12.",
+          "date_badge": "31. dec.",
           "loc_select": {
             "selected": "Ljubljana",
             "options": [
@@ -69528,13 +69528,13 @@
           },
           "category_label": "Normalno",
           "category_color": "rgb(231, 217, 184)",
-          "description": "Točno takšno, kot 31.12 v Slovenija ponavadi je.",
+          "description": "Točno takšno, kot 31. dec. v Slovenija ponavadi je.",
           "percentile": "34",
           "percentile_label": "percentil",
-          "samples": "1,166 vzorcev",
+          "samples": "1166 vzorcev",
           "preliminary_badge": null,
           "explain": "Temperatura na postaji Ljubljana, razvrstena glede na zapise ERA5-Land od leta 1950 za isto ±7-dnevno okno.",
-          "footer": "1.5 °C · 34. percentil · 1,166 vzorcev (1950–2026)",
+          "footer": "1,5 °C · 34. percentil · 1166 vzorcev (1950–2026)",
           "unavailable_message": null
         },
         "last7": {
@@ -69810,7 +69810,7 @@
                 {
                   "id": null,
                   "value": 1.456,
-                  "label": "DANES: 1.5 °C",
+                  "label": "DANES: 1,5 °C",
                   "dash_style": null
                 }
               ],
@@ -69818,27 +69818,27 @@
                 {
                   "from": -14.74752,
                   "to": -2.43,
-                  "label": "< -2.4°C"
+                  "label": "< −2,4°C"
                 },
                 {
                   "from": -2.43,
                   "to": -0.36,
-                  "label": "-2.4–-0.4°C"
+                  "label": "−2,4–−0,4°C"
                 },
                 {
                   "from": -0.36,
                   "to": 6.49,
-                  "label": "-0.4–6.5°C"
+                  "label": "−0,4–6,5°C"
                 },
                 {
                   "from": 6.49,
                   "to": 9.54,
-                  "label": "6.5–9.5°C"
+                  "label": "6,5–9,5°C"
                 },
                 {
                   "from": 9.54,
                   "to": 16.99552,
-                  "label": "> 9.5°C"
+                  "label": "> 9,5°C"
                 }
               ]
             },
@@ -70676,9 +70676,9 @@
       },
       "today_chart_copy": {
         "_note": "Raw JSX in AliJeVroceERA5.tsx:99-112, mirrored by TodayChartCopy in harness.tsx and checked against the source by main.mjs assertMirroredCopy.",
-        "title": "Dnevne najvišje temperature na postaji Ljubljana za dva tedna okoli 31.12 od 1950",
+        "title": "Dnevne najvišje temperature na postaji Ljubljana za dva tedna okoli 31. dec. od 1950",
         "explain": "Krivulja prikazuje, kako pogosto se je pojavila vsaka vrhunska temperatura na dneve, kot je danes, v vseh letih. Barve označujejo klimatološke cone — od hladne modre prek tipičnega bežastega pasu do ekstremne rdeče.",
-        "footer": "Danes: 1.5 °C · 34. percentil · mediana 3.3 °C · 1,166 opazovanj · 1950–2026"
+        "footer": "Danes: 1,5 °C · 34. percentil · mediana 3,3 °C · 1166 opazovanj · 1950–2026"
       },
       "today_trend": {
         "api": {
@@ -71036,9 +71036,9 @@
           ]
         },
         "rendered": {
-          "title": "Najvišje temperature na postaji Ljubljana okoli Dec 31 · 1950–2025 · trend s projekcijo do 2050",
-          "explain": "Vsaka pika je 90. percentil lapsno popravljene dnevne najvišje temperature na postaji Ljubljana v ±30-dnevnem oknu okoli tega datuma za vsako leto od 1950. Trend Theil-Sen je +0.45 °C/desetletje (p < 0.001). Po tem tempu projekcija kaže 6.0 °C do leta 2050. Zasenčeni pas je 95% interval zaupanja za nagib.",
-          "footer": "Theil-Sen + TFPW MK: +0.45 °C/desetletje · p < 0.001 · τ = 0.344 · 95% CI · 76 let",
+          "title": "Najvišje temperature na postaji Ljubljana okoli 31. dec. · 1950–2025 · trend s projekcijo do 2050",
+          "explain": "Vsaka pika je 90. percentil lapsno popravljene dnevne najvišje temperature na postaji Ljubljana v ±30-dnevnem oknu okoli tega datuma za vsako leto od 1950. Trend Theil-Sen je +0,45 °C/desetletje (p < 0,001). Po tem tempu projekcija kaže 6,0 °C do leta 2050. Zasenčeni pas je 95% interval zaupanja za nagib.",
+          "footer": "Theil-Sen + TFPW MK: +0,45 °C/desetletje · p < 0,001 · τ = 0,344 · 95% CI · 76 let",
           "current_year_plotline": {
             "value": 2026,
             "label": "2026",
@@ -71472,25 +71472,25 @@
       "analysis": {
         "rendered": {
           "toolbar": [
-            "LocationLjubljana",
-            "VariableMax temperature (°C)Min temperature (°C)Mean temperature (°C)Precipitation (mm)ET₀ (mm)",
-            "Day31 Dec◀▶"
+            "LokacijaLjubljana",
+            "SpremenljivkaNajvišja temperatura (°C)Najnižja temperatura (°C)Povprečna temperatura (°C)Padavine (mm)ET₀ (mm)",
+            "Dan31. dec.◀▶"
           ],
           "variable_select": {
             "selected": "temperature_max",
             "options": [
-              "Max temperature (°C)",
-              "Min temperature (°C)",
-              "Mean temperature (°C)",
-              "Precipitation (mm)",
+              "Najvišja temperatura (°C)",
+              "Najnižja temperatura (°C)",
+              "Povprečna temperatura (°C)",
+              "Padavine (mm)",
               "ET₀ (mm)"
             ]
           },
-          "day_label": "31 Dec",
-          "title": "Max temperature · 31 Dec",
+          "day_label": "31. dec.",
+          "title": "Najvišja temperatura · 31. dec.",
           "subtitle": "Ljubljana",
-          "stats_badge": "Theil-Sen + TFPW MK · τ = 0.34",
-          "total_change": "+3.44°C",
+          "stats_badge": "Theil-Sen + TFPW MK · τ = 0,34",
+          "total_change": "+3,44°C",
           "total_change_color": "rgb(204, 34, 34)",
           "footer": [
             "Theil-Sen regresija + Yue-Wang TFPW Mann-Kendall test · ERA5-Land · nadmorska korekcija"
@@ -71510,7 +71510,7 @@
               "plot_bands": []
             },
             "y_axis": {
-              "title": "Max temperature (°C)",
+              "title": "Najvišja temperatura (°C)",
               "min": null,
               "max": null,
               "categories": null,
@@ -71518,7 +71518,7 @@
                 {
                   "id": "baseline-Ljubljana",
                   "value": 4.044666666666668,
-                  "label": "76-YR MEAN 4.0",
+                  "label": "POVPREČJE 76 let: 4,0",
                   "dash_style": "Dash"
                 }
               ],
@@ -72179,18 +72179,18 @@
       },
       "hero_cards": {
         "rendered": {
-          "headline": "+0.452",
+          "headline": "+0,452",
           "headline_color": "rgb(194, 90, 44)",
           "category": "Katastrofalno",
           "paragraphs": [
             "Podaljšani poletni vročinski valovi presegajo hladilne zmogljivosti mesta. Hudourniške poplave iz okrepljenih alpskih padavin večkrat ogrozijo nizko ležečo kotlino.",
-            "Sto let segrevanja za +4.52 °C – pri trenutnem tempu vsaka 22.1 let doda eno stopinjo.",
+            "Sto let segrevanja za +4,52 °C – pri trenutnem tempu vsaka 22,1 let doda eno stopinjo.",
             "Theil-Sen + TFPW Mann-Kendall"
           ],
           "stats": [
             "Mestni toplotni otok — poletni vročinski stres in tveganje hudourniških poplav v Ljubljanski kotlini",
-            "★★★ p < 0.001",
-            "0.4520",
+            "★★★ p < 0,001",
+            "0,4520",
             "76 let",
             "—"
           ]
@@ -73042,7 +73042,7 @@
           }
         },
         "rendered": {
-          "date_badge": "03.08.",
+          "date_badge": "3. avg.",
           "loc_select": {
             "selected": "Ljubljana",
             "options": [
@@ -73069,13 +73069,13 @@
           },
           "category_label": "Peklensko",
           "category_color": "rgb(150, 44, 26)",
-          "description": "Izjemna vročina — vrh 5 % vseh 03.08 od 1950.",
+          "description": "Izjemna vročina — vrh 5 % vseh 3. avg. od 1950.",
           "percentile": "99",
           "percentile_label": "percentil",
-          "samples": "1,140 vzorcev",
+          "samples": "1140 vzorcev",
           "preliminary_badge": null,
           "explain": "Temperatura na postaji Ljubljana, razvrstena glede na zapise ERA5-Land od leta 1950 za isto ±7-dnevno okno.",
-          "footer": "35.6 °C · 99. percentil · 1,140 vzorcev (1950–2026)",
+          "footer": "35,6 °C · 99. percentil · 1140 vzorcev (1950–2026)",
           "unavailable_message": null
         },
         "last7": {
@@ -73351,7 +73351,7 @@
                 {
                   "id": null,
                   "value": 35.591,
-                  "label": "DANES: 35.6 °C",
+                  "label": "DANES: 35,6 °C",
                   "dash_style": null
                 }
               ],
@@ -73359,27 +73359,27 @@
                 {
                   "from": 12.19058,
                   "to": 20.59,
-                  "label": "< 20.6°C"
+                  "label": "< 20,6°C"
                 },
                 {
                   "from": 20.59,
                   "to": 22.14,
-                  "label": "20.6–22.1°C"
+                  "label": "20,6–22,1°C"
                 },
                 {
                   "from": 22.14,
                   "to": 28.44,
-                  "label": "22.1–28.4°C"
+                  "label": "22,1–28,4°C"
                 },
                 {
                   "from": 28.44,
                   "to": 31.36,
-                  "label": "28.4–31.4°C"
+                  "label": "28,4–31,4°C"
                 },
                 {
                   "from": 31.36,
                   "to": 39.806419999999996,
-                  "label": "> 31.4°C"
+                  "label": "> 31,4°C"
                 }
               ]
             },
@@ -74217,9 +74217,9 @@
       },
       "today_chart_copy": {
         "_note": "Raw JSX in AliJeVroceERA5.tsx:99-112, mirrored by TodayChartCopy in harness.tsx and checked against the source by main.mjs assertMirroredCopy.",
-        "title": "Dnevne najvišje temperature na postaji Ljubljana za dva tedna okoli 03.08 od 1950",
+        "title": "Dnevne najvišje temperature na postaji Ljubljana za dva tedna okoli 3. avg. od 1950",
         "explain": "Krivulja prikazuje, kako pogosto se je pojavila vsaka vrhunska temperatura na dneve, kot je danes, v vseh letih. Barve označujejo klimatološke cone — od hladne modre prek tipičnega bežastega pasu do ekstremne rdeče.",
-        "footer": "Danes: 35.6 °C · 99. percentil · mediana 25.1 °C · 1,140 opazovanj · 1950–2026"
+        "footer": "Danes: 35,6 °C · 99. percentil · mediana 25,1 °C · 1140 opazovanj · 1950–2026"
       },
       "today_trend": {
         "api": {
@@ -74577,9 +74577,9 @@
           ]
         },
         "rendered": {
-          "title": "Najvišje temperature na postaji Ljubljana okoli Aug 3 · 1950–2025 · trend s projekcijo do 2050",
-          "explain": "Vsaka pika je 90. percentil lapsno popravljene dnevne najvišje temperature na postaji Ljubljana v ±30-dnevnem oknu okoli tega datuma za vsako leto od 1950. Trend Theil-Sen je +0.53 °C/desetletje (p < 0.001). Po tem tempu projekcija kaže 27.3 °C do leta 2050. Zasenčeni pas je 95% interval zaupanja za nagib.",
-          "footer": "Theil-Sen + TFPW MK: +0.53 °C/desetletje · p < 0.001 · τ = 0.437 · 95% CI · 76 let",
+          "title": "Najvišje temperature na postaji Ljubljana okoli 3. avg. · 1950–2025 · trend s projekcijo do 2050",
+          "explain": "Vsaka pika je 90. percentil lapsno popravljene dnevne najvišje temperature na postaji Ljubljana v ±30-dnevnem oknu okoli tega datuma za vsako leto od 1950. Trend Theil-Sen je +0,53 °C/desetletje (p < 0,001). Po tem tempu projekcija kaže 27,3 °C do leta 2050. Zasenčeni pas je 95% interval zaupanja za nagib.",
+          "footer": "Theil-Sen + TFPW MK: +0,53 °C/desetletje · p < 0,001 · τ = 0,437 · 95% CI · 76 let",
           "current_year_plotline": {
             "value": 2026,
             "label": "2026",
@@ -75013,25 +75013,25 @@
       "analysis": {
         "rendered": {
           "toolbar": [
-            "LocationLjubljana",
-            "VariableMax temperature (°C)Min temperature (°C)Mean temperature (°C)Precipitation (mm)ET₀ (mm)",
-            "Day3 Aug◀▶"
+            "LokacijaLjubljana",
+            "SpremenljivkaNajvišja temperatura (°C)Najnižja temperatura (°C)Povprečna temperatura (°C)Padavine (mm)ET₀ (mm)",
+            "Dan3. avg.◀▶"
           ],
           "variable_select": {
             "selected": "temperature_max",
             "options": [
-              "Max temperature (°C)",
-              "Min temperature (°C)",
-              "Mean temperature (°C)",
-              "Precipitation (mm)",
+              "Najvišja temperatura (°C)",
+              "Najnižja temperatura (°C)",
+              "Povprečna temperatura (°C)",
+              "Padavine (mm)",
               "ET₀ (mm)"
             ]
           },
-          "day_label": "3 Aug",
-          "title": "Max temperature · 3 Aug",
+          "day_label": "3. avg.",
+          "title": "Najvišja temperatura · 3. avg.",
           "subtitle": "Ljubljana",
-          "stats_badge": "Theil-Sen + TFPW MK · τ = 0.44",
-          "total_change": "+3.99°C",
+          "stats_badge": "Theil-Sen + TFPW MK · τ = 0,44",
+          "total_change": "+3,99°C",
           "total_change_color": "rgb(204, 34, 34)",
           "footer": [
             "Theil-Sen regresija + Yue-Wang TFPW Mann-Kendall test · ERA5-Land · nadmorska korekcija"
@@ -75051,7 +75051,7 @@
               "plot_bands": []
             },
             "y_axis": {
-              "title": "Max temperature (°C)",
+              "title": "Najvišja temperatura (°C)",
               "min": null,
               "max": null,
               "categories": null,
@@ -75059,7 +75059,7 @@
                 {
                   "id": "baseline-Ljubljana",
                   "value": 25.27533333333334,
-                  "label": "76-YR MEAN 25.3",
+                  "label": "POVPREČJE 76 let: 25,3",
                   "dash_style": "Dash"
                 }
               ],
@@ -75720,18 +75720,18 @@
       },
       "hero_cards": {
         "rendered": {
-          "headline": "+0.525",
+          "headline": "+0,525",
           "headline_color": "rgb(194, 90, 44)",
           "category": "Katastrofalno",
           "paragraphs": [
             "Podaljšani poletni vročinski valovi presegajo hladilne zmogljivosti mesta. Hudourniške poplave iz okrepljenih alpskih padavin večkrat ogrozijo nizko ležečo kotlino.",
-            "Sto let segrevanja za +5.25 °C – pri trenutnem tempu vsaka 19.0 let doda eno stopinjo.",
+            "Sto let segrevanja za +5,25 °C – pri trenutnem tempu vsaka 19,0 let doda eno stopinjo.",
             "Theil-Sen + TFPW Mann-Kendall"
           ],
           "stats": [
             "Mestni toplotni otok — poletni vročinski stres in tveganje hudourniških poplav v Ljubljanski kotlini",
-            "★★★ p < 0.001",
-            "0.5250",
+            "★★★ p < 0,001",
+            "0,5250",
             "76 let",
             "—"
           ]
@@ -76583,7 +76583,7 @@
           }
         },
         "rendered": {
-          "date_badge": "03.08.",
+          "date_badge": "3. avg.",
           "loc_select": {
             "selected": "Kredarica",
             "options": [
@@ -76610,13 +76610,13 @@
           },
           "category_label": "Peklensko",
           "category_color": "rgb(150, 44, 26)",
-          "description": "Izjemna vročina — vrh 5 % vseh 03.08 od 1950.",
+          "description": "Izjemna vročina — vrh 5 % vseh 3. avg. od 1950.",
           "percentile": "100",
           "percentile_label": "percentil",
-          "samples": "1,140 vzorcev",
+          "samples": "1140 vzorcev",
           "preliminary_badge": null,
           "explain": "Temperatura na postaji Kredarica, razvrstena glede na zapise ERA5-Land od leta 1950 za isto ±7-dnevno okno.",
-          "footer": "21.7 °C · 100. percentil · 1,140 vzorcev (1950–2026)",
+          "footer": "21,7 °C · 100. percentil · 1140 vzorcev (1950–2026)",
           "unavailable_message": null
         },
         "last7": {
@@ -76892,7 +76892,7 @@
                 {
                   "id": null,
                   "value": 21.743,
-                  "label": "DANES: 21.7 °C",
+                  "label": "DANES: 21,7 °C",
                   "dash_style": null
                 }
               ],
@@ -76900,27 +76900,27 @@
                 {
                   "from": -0.7545999999999998,
                   "to": 7.09,
-                  "label": "< 7.1°C"
+                  "label": "< 7,1°C"
                 },
                 {
                   "from": 7.09,
                   "to": 8.49,
-                  "label": "7.1–8.5°C"
+                  "label": "7,1–8,5°C"
                 },
                 {
                   "from": 8.49,
                   "to": 14.19,
-                  "label": "8.5–14.2°C"
+                  "label": "8,5–14,2°C"
                 },
                 {
                   "from": 14.19,
                   "to": 16.79,
-                  "label": "14.2–16.8°C"
+                  "label": "14,2–16,8°C"
                 },
                 {
                   "from": 16.79,
                   "to": 25.2406,
-                  "label": "> 16.8°C"
+                  "label": "> 16,8°C"
                 }
               ]
             },
@@ -77758,9 +77758,9 @@
       },
       "today_chart_copy": {
         "_note": "Raw JSX in AliJeVroceERA5.tsx:99-112, mirrored by TodayChartCopy in harness.tsx and checked against the source by main.mjs assertMirroredCopy.",
-        "title": "Dnevne najvišje temperature na postaji Kredarica za dva tedna okoli 03.08 od 1950",
+        "title": "Dnevne najvišje temperature na postaji Kredarica za dva tedna okoli 3. avg. od 1950",
         "explain": "Krivulja prikazuje, kako pogosto se je pojavila vsaka vrhunska temperatura na dneve, kot je danes, v vseh letih. Barve označujejo klimatološke cone — od hladne modre prek tipičnega bežastega pasu do ekstremne rdeče.",
-        "footer": "Danes: 21.7 °C · 100. percentil · mediana 11.4 °C · 1,140 opazovanj · 1950–2026"
+        "footer": "Danes: 21,7 °C · 100. percentil · mediana 11,4 °C · 1140 opazovanj · 1950–2026"
       },
       "today_trend": {
         "api": {
@@ -78118,9 +78118,9 @@
           ]
         },
         "rendered": {
-          "title": "Najvišje temperature na postaji Kredarica okoli Aug 3 · 1950–2025 · trend s projekcijo do 2050",
-          "explain": "Vsaka pika je 90. percentil lapsno popravljene dnevne najvišje temperature na postaji Kredarica v ±30-dnevnem oknu okoli tega datuma za vsako leto od 1950. Trend Theil-Sen je +0.33 °C/desetletje (p < 0.001). Po tem tempu projekcija kaže 12.6 °C do leta 2050. Zasenčeni pas je 95% interval zaupanja za nagib.",
-          "footer": "Theil-Sen + TFPW MK: +0.33 °C/desetletje · p < 0.001 · τ = 0.369 · 95% CI · 76 let",
+          "title": "Najvišje temperature na postaji Kredarica okoli 3. avg. · 1950–2025 · trend s projekcijo do 2050",
+          "explain": "Vsaka pika je 90. percentil lapsno popravljene dnevne najvišje temperature na postaji Kredarica v ±30-dnevnem oknu okoli tega datuma za vsako leto od 1950. Trend Theil-Sen je +0,33 °C/desetletje (p < 0,001). Po tem tempu projekcija kaže 12,6 °C do leta 2050. Zasenčeni pas je 95% interval zaupanja za nagib.",
+          "footer": "Theil-Sen + TFPW MK: +0,33 °C/desetletje · p < 0,001 · τ = 0,369 · 95% CI · 76 let",
           "current_year_plotline": {
             "value": 2026,
             "label": "2026",
@@ -78554,25 +78554,25 @@
       "analysis": {
         "rendered": {
           "toolbar": [
-            "LocationKredarica",
-            "VariableMax temperature (°C)Min temperature (°C)Mean temperature (°C)Precipitation (mm)ET₀ (mm)",
-            "Day3 Aug◀▶"
+            "LokacijaKredarica",
+            "SpremenljivkaNajvišja temperatura (°C)Najnižja temperatura (°C)Povprečna temperatura (°C)Padavine (mm)ET₀ (mm)",
+            "Dan3. avg.◀▶"
           ],
           "variable_select": {
             "selected": "temperature_max",
             "options": [
-              "Max temperature (°C)",
-              "Min temperature (°C)",
-              "Mean temperature (°C)",
-              "Precipitation (mm)",
+              "Najvišja temperatura (°C)",
+              "Najnižja temperatura (°C)",
+              "Povprečna temperatura (°C)",
+              "Padavine (mm)",
               "ET₀ (mm)"
             ]
           },
-          "day_label": "3 Aug",
-          "title": "Max temperature · 3 Aug",
+          "day_label": "3. avg.",
+          "title": "Najvišja temperatura · 3. avg.",
           "subtitle": "Kredarica",
-          "stats_badge": "Theil-Sen + TFPW MK · τ = 0.37",
-          "total_change": "+2.54°C",
+          "stats_badge": "Theil-Sen + TFPW MK · τ = 0,37",
+          "total_change": "+2,54°C",
           "total_change_color": "rgb(204, 34, 34)",
           "footer": [
             "Theil-Sen regresija + Yue-Wang TFPW Mann-Kendall test · ERA5-Land · nadmorska korekcija"
@@ -78592,7 +78592,7 @@
               "plot_bands": []
             },
             "y_axis": {
-              "title": "Max temperature (°C)",
+              "title": "Najvišja temperatura (°C)",
               "min": null,
               "max": null,
               "categories": null,
@@ -78600,7 +78600,7 @@
                 {
                   "id": "baseline-Kredarica",
                   "value": 11.314666666666666,
-                  "label": "76-YR MEAN 11.3",
+                  "label": "POVPREČJE 76 let: 11,3",
                   "dash_style": "Dash"
                 }
               ],
@@ -79261,18 +79261,18 @@
       },
       "hero_cards": {
         "rendered": {
-          "headline": "+0.334",
+          "headline": "+0,334",
           "headline_color": "rgb(194, 90, 44)",
           "category": "Katastrofalno",
           "paragraphs": [
             "Popolna izguba Triglavskega ledenika — narodni simbol in vir savinjskih rek. Propad alpskega ekosistema sproži kaskadne učinke.",
-            "Sto let segrevanja za +3.34 °C – pri trenutnem tempu vsaka 29.9 let doda eno stopinjo.",
+            "Sto let segrevanja za +3,34 °C – pri trenutnem tempu vsaka 29,9 let doda eno stopinjo.",
             "Theil-Sen + TFPW Mann-Kendall"
           ],
           "stats": [
             "Izguba Triglavskega ledenika — izsušitev izvirnih vod za Slovenijo reke",
-            "★★★ p < 0.001",
-            "0.3340",
+            "★★★ p < 0,001",
+            "0,3340",
             "76 let",
             "—"
           ]
@@ -80124,7 +80124,7 @@
           }
         },
         "rendered": {
-          "date_badge": "07.02.",
+          "date_badge": "7. feb.",
           "loc_select": {
             "selected": "Ljubljana",
             "options": [
@@ -80151,13 +80151,13 @@
           },
           "category_label": "Zmrzujoče",
           "category_color": "rgb(58, 90, 138)",
-          "description": "Med najhladnejšimi 07.02 v naših 77 letih zapisov.",
+          "description": "Med najhladnejšimi 7. feb. v naših 77 letih zapisov.",
           "percentile": "3",
           "percentile_label": "percentil",
-          "samples": "1,155 vzorcev",
+          "samples": "1155 vzorcev",
           "preliminary_badge": null,
           "explain": "Temperatura na postaji Ljubljana, razvrstena glede na zapise ERA5-Land od leta 1950 za isto ±7-dnevno okno.",
-          "footer": "-5.8 °C · 3. percentil · 1,155 vzorcev (1950–2026)",
+          "footer": "−5,8 °C · 3. percentil · 1155 vzorcev (1950–2026)",
           "unavailable_message": null
         },
         "last7": {
@@ -80433,7 +80433,7 @@
                 {
                   "id": null,
                   "value": -5.759,
-                  "label": "DANES: -5.8 °C",
+                  "label": "DANES: −5,8 °C",
                   "dash_style": null
                 }
               ],
@@ -80441,27 +80441,27 @@
                 {
                   "from": -14.6882,
                   "to": -2.06,
-                  "label": "< -2.1°C"
+                  "label": "< −2,1°C"
                 },
                 {
                   "from": -2.06,
                   "to": 0.53,
-                  "label": "-2.1–0.5°C"
+                  "label": "−2,1–0,5°C"
                 },
                 {
                   "from": 0.53,
                   "to": 8.25,
-                  "label": "0.5–8.3°C"
+                  "label": "0,5–8,3°C"
                 },
                 {
                   "from": 8.25,
                   "to": 10.95,
-                  "label": "8.3–10.9°C"
+                  "label": "8,3–10,9°C"
                 },
                 {
                   "from": 10.95,
                   "to": 20.6702,
-                  "label": "> 10.9°C"
+                  "label": "> 10,9°C"
                 }
               ]
             },
@@ -81299,9 +81299,9 @@
       },
       "today_chart_copy": {
         "_note": "Raw JSX in AliJeVroceERA5.tsx:99-112, mirrored by TodayChartCopy in harness.tsx and checked against the source by main.mjs assertMirroredCopy.",
-        "title": "Dnevne najvišje temperature na postaji Ljubljana za dva tedna okoli 07.02 od 1950",
+        "title": "Dnevne najvišje temperature na postaji Ljubljana za dva tedna okoli 7. feb. od 1950",
         "explain": "Krivulja prikazuje, kako pogosto se je pojavila vsaka vrhunska temperatura na dneve, kot je danes, v vseh letih. Barve označujejo klimatološke cone — od hladne modre prek tipičnega bežastega pasu do ekstremne rdeče.",
-        "footer": "Danes: -5.8 °C · 3. percentil · mediana 4.8 °C · 1,155 opazovanj · 1950–2026"
+        "footer": "Danes: −5,8 °C · 3. percentil · mediana 4,8 °C · 1155 opazovanj · 1950–2026"
       },
       "today_trend": {
         "api": {
@@ -81663,9 +81663,9 @@
           ]
         },
         "rendered": {
-          "title": "Najvišje temperature na postaji Ljubljana okoli Feb 7 · 1950–2026 · trend s projekcijo do 2050",
-          "explain": "Vsaka pika je 90. percentil lapsno popravljene dnevne najvišje temperature na postaji Ljubljana v ±30-dnevnem oknu okoli tega datuma za vsako leto od 1950. Trend Theil-Sen je +0.55 °C/desetletje (p < 0.001). Po tem tempu projekcija kaže 7.7 °C do leta 2050. Zasenčeni pas je 95% interval zaupanja za nagib.",
-          "footer": "Theil-Sen + TFPW MK: +0.55 °C/desetletje · p < 0.001 · τ = 0.341 · 95% CI · 77 let",
+          "title": "Najvišje temperature na postaji Ljubljana okoli 7. feb. · 1950–2026 · trend s projekcijo do 2050",
+          "explain": "Vsaka pika je 90. percentil lapsno popravljene dnevne najvišje temperature na postaji Ljubljana v ±30-dnevnem oknu okoli tega datuma za vsako leto od 1950. Trend Theil-Sen je +0,55 °C/desetletje (p < 0,001). Po tem tempu projekcija kaže 7,7 °C do leta 2050. Zasenčeni pas je 95% interval zaupanja za nagib.",
+          "footer": "Theil-Sen + TFPW MK: +0,55 °C/desetletje · p < 0,001 · τ = 0,341 · 95% CI · 77 let",
           "current_year_plotline": {
             "value": 2026,
             "label": "2026",
@@ -82103,25 +82103,25 @@
       "analysis": {
         "rendered": {
           "toolbar": [
-            "LocationLjubljana",
-            "VariableMax temperature (°C)Min temperature (°C)Mean temperature (°C)Precipitation (mm)ET₀ (mm)",
-            "Day7 Feb◀▶"
+            "LokacijaLjubljana",
+            "SpremenljivkaNajvišja temperatura (°C)Najnižja temperatura (°C)Povprečna temperatura (°C)Padavine (mm)ET₀ (mm)",
+            "Dan7. feb.◀▶"
           ],
           "variable_select": {
             "selected": "temperature_max",
             "options": [
-              "Max temperature (°C)",
-              "Min temperature (°C)",
-              "Mean temperature (°C)",
-              "Precipitation (mm)",
+              "Najvišja temperatura (°C)",
+              "Najnižja temperatura (°C)",
+              "Povprečna temperatura (°C)",
+              "Padavine (mm)",
               "ET₀ (mm)"
             ]
           },
-          "day_label": "7 Feb",
-          "title": "Max temperature · 7 Feb",
+          "day_label": "7. feb.",
+          "title": "Najvišja temperatura · 7. feb.",
           "subtitle": "Ljubljana",
-          "stats_badge": "Theil-Sen + TFPW MK · τ = 0.34",
-          "total_change": "+4.24°C",
+          "stats_badge": "Theil-Sen + TFPW MK · τ = 0,34",
+          "total_change": "+4,24°C",
           "total_change_color": "rgb(204, 34, 34)",
           "footer": [
             "Theil-Sen regresija + Yue-Wang TFPW Mann-Kendall test · ERA5-Land · nadmorska korekcija"
@@ -82141,7 +82141,7 @@
               "plot_bands": []
             },
             "y_axis": {
-              "title": "Max temperature (°C)",
+              "title": "Najvišja temperatura (°C)",
               "min": null,
               "max": null,
               "categories": null,
@@ -82149,7 +82149,7 @@
                 {
                   "id": "baseline-Ljubljana",
                   "value": 5.375,
-                  "label": "77-YR MEAN 5.4",
+                  "label": "POVPREČJE 77 let: 5,4",
                   "dash_style": "Dash"
                 }
               ],
@@ -82818,18 +82818,18 @@
       },
       "hero_cards": {
         "rendered": {
-          "headline": "+0.550",
+          "headline": "+0,550",
           "headline_color": "rgb(194, 90, 44)",
           "category": "Katastrofalno",
           "paragraphs": [
             "Podaljšani poletni vročinski valovi presegajo hladilne zmogljivosti mesta. Hudourniške poplave iz okrepljenih alpskih padavin večkrat ogrozijo nizko ležečo kotlino.",
-            "Sto let segrevanja za +5.50 °C – pri trenutnem tempu vsaka 18.2 let doda eno stopinjo.",
+            "Sto let segrevanja za +5,50 °C – pri trenutnem tempu vsaka 18,2 let doda eno stopinjo.",
             "Theil-Sen + TFPW Mann-Kendall"
           ],
           "stats": [
             "Mestni toplotni otok — poletni vročinski stres in tveganje hudourniških poplav v Ljubljanski kotlini",
-            "★★★ p < 0.001",
-            "0.5500",
+            "★★★ p < 0,001",
+            "0,5500",
             "77 let",
             "—"
           ]
@@ -83686,7 +83686,7 @@
           }
         },
         "rendered": {
-          "date_badge": "07.01.",
+          "date_badge": "7. jan.",
           "loc_select": {
             "selected": "Kredarica",
             "options": [
@@ -83713,13 +83713,13 @@
           },
           "category_label": "Zmrzujoče",
           "category_color": "rgb(58, 90, 138)",
-          "description": "Med najhladnejšimi 07.01 v naših 77 letih zapisov.",
+          "description": "Med najhladnejšimi 7. jan. v naših 77 letih zapisov.",
           "percentile": "0",
           "percentile_label": "percentil",
-          "samples": "1,173 vzorcev",
+          "samples": "1173 vzorcev",
           "preliminary_badge": null,
           "explain": "Temperatura na postaji Kredarica, razvrstena glede na zapise ERA5-Land od leta 1950 za isto ±7-dnevno okno.",
-          "footer": "-23.7 °C · 0. percentil · 1,173 vzorcev (1950–2026)",
+          "footer": "−23,7 °C · 0. percentil · 1173 vzorcev (1950–2026)",
           "unavailable_message": null
         },
         "last7": {
@@ -83995,7 +83995,7 @@
                 {
                   "id": null,
                   "value": -23.707,
-                  "label": "DANES: -23.7 °C",
+                  "label": "DANES: −23,7 °C",
                   "dash_style": null
                 }
               ],
@@ -84003,27 +84003,27 @@
                 {
                   "from": -29.81448,
                   "to": -15.09,
-                  "label": "< -15.1°C"
+                  "label": "< −15,1°C"
                 },
                 {
                   "from": -15.09,
                   "to": -12.75,
-                  "label": "-15.1–-12.8°C"
+                  "label": "−15,1–−12,8°C"
                 },
                 {
                   "from": -12.75,
                   "to": -5.61,
-                  "label": "-12.8–-5.6°C"
+                  "label": "−12,8–−5,6°C"
                 },
                 {
                   "from": -5.61,
                   "to": -2.96,
-                  "label": "-5.6–-3.0°C"
+                  "label": "−5,6–−3,0°C"
                 },
                 {
                   "from": -2.96,
                   "to": 9.56248,
-                  "label": "> -3.0°C"
+                  "label": "> −3,0°C"
                 }
               ]
             },
@@ -84861,9 +84861,9 @@
       },
       "today_chart_copy": {
         "_note": "Raw JSX in AliJeVroceERA5.tsx:99-112, mirrored by TodayChartCopy in harness.tsx and checked against the source by main.mjs assertMirroredCopy.",
-        "title": "Dnevne najvišje temperature na postaji Kredarica za dva tedna okoli 07.01 od 1950",
+        "title": "Dnevne najvišje temperature na postaji Kredarica za dva tedna okoli 7. jan. od 1950",
         "explain": "Krivulja prikazuje, kako pogosto se je pojavila vsaka vrhunska temperatura na dneve, kot je danes, v vseh letih. Barve označujejo klimatološke cone — od hladne modre prek tipičnega bežastega pasu do ekstremne rdeče.",
-        "footer": "Danes: -23.7 °C · 0. percentil · mediana -8.8 °C · 1,173 opazovanj · 1950–2026"
+        "footer": "Danes: −23,7 °C · 0. percentil · mediana −8,8 °C · 1173 opazovanj · 1950–2026"
       },
       "today_trend": {
         "api": {
@@ -85225,9 +85225,9 @@
           ]
         },
         "rendered": {
-          "title": "Najvišje temperature na postaji Kredarica okoli Jan 7 · 1950–2026 · trend s projekcijo do 2050",
-          "explain": "Vsaka pika je 90. percentil lapsno popravljene dnevne najvišje temperature na postaji Kredarica v ±30-dnevnem oknu okoli tega datuma za vsako leto od 1950. Trend Theil-Sen je +0.49 °C/desetletje (p < 0.001). Po tem tempu projekcija kaže -5.6 °C do leta 2050. Zasenčeni pas je 95% interval zaupanja za nagib.",
-          "footer": "Theil-Sen + TFPW MK: +0.49 °C/desetletje · p < 0.001 · τ = 0.405 · 95% CI · 77 let",
+          "title": "Najvišje temperature na postaji Kredarica okoli 7. jan. · 1950–2026 · trend s projekcijo do 2050",
+          "explain": "Vsaka pika je 90. percentil lapsno popravljene dnevne najvišje temperature na postaji Kredarica v ±30-dnevnem oknu okoli tega datuma za vsako leto od 1950. Trend Theil-Sen je +0,49 °C/desetletje (p < 0,001). Po tem tempu projekcija kaže −5,6 °C do leta 2050. Zasenčeni pas je 95% interval zaupanja za nagib.",
+          "footer": "Theil-Sen + TFPW MK: +0,49 °C/desetletje · p < 0,001 · τ = 0,405 · 95% CI · 77 let",
           "current_year_plotline": {
             "value": 2026,
             "label": "2026",
@@ -85665,25 +85665,25 @@
       "analysis": {
         "rendered": {
           "toolbar": [
-            "LocationKredarica",
-            "VariableMax temperature (°C)Min temperature (°C)Mean temperature (°C)Precipitation (mm)ET₀ (mm)",
-            "Day7 Jan◀▶"
+            "LokacijaKredarica",
+            "SpremenljivkaNajvišja temperatura (°C)Najnižja temperatura (°C)Povprečna temperatura (°C)Padavine (mm)ET₀ (mm)",
+            "Dan7. jan.◀▶"
           ],
           "variable_select": {
             "selected": "temperature_max",
             "options": [
-              "Max temperature (°C)",
-              "Min temperature (°C)",
-              "Mean temperature (°C)",
-              "Precipitation (mm)",
+              "Najvišja temperatura (°C)",
+              "Najnižja temperatura (°C)",
+              "Povprečna temperatura (°C)",
+              "Padavine (mm)",
               "ET₀ (mm)"
             ]
           },
-          "day_label": "7 Jan",
-          "title": "Max temperature · 7 Jan",
+          "day_label": "7. jan.",
+          "title": "Najvišja temperatura · 7. jan.",
           "subtitle": "Kredarica",
-          "stats_badge": "Theil-Sen + TFPW MK · τ = 0.41",
-          "total_change": "+3.79°C",
+          "stats_badge": "Theil-Sen + TFPW MK · τ = 0,41",
+          "total_change": "+3,79°C",
           "total_change_color": "rgb(204, 34, 34)",
           "footer": [
             "Theil-Sen regresija + Yue-Wang TFPW Mann-Kendall test · ERA5-Land · nadmorska korekcija"
@@ -85703,7 +85703,7 @@
               "plot_bands": []
             },
             "y_axis": {
-              "title": "Max temperature (°C)",
+              "title": "Najvišja temperatura (°C)",
               "min": null,
               "max": null,
               "categories": null,
@@ -85711,7 +85711,7 @@
                 {
                   "id": "baseline-Kredarica",
                   "value": -7.949666666666668,
-                  "label": "77-YR MEAN -7.9",
+                  "label": "POVPREČJE 77 let: −7,9",
                   "dash_style": "Dash"
                 }
               ],
@@ -86380,18 +86380,18 @@
       },
       "hero_cards": {
         "rendered": {
-          "headline": "+0.492",
+          "headline": "+0,492",
           "headline_color": "rgb(194, 90, 44)",
           "category": "Katastrofalno",
           "paragraphs": [
             "Popolna izguba Triglavskega ledenika — narodni simbol in vir savinjskih rek. Propad alpskega ekosistema sproži kaskadne učinke.",
-            "Sto let segrevanja za +4.92 °C – pri trenutnem tempu vsaka 20.3 let doda eno stopinjo.",
+            "Sto let segrevanja za +4,92 °C – pri trenutnem tempu vsaka 20,3 let doda eno stopinjo.",
             "Theil-Sen + TFPW Mann-Kendall"
           ],
           "stats": [
             "Izguba Triglavskega ledenika — izsušitev izvirnih vod za Slovenijo reke",
-            "★★★ p < 0.001",
-            "0.4920",
+            "★★★ p < 0,001",
+            "0,4920",
             "77 let",
             "—"
           ]

--- a/tests/snapshot/harness.tsx
+++ b/tests/snapshot/harness.tsx
@@ -58,6 +58,7 @@ import {
 } from "../../code/ali-je-vroce-era5/api.ts";
 import { installFixtures, misses } from "../../code/ali-je-vroce-era5/fixtures/install.ts";
 import { today as todayIso, todayYear } from "../../code/ali-je-vroce-era5/clock.ts";
+import { t, fmtNum, fmtInt, fmtMonthDay } from "../../code/ali-je-vroce-era5/i18n/format.ts";
 import type { SiteMeta, TodayStatus, Last7 } from "../../code/ali-je-vroce-era5/types.ts";
 
 import { TodayCard } from "../../code/ali-je-vroce-era5/components/TodayCard.tsx";
@@ -614,45 +615,56 @@ function captureAnalysis(unit: Unit): any {
 // editing the page without editing the harness fails the run rather than
 // baselining a string the page no longer renders.
 
-const EN_MONTHS: Record<string, string> = {
-  Jan: "01", Feb: "02", Mar: "03", Apr: "04", May: "05", Jun: "06",
-  Jul: "07", Aug: "08", Sep: "09", Oct: "10", Nov: "11", Dec: "12",
+// T-5.5 — the mirrored copy now goes through the SAME i18n catalogue + formatter
+// (t / fmtMonthDay / fmtNum / fmtInt) as the page, so it cannot drift on wording
+// or number formatting. day_label ("Mon D") maps to a Slovenian short date exactly
+// as AliJeVroceERA5.fmtDayLabel does.
+const EN_MONTHS: Record<string, number> = {
+  Jan: 1, Feb: 2, Mar: 3, Apr: 4, May: 5, Jun: 6,
+  Jul: 7, Aug: 8, Sep: 9, Oct: 10, Nov: 11, Dec: 12,
 };
-
-/** AliJeVroceERA5.tsx:23-26. */
 function fmtDayLabel(dl: string): string {
   const [mon, day] = dl.split(" ");
-  return `${(day ?? "").padStart(2, "0")}.${EN_MONTHS[mon ?? ""] ?? "??"}`;
+  const m = EN_MONTHS[mon ?? ""] ?? 0;
+  return m ? fmtMonthDay(m, Number(day)) : "??";
 }
 
-/** Mirrors AliJeVroceERA5.tsx:99-112 — the today-chart title, explain and foot. */
+/** Mirrors AliJeVroceERA5.tsx:104-124 — the today-chart title, explain and foot. */
 function TodayChartCopy(props: { data: TodayStatus; isNat: boolean }) {
-  const t = () => props.data;
+  const d = () => props.data;
   return (
     <div class="today-chart">
       <div class="today-chart-title">
         {props.isNat
-          ? `Dnevne najvišje temperature v Sloveniji za dva tedna okoli ${fmtDayLabel(t().day_label ?? "")} od ${t().year_min}`
-          : `Dnevne najvišje temperature na postaji ${t().loc!.replace(/_/g, " ")} za dva tedna okoli ${fmtDayLabel(t().day_label ?? "")} od ${t().year_min}`}
+          ? t("today.chart_title_nat", { day: fmtDayLabel(d().day_label ?? ""), year_min: d().year_min ?? 0 })
+          : t("today.chart_title_station", { station: d().loc!.replace(/_/g, " "), day: fmtDayLabel(d().day_label ?? ""), year_min: d().year_min ?? 0 })}
       </div>
       <p class="today-explain" style={{ "font-size": "12px", "padding-top": "6px" }}>
-        Krivulja prikazuje, kako pogosto se je pojavila vsaka vrhunska temperatura na dneve, kot je danes, v vseh letih. Barve označujejo klimatološke cone — od hladne modre prek tipičnega bežastega pasu do ekstremne rdeče.
+        {t("today.chart_explain")}
       </p>
       <div class="today-foot">
-        {`${props.isNat ? "Slovenija" : "Danes"}: ${t().today_temp!.toFixed(1)} °C · ${t().percentile!.toFixed(0)}. percentil · mediana ${t().cutoffs!.p50.toFixed(1)} °C · ${(t().n_samples ?? 0).toLocaleString()} opazovanj · ${t().year_min}–${t().year_max}`}
+        {t("today.foot2", {
+          region: props.isNat ? t("today.foot2_region_nat") : t("today.foot2_region_day"),
+          temp: fmtNum(d().today_temp!, 1),
+          pct: fmtInt(d().percentile!),
+          median: fmtNum(d().cutoffs!.p50, 1),
+          count: d().n_samples ?? 0,
+          year_min: d().year_min ?? 0,
+          year_max: d().year_max ?? 0,
+        })}
       </div>
     </div>
   );
 }
 
-/** Mirrors AliJeVroceERA5.tsx:137-145 — the map panel header. */
+/** Mirrors AliJeVroceERA5.tsx:155-158 — the map panel header. */
 function MapPanelHeader(props: { mapLoc: string | null; stationCount: number }) {
   return (
     <div>
       <div class="mirror-panel-title">
-        {props.mapLoc ? props.mapLoc.replace(/_/g, " ") : `Slovenija — vseh ${props.stationCount} postaj`}
+        {props.mapLoc ? props.mapLoc.replace(/_/g, " ") : t("map.panel_title_all", { count: props.stationCount })}
       </div>
-      <div class="mirror-panel-sub">{props.stationCount} postaj · ERA5</div>
+      <div class="mirror-panel-sub">{t("map.panel_sub_count", { count: props.stationCount })}</div>
     </div>
   );
 }

--- a/tests/typecheck-allowlist.txt
+++ b/tests/typecheck-allowlist.txt
@@ -17,11 +17,11 @@
 #   yarn typecheck 2>&1 | grep -E '^\S.*\([0-9]+,[0-9]+\): error TS' \
 #     | sed -E 's/: error (TS[0-9]+).*/: \1/'
 
-code/ali-je-vroce-era5/charts/DistributionChart.tsx(42,10): TS2352
-code/ali-je-vroce-era5/charts/RegressionChart.tsx(38,23): TS2724
-code/ali-je-vroce-era5/charts/RegressionChart.tsx(76,33): TS2352
-code/ali-je-vroce-era5/charts/RegressionChart.tsx(97,36): TS2694
-code/ali-je-vroce-era5/charts/TodayGauge.tsx(43,41): TS2352
-code/ali-je-vroce-era5/charts/YearRoundChart.tsx(57,41): TS2352
-code/ali-je-vroce-era5/components/TodayLast7Chart.tsx(36,41): TS2352
-code/ali-je-vroce-era5/components/TodayTrendChart.tsx(52,41): TS2352
+code/ali-je-vroce-era5/charts/DistributionChart.tsx(46,10): TS2352
+code/ali-je-vroce-era5/charts/RegressionChart.tsx(39,23): TS2724
+code/ali-je-vroce-era5/charts/RegressionChart.tsx(77,33): TS2352
+code/ali-je-vroce-era5/charts/RegressionChart.tsx(98,36): TS2694
+code/ali-je-vroce-era5/charts/TodayGauge.tsx(44,41): TS2352
+code/ali-je-vroce-era5/charts/YearRoundChart.tsx(58,41): TS2352
+code/ali-je-vroce-era5/components/TodayLast7Chart.tsx(40,41): TS2352
+code/ali-je-vroce-era5/components/TodayTrendChart.tsx(53,41): TS2352


### PR DESCRIPTION
## T-5.5 — Slovenian i18n extraction (D-8)

There was no i18n mechanism (the salvaged sl_default.json was dead, all strings hardcoded). Per decision, built a dependency-free ICU-subset runtime (`i18n/format.ts`) with native `Intl.PluralRules("sl")` (dual/few/other) + `sl-SI` formatters.

**Extracted** all JSX text, Highcharts `accessibility.description`, every tooltip/dataLabel/plotLine formatter, and the Highcharts `lang` object into `i18n/sl.ts` (+ `hero-content.ts` for 108 per-location prose strings, byte-verified). No concatenation around any number/date, including in Highcharts formatters. Deleted contradictory `languages:["en"]`, aligned si.yaml. No switcher/routing/hreflang (D-8).

**Value-neutral (verified):** caught that `Intl.NumberFormat` rounds differently from `toFixed` (would've shifted a trend +0.35→+0.36); pre-rounded to fix. Digit-diffed all 551 moved snapshot paths — no data value or colour moved, only separators/dates/translations.

**Flagged for content review:** register wording ("Peklensko"/"stoletni"), numeral-genitive agreement, the English Highcharts `lang` strings, phrase-level copy. All Slovenian now centralised in `i18n/sl.ts` — the content-authoring seam.

**Gates:** typecheck OK (8 allowlisted), test 45, snapshot re-recorded (value-neutral), pytest 25.