### PR TITLE
T-6.1 + T-6.2: methodology panel + trust furniture

### DIFF
--- a/code/ali-je-vroce-era5/AliJeVroceERA5.tsx
+++ b/code/ali-je-vroce-era5/AliJeVroceERA5.tsx
@@ -7,6 +7,7 @@ import { DistributionChart } from "./charts/DistributionChart.tsx";
 import { TodayTrendChart } from "./components/TodayTrendChart.tsx";
 import { RegressionPanel, RegToolbar, RegScatterCard, RegYearRoundCard, useReg,
          panelHStyle, panelTitleStyle, panelSubStyle } from "./components/RegressionPanel.tsx";
+import { MethodologyPanel } from "./components/MethodologyPanel.tsx";
 import type { SiteMeta } from "./types.ts";
 import { t, fmtNum, fmtInt, fmtMonthDay } from "./i18n/format.ts";
 
@@ -188,6 +189,9 @@ function Dashboard(props: { meta: SiteMeta }) {
         <Era5Charts />
 
       </RegressionPanel>
+
+      {/* ── Methodology + trust furniture (T-6.1 / T-6.2) — foot of content ── */}
+      <MethodologyPanel stationCount={era5Stations.length} />
 
     </div>
   );

--- a/code/ali-je-vroce-era5/components/MethodologyPanel.tsx
+++ b/code/ali-je-vroce-era5/components/MethodologyPanel.tsx
@@ -1,0 +1,154 @@
+// T-6.1 / T-6.2 — methodology as an expandable block + on-page trust furniture.
+//
+// T-6.1: the reviewed methodology document (data source, grid resolution, the
+// 18-station national definition, the 1991–2020 baseline + SPEI carve-out, the
+// fixed 6.5 °C/km lapse correction and Kredarica's −7.85 °C, timezone, "hot"
+// thresholds, known limits, and the "not directly comparable to ARSO" statement)
+// is rendered here, at the foot of the page, inside a native <details> disclosure
+// — closed by default because it is long prose. Native <details>/<summary> is
+// keyboard-operable and screen-reader-labelled with no ARIA of our own, matching
+// the T-5.4a accessibility work and the existing SeaLevelWidget precedent.
+//
+// T-6.2 (trimmed scope, 2026-07-27): the always-visible trust strip carries the
+// STATION COUNT (derived from meta.stations — never hardcoded) and the correction
+// CONTACT (info@podnebnik.org). The deferred items (last-updated timestamp, data
+// download link) are intentionally NOT rendered here.
+//
+// The prose lives VERBATIM in i18n/hero-content.ts (`methodologyMarkdown`); the
+// short chrome strings come from the sl.ts catalogue via t(). Nothing Slovenian is
+// hardcoded inline in this file.
+
+import { For } from "solid-js";
+import type { JSX } from "solid-js";
+import { methodologyMarkdown } from "../i18n/hero-content.ts";
+import { t } from "../i18n/format.ts";
+
+// T-6.2 correction contact. A literal address, not translatable prose.
+const CONTACT_EMAIL = "info@podnebnik.org";
+
+// ── Block-level markdown renderer ───────────────────────────────────────────────
+// A deliberately small parser for the exact subset METHODOLOGY.md uses, so the
+// reviewed text can be stored byte-for-byte rather than hand-restructured into
+// objects: `*italic*` line (subtitle / closing note), `---` rule (spacing only),
+// `## heading`, `- bullet`, and the inline marks `**bold**`, `[text](href)`,
+// `` `code` ``.
+
+type Block =
+  | { kind: "lede"; text: string }   // a whole line wrapped in single `*` (italic)
+  | { kind: "h"; text: string }      // `## …`
+  | { kind: "p"; text: string }      // paragraph
+  | { kind: "ul"; items: string[] }; // consecutive `- …` lines
+
+function parseBlocks(md: string): Block[] {
+  const blocks: Block[] = [];
+  let list: string[] | null = null;
+  const flushList = () => {
+    if (list) { blocks.push({ kind: "ul", items: list }); list = null; }
+  };
+
+  for (const raw of md.split("\n")) {
+    const line = raw.trim();
+    if (line === "" || line === "---") { flushList(); continue; }
+    if (line.startsWith("## ")) { flushList(); blocks.push({ kind: "h", text: line.slice(3) }); continue; }
+    if (line.startsWith("- ")) { (list ??= []).push(line.slice(2)); continue; }
+    flushList();
+    // A line wholly wrapped in a SINGLE `*` (not `**`) is an italic note.
+    if (line.length > 1 && line.startsWith("*") && !line.startsWith("**") && line.endsWith("*")) {
+      blocks.push({ kind: "lede", text: line.slice(1, -1) });
+      continue;
+    }
+    blocks.push({ kind: "p", text: line });
+  }
+  flushList();
+  return blocks;
+}
+
+/** Render inline `**bold**`, `[text](href)` and `` `code` `` within one text run. */
+function renderInline(text: string): (string | JSX.Element)[] {
+  const out: (string | JSX.Element)[] = [];
+  let buf = "";
+  let i = 0;
+  const flush = () => { if (buf) { out.push(buf); buf = ""; } };
+
+  while (i < text.length) {
+    // [text](href)
+    if (text.charAt(i) === "[") {
+      const close = text.indexOf("]", i);
+      if (close !== -1 && text.charAt(close + 1) === "(") {
+        const paren = text.indexOf(")", close + 2);
+        if (paren !== -1) {
+          flush();
+          out.push(<a href={text.slice(close + 2, paren)}>{renderInline(text.slice(i + 1, close))}</a>);
+          i = paren + 1;
+          continue;
+        }
+      }
+    }
+    // **bold**
+    if (text.charAt(i) === "*" && text.charAt(i + 1) === "*") {
+      const end = text.indexOf("**", i + 2);
+      if (end !== -1) {
+        flush();
+        out.push(<strong>{renderInline(text.slice(i + 2, end))}</strong>);
+        i = end + 2;
+        continue;
+      }
+    }
+    // `code`
+    if (text.charAt(i) === "`") {
+      const end = text.indexOf("`", i + 1);
+      if (end !== -1) {
+        flush();
+        out.push(<code>{text.slice(i + 1, end)}</code>);
+        i = end + 1;
+        continue;
+      }
+    }
+    buf += text.charAt(i);
+    i++;
+  }
+  flush();
+  return out;
+}
+
+// Parsed once — the document is static.
+const BLOCKS: Block[] = parseBlocks(methodologyMarkdown);
+
+export function MethodologyPanel(props: { stationCount: number }) {
+  return (
+    <section class="methodology sec-p">
+      <details class="methodology-details">
+        <summary class="methodology-summary">{t("methodology.summary")}</summary>
+        <div class="methodology-body">
+          <For each={BLOCKS}>
+            {(b) =>
+              b.kind === "h" ? (
+                <h3 class="methodology-h">{renderInline(b.text)}</h3>
+              ) : b.kind === "lede" ? (
+                <p class="methodology-lede"><em>{renderInline(b.text)}</em></p>
+              ) : b.kind === "ul" ? (
+                <ul class="methodology-ul">
+                  <For each={b.items}>{(it) => <li>{renderInline(it)}</li>}</For>
+                </ul>
+              ) : (
+                <p class="methodology-p">{renderInline(b.text)}</p>
+              )
+            }
+          </For>
+        </div>
+      </details>
+
+      {/* Always-visible trust furniture: station count (derived) + correction contact. */}
+      <p class="methodology-furniture">
+        <span class="methodology-furniture-stations">
+          {t("methodology.stations", { count: props.stationCount })}
+        </span>
+        <span class="methodology-furniture-sep" aria-hidden="true">·</span>
+        <span class="methodology-furniture-contact">
+          {t("methodology.contact_label")}{" "}
+          <a href={`mailto:${CONTACT_EMAIL}`}>{CONTACT_EMAIL}</a>
+        </span>
+      </p>
+    </section>
+  );
+}

--- a/code/ali-je-vroce-era5/i18n/hero-content.ts
+++ b/code/ali-je-vroce-era5/i18n/hero-content.ts
@@ -156,3 +156,110 @@ export const heroContext: Record<string, Record<string, string>> = {
     catastrophic: "Popolna izguba Triglavskega ledenika — narodni simbol in vir savinjskih rek. Propad alpskega ekosistema sproži kaskadne učinke.",
   },
 };
+
+// T-6.1 / T-6.2 (D-8) — the methodology document, editorial CONTENT rendered as an
+// expandable block on the page (see components/MethodologyPanel.tsx).
+//
+// Stored VERBATIM as Slovenian markdown from the reviewed source METHODOLOGY.md
+// (its `# Metodologija` H1 becomes the disclosure <summary>; the body below begins
+// at the subtitle). The ONE authorised edit vs. the source is the contact address:
+// the `[KONTAKT — dopolniti]` placeholder at METHODOLOGY.md:93 is filled with
+// info@podnebnik.org (T-6.2 correction contact). The text is kept as a single
+// markdown string — rather than hand-restructured into nested objects — so the
+// reviewed wording is preserved byte-for-byte; a small block-markdown renderer in
+// MethodologyPanel.tsx turns `##` headings, `-` bullets, `**bold**` and
+// `[text](href)` links into accessible semantic markup.
+//
+// Markdown subset actually used below: `*italic*` (subtitle), `---` (section rule,
+// rendered as spacing), `## heading`, `- bullet`, `**bold**`, `[text](href)`.
+export const methodologyMarkdown = `*Kako nastanejo številke na strani »Ali je vroče?«*
+
+---
+
+## Na kratko
+
+Ta stran prikazuje, kako topel je današnji dan v Sloveniji v primerjavi z zgodovino od leta 1950. Nekaj stvari, ki jih je dobro vedeti pri branju:
+
+- **Podatki niso meritve slovenskih vremenskih postaj (ARSO).** Prihajajo iz **reanalize ERA5-Land** (evropski podatkovni model, dostopen prek arhiva Open-Meteo). Reanaliza združi meritve, satelite in fizikalni model v enotno mrežo vrednosti. Zato **številke niso neposredno primerljive** z uradnimi objavami ARSO, ki temeljijo na meritvah postaj.
+- **Stran privzeto prikazuje najvišjo dnevno temperaturo (Tmax)** — »kako vroč je bil dan«. Povprečno in najnižjo temperaturo lahko izberete ročno, a nista privzeti (razlog je spodaj).
+- **Vsaka postaja je višinsko popravljena.** Ker mreža modela ne leži točno na višini postaje, vrednosti prilagodimo za razliko v nadmorski višini. **Za Kredarico je ta popravek −7,85 °C** — daleč največji na strani. Podrobnosti so spodaj; navajamo jih odkrito, ker gre za velik poseg v prikazano vrednost.
+- **»Slovenija« pomeni povprečje 18 postaj**, ne ene same nacionalne meritve. Postaje segajo od morske gladine (10 m) do Kredarice (2514 m).
+- **Referenčno obdobje za odklone je 1991–2020** (veljavna klimatološka norma WMO). Ker je to razmeroma toplo obdobje, se velik del zapisov 1950–2026 prikaže kot negativni odklon.
+
+Podroben tehnični opis sledi spodaj.
+
+---
+
+## Vir podatkov
+
+Stran uporablja **reanalizo ERA5-Land**, dostopano prek **arhivskega API-ja Open-Meteo** (ne neposredno prek ECMWF/CDS). ERA5-Land je globalni reanalizni niz Evropskega centra za srednjeročne vremenske napovedi (ECMWF) z mrežno ločljivostjo približno 9 km.
+
+Reanaliza ni isto kot meritev postaje. Je rekonstrukcija preteklega vremena, ki jo model ustvari z asimilacijo številnih virov opazovanj. Prednost je enotna, prostorsko in časovno polna pokritost brez vrzeli; slabost je, da posamezna mrežna celica ne ujame lokalnih posebnosti (npr. mestnega toplotnega otoka ali natančne mikrolokacije postaje).
+
+Za današnje in najnovejše vrednosti, kjer reanaliza še ni na voljo, stran uporabi napoved Open-Meteo. Takšna vrednost je na strani označena z **»napoved«**; reanalizne vrednosti oznake nimajo.
+
+## Postaje
+
+Stran zajema **18 lokacij** po Sloveniji. Za vsako je vrednost vzeta iz mrežne celice ERA5-Land nad njo. Nabor postaj sega od nižin do visokogorja — med drugim Koper (blizu morske gladine, ~10 m), Postojna (549 m), Rateče (864 m) in Kredarica (2514 m). Celoten razpon nadmorskih višin je **10–2514 m**.
+
+## Višinski popravek (lapse-rate)
+
+Mrežna celica ERA5-Land redko leži točno na nadmorski višini postaje. Da bi vrednosti ustrezale višini postaje in ne višini mrežne celice, vsako popravimo s **fiksno stopnjo 6,5 °C na kilometer** razlike med višino postaje in višino mrežne celice. To je standardna vrednost povprečne stopnje ohlajanja ozračja z višino.
+
+Za 17 od 18 postaj je ta popravek majhen. **Za Kredarico je velik: −7,85 °C.** Postaja leži na 2514 m, pripadajoča mrežna celica ERA5-Land pa na 1307 m — razlika 1207 m, kar pri 6,5 °C/km da popravek −7,85 °C. To je **daleč največji posamezni popravek na strani.**
+
+Odkrito navajamo njegove omejitve:
+
+- Popravljene vrednosti ERA5-Land za Kredarico smo **primerjali z meritvami ARSO in so bile blizu.** A šlo je za primerjavo, **ne za sistematično validacijo** — ni bila opravljena analiza pristranskosti po mesecih.
+- Fiksna stopnja 6,5 °C/km je **povprečje za prosto ozračje.** Dejanska prizemna stopnja nad gorskim pobočjem se spreminja s sezono in se lahko **splošči ali celo obrne pri zimskih temperaturnih inverzijah.** Popravek je torej lahko dober v letnem povprečju, a sistematično odstopa v posameznih mesecih (predvsem pozimi).
+- Empirični popravek po postaji in mesecu bi bil boljša dolgoročna rešitev; zaenkrat ni izveden.
+
+## Katera temperatura je privzeta
+
+Stran privzeto vodi z **najvišjo dnevno temperaturo (Tmax)** — na prvih karticah, ob nalaganju in v trendu, ki ga stran postavi v ospredje. Povprečna (Tmean) in najnižja (Tmin) dnevna temperatura sta na voljo za ročno izbiro, a nista privzeti.
+
+Razlog je kakovost podatkov. Reanaliza ERA5-Land sistematično slabše oceni **najnižjo** temperaturo v pozidanih območjih, ker mreža ne razreši mestnega toplotnega otoka. Ker se **povprečna** temperatura izračuna tudi iz najnižje, to pristranskost podeduje — ravno v naseljenih krajih, ki bralce najbolj zanimajo. Najvišja dnevna temperatura te pristranskosti ne nosi in se ujema z vprašanjem strani (»ali je vroče« — občutena dnevna vročina). Zato stran vodi s Tmax, izbira Tmean/Tmin pa ostaja bralcu, ki omejitev razume.
+
+## Kaj pomeni »Slovenija«
+
+Nacionalna vrednost je **neutežено povprečje vseh 18 postaj**, vključno z višinsko popravljeno Kredarico — na strani poimenovano »povprečje 18 postaj«, s prikazanim naborom postaj in razponom višin.
+
+Uteževanje po površini ali višinskih pasovih smo pretehtali in **zavrnili**: ker je nad 1000 m le ena postaja (Kredarica), bi ta sama nosila cel višinski pas. To bi bilo videti natančno, a bi slonelo na eni sami točki. Neuteženo povprečje nad vidnim, poimenovanim naborom postaj je poštenejša konstrukcija.
+
+## Časovni pas in dnevna meja
+
+Dnevne vrednosti in meja »danes« sta določeni po času **Europe/Ljubljana**. Dnevni podatki so agregirani iz arhiva Open-Meteo v tem časovnem pasu. (Dan po UTC bi napačno razvrstil skrajne vrednosti blizu lokalne polnoči, kar je najbolj občutljivo pri štetju tropskih noči.)
+
+## Referenčno obdobje in odkloni
+
+Odkloni (koliko je dan topel »glede na normalo«) se merijo proti **referenčnemu obdobju 1991–2020** — veljavni klimatološki normali WMO — enotno po vsej strani.
+
+Ena posledica je pomembna za branje: ker je 1991–2020 razmeroma toplo obdobje, se **velik del zapisov 1950–2026 prikaže kot negativni odklon.** To ni napaka, temveč posledica primerjave s toplo sodobno normalo.
+
+**Izjema — SPEI (suša):** indeks suše SPEI je ločen in umerjen na obdobje **1950–1980**, ne 1991–2020. Absolutni pragovi (npr. za vroče dneve in tropske noči) na referenčno obdobje niso vezani.
+
+## Porazdelitev in percentil
+
+Za vsak dan v letu stran prikaže **porazdelitev** preteklih vrednosti (kako pogosti so bili posamezni odkloni) in **percentil** današnje vrednosti (topleje od kolikšnega deleža primerjalnih dni).
+
+- Porazdelitev je **empirična ocena gostote (KDE)** — sledi dejanski obliki podatkov — ne simetrična zvonasta (Gaussova) krivulja. Temperaturne porazdelitve so pogosto nesimetrične, zato bi Gaussova krivulja napačno prikazala repe, ravno tam, kjer se presoja »kako izjemen je današnji dan«.
+- Nacionalna krivulja je **povprečje 18 krivulj posameznih postaj**, ne skupni bazen vzorcev — s čimer ohrani pomen »povprečja 18 postaj«.
+- Percentil je **pravi empirični percentil**, izračunan iz te krivulje (integral gostote do današnje vrednosti), ne približek iz barvnega pasu.
+
+Primerjalni vzorec za vsak koledarski dan je **združeno okno ±7 dni** čez vsa leta — tako ima vsak dan dovolj gost in stabilen vzorec. **29. februar** se pri tem pridruži oknu 28. februarja (redki prestopni dnevi se ne obravnavajo kot ločen, statistično šumeč dan).
+
+## Pragovi za »vroče«
+
+Štetje vročih dni in tropskih noči uporablja **stroge pragove (\`>\`, ne \`≥\`).** To je usklajeno s standardom ETCCDI/ECA&D (medtem ko npr. nemški DWD uporablja \`≥\`). Standard je dejansko sporen; izbrali smo \`>\`. Sprememba na \`≥\` bi premaknila štetje vsakega mejnega dne, zato je izbira zapisana zavestno.
+
+## Znane omejitve
+
+- **Ni ARSO.** Vrednosti so reanaliza ERA5-Land, ne meritve postaj, in **niso neposredno primerljive** z objavami ARSO.
+- **Višinski popravek Kredarice** (−7,85 °C) je velik, preverjen a ne validiran po mesecih, in lahko odstopa pozimi (glej zgoraj).
+- **ERA5-Land Tmin** je v mestih nezanesljiv (toplotni otok); zato stran privzeto ne vodi s Tmean/Tmin.
+- **Mrežna ločljivost** (~9 km) ne ujame lokalnih posebnosti pod to velikostjo.
+- **Najnovejše vrednosti** so lahko napoved (označene z »napoved«), dokler reanaliza ni na voljo.
+
+---
+
+*Za morebitne popravke ali vprašanja o metodologiji nas kontaktirajte na [info@podnebnik.org](mailto:info@podnebnik.org).*`;

--- a/code/ali-je-vroce-era5/i18n/sl.ts
+++ b/code/ali-je-vroce-era5/i18n/sl.ts
@@ -407,6 +407,17 @@ export const sl = {
     src_warn: "⚠ Poplavne cone so shematske — zamenjava z LIDAR DEM poligoni sledi.",
   },
 
+  // T-6.1 / T-6.2 — methodology disclosure + trust furniture. The long prose lives
+  // VERBATIM in hero-content.ts `methodologyMarkdown`; these are the short chrome
+  // strings around it. `stations` is plural-selected on the live station count
+  // (derived from meta.stations, never hardcoded); `contact` is the T-6.2 correction
+  // contact. The email address itself is a literal, not translatable prose.
+  methodology: {
+    summary: "Metodologija",
+    stations: "{count, plural, one{# postaja} two{# postaji} few{# postaje} other{# postaj}} ERA5-Land",
+    contact_label: "Popravki in vprašanja:",
+  },
+
   // Site meta (fallbacks)
   meta: {
     name: "Slovenija",

--- a/styles/era5.css
+++ b/styles/era5.css
@@ -146,6 +146,37 @@
 /* ── Responsive: Section horizontal padding ──────────────────────────────── */
 .sec-p  { padding-inline: 40px; }
 
+/* ── Methodology block + trust furniture (T-6.1 / T-6.2) ──────────────────── */
+.methodology { padding-top: 8px; padding-bottom: 56px; margin-top: 24px; border-top: 1px solid var(--color-rule); }
+.methodology-details { max-width: 760px; }
+.methodology-summary {
+  font-family: var(--font-mono); font-size: 12px; font-weight: 600; letter-spacing: 0.08em;
+  text-transform: uppercase; color: var(--color-ink-soft); cursor: pointer;
+  padding: 14px 0; list-style: none; display: flex; align-items: center; gap: 8px;
+}
+.methodology-summary::-webkit-details-marker { display: none; }
+.methodology-summary::before { content: "▸"; font-size: 10px; transition: transform 0.15s; }
+.methodology-details[open] .methodology-summary::before { transform: rotate(90deg); }
+.methodology-summary:hover { color: var(--color-ink); }
+.methodology-summary:focus-visible { outline: 2px solid var(--color-accent); outline-offset: 3px; border-radius: 3px; }
+
+.methodology-body { max-width: 720px; padding: 4px 0 8px; }
+.methodology-h    { font-family: var(--font-sans); font-size: 16px; font-weight: 600; color: var(--color-ink); margin: 22px 0 6px; }
+.methodology-lede { font-family: var(--font-sans); font-size: 14px; font-style: italic; color: var(--color-ink-soft); margin: 0 0 4px; }
+.methodology-p    { font-family: var(--font-sans); font-size: 14px; line-height: 1.62; color: var(--color-ink-2); margin: 8px 0; }
+.methodology-ul   { margin: 8px 0; padding-left: 20px; }
+.methodology-ul li{ font-family: var(--font-sans); font-size: 14px; line-height: 1.6; color: var(--color-ink-2); margin: 5px 0; }
+.methodology-body strong { font-weight: 600; color: var(--color-ink); }
+.methodology-body a      { color: var(--color-accent); }
+.methodology-body code   { font-family: var(--font-mono); font-size: 0.9em; background: var(--color-paper-2); padding: 1px 4px; border-radius: 4px; }
+
+.methodology-furniture {
+  font-family: var(--font-mono); font-size: 11px; letter-spacing: 0.04em; color: var(--color-ink-soft);
+  margin: 14px 0 0; display: flex; flex-wrap: wrap; align-items: center; gap: 8px;
+}
+.methodology-furniture a   { color: var(--color-accent); }
+.methodology-furniture-sep { opacity: 0.5; }
+
 /* ── Responsive: Regression toolbar ──────────────────────────────────────── */
 .reg-toolbar {
   margin: 20px 40px 0;

--- a/tests/fixtures/snapshot.json
+++ b/tests/fixtures/snapshot.json
@@ -49,6 +49,7 @@
       "Era5SeasonHeatmapChart",
       "Era5TropicalChart",
       "HeroCardsPanel",
+      "MethodologyPanel",
       "RegScatterCard",
       "RegToolbar",
       "RegYearRoundCard",
@@ -3275,6 +3276,12 @@
         "Zima",
         "▶ Animacija"
       ]
+    },
+    "methodology": {
+      "_note": "T-6.1/T-6.2 trust furniture (MethodologyPanel.tsx, mounted AliJeVroceERA5.tsx:191). The methodology PROSE is static reviewed content and is not captured; the station count is the only rendered value worth watching and is the same figure as global.meta.station_count / station_map.panel_header.station_count.",
+      "summary": "Metodologija",
+      "station_count": "18 postaj ERA5-Land",
+      "contact": "Popravki in vprašanja: info@podnebnik.org"
     },
     "spei_station": {
       "available": true,

--- a/tests/snapshot/harness.tsx
+++ b/tests/snapshot/harness.tsx
@@ -76,6 +76,7 @@ import {
   RegScatterCard,
   RegYearRoundCard,
 } from "../../code/ali-je-vroce-era5/components/RegressionPanel.tsx";
+import { MethodologyPanel } from "../../code/ali-je-vroce-era5/components/MethodologyPanel.tsx";
 
 import { chartLog, resetChartLog, type RecordedChart } from "./highcharts-stub.ts";
 import cases from "./cases.json";
@@ -715,6 +716,17 @@ export async function run(): Promise<RunResult> {
     0,
   );
 
+  // T-6.1 / T-6.2 — the methodology disclosure + trust furniture at the foot of
+  // the page (AliJeVroceERA5.tsx:191). The real component is mounted (not a
+  // mirror), so no assertMirroredCopy is needed. Only the always-visible furniture
+  // — the derived station-count line and the correction contact — plus the summary
+  // label are read; the static methodology prose is deliberately not captured.
+  const methodologyUnit = await mount(
+    "global.methodology",
+    () => <MethodologyPanel stationCount={era5Stations.length} />,
+    0,
+  );
+
   const speiNational = await fetchSpeiHeatmap();
   assertNoMisses("global.spei_national (fetch)");
   const speiUnit = await mount(
@@ -815,6 +827,16 @@ export async function run(): Promise<RunResult> {
       n_rows: speiNational.data?.length ?? 0,
       rows: speiRows,
       rendered_legend: read(speiUnit).all("button"),
+    },
+    methodology: {
+      _note:
+        "T-6.1/T-6.2 trust furniture (MethodologyPanel.tsx, mounted AliJeVroceERA5.tsx:191). " +
+        "The methodology PROSE is static reviewed content and is not captured; the station " +
+        "count is the only rendered value worth watching and is the same figure as " +
+        "global.meta.station_count / station_map.panel_header.station_count.",
+      summary: read(methodologyUnit).txt(".methodology-summary"),
+      station_count: read(methodologyUnit).txt(".methodology-furniture-stations"),
+      contact: read(methodologyUnit).txt(".methodology-furniture-contact"),
     },
     spei_station: {
       available: speiStation.available,

--- a/tests/snapshot/sections.json
+++ b/tests/snapshot/sections.json
@@ -89,6 +89,11 @@
       "mounted_at": "AliJeVroceERA5.tsx:279 (days), :291 (nights)",
       "harness_unit": "by_station.tropical_days / by_station.tropical_nights",
       "captures": "per-year counts, NB-GLM trend, and the highlighted current-year bar (TropicalChart.tsx:73-76) — the second former clock leak"
+    },
+    "MethodologyPanel": {
+      "mounted_at": "AliJeVroceERA5.tsx:191",
+      "harness_unit": "global.methodology",
+      "captures": "the always-visible trust furniture — the derived station-count line (`{era5Stations.length} postaj`, the same figure global.meta.station_count and the map panel_header watch) and the correction-contact line — plus the disclosure summary label. The methodology PROSE itself (i18n/hero-content.ts methodologyMarkdown) is static reviewed editorial content and is NOT captured, per the capture-surface rule (capture inputs the numbers depend on, not annotation); the station count is the only rendered value here worth watching."
     }
   },
 


### PR DESCRIPTION
## T-6.1 + T-6.2 — methodology + trust furniture

**Methodology** now lives on the page as an expandable `<details>` block (closed by default, keyboard-operable) via new `MethodologyPanel.tsx`. The Slovenian text is in `hero-content.ts` (`methodologyMarkdown`) rendered by a small block-markdown renderer — NOT hardcoded inline (consistent with T-5.5's i18n catalogue). Covers ERA5-Land provenance, the Kredarica −7,85 °C lapse correction (named explicitly with caveats), baseline, Tmax-default, KDE, thresholds, limits.

**Trust furniture:** station count derived from `meta.stations`, correction contact info@podnebnik.org. Last-updated timestamp + data-download deferred (no honest source yet — T-6.2 scope note).

**Snapshot:** only the new MethodologyPanel section + `global.methodology` leaf moved; no existing value/chart/colour moved.

**Gates:** typecheck OK (8 allowlisted), test 45, snapshot re-recorded (additive only), pytest 25.