### PR TITLE
T-5.2: guard silent _size truncation cliffs

### DIFF
--- a/code/ali-je-vroce-era5/api.ts
+++ b/code/ali-je-vroce-era5/api.ts
@@ -80,6 +80,49 @@ export function parseJsonColumn<T>(raw: string, column: string): T {
   }
 }
 
+// T-5.2 — kill the silent `_size` truncation cliff on the national aggregates.
+//
+// datasette returns at most `_size` rows and drops the rest WITHOUT any signal —
+// the same silent-failure class T-5.1 removed from the fetch/parse paths. The
+// three national helpers below (daily_window / daily / annual_trend, each filtered
+// to a single month-day or date) pool "one row per ERA5 station" and average them.
+// The healthy result is ALL-OR-NOTHING: either the day has no rows at all (Feb 29
+// has no pooled climatology row; a date beyond the reanalysis boundary has no
+// observation) or exactly one row per station. A count that is neither 0 nor the
+// station count is either a partial pool — a national mean silently computed over a
+// subset, which D-7's "povprečje 18 postaj" would then mislabel — or a response
+// truncated at the `_size` cap. Both are silent failures and must fail loudly; the
+// throw reaches each section's ErrorBoundary and renders SectionError instead of a
+// wrong number.
+//
+// The station count comes from `era5Coords`, populated by fetchMeta from
+// `stations.json?…&_size=30` (api.ts:267). NOTE: that `_size=30` is the SAME class
+// of latent cliff (18 rows today, margin 12) and bounds how far this assert can be
+// trusted — past 30 stations it truncates first and this "expected" undercounts.
+// It is out of T-5.2's `_size=50` scope; see the PROGRESS finding.
+//
+// The `_size=50` in the three query URLs is deliberately NOT removed: the offline
+// fixture layer keys on the EXACT request URL (fixtures/install.ts index.routes),
+// so changing it would miss every recorded response and force a network re-record
+// for no data benefit. 50 is already a correct bound (> the 18-station count); this
+// assert is the loud "you didn't hit the cap" guard layered on top of it.
+function assertNationalStationRows(rows: readonly unknown[], table: string): void {
+  const expected = Object.keys(era5Coords).length;
+  if (expected === 0) {
+    throw new Error(
+      `[T-5.2] ${table}: station registry not loaded (fetchMeta must run before a ` +
+        `national aggregate) — cannot validate the national row count`,
+    );
+  }
+  if (rows.length !== 0 && rows.length !== expected) {
+    throw new Error(
+      `[T-5.2] ${table}: national aggregate expected 0 or ${expected} station rows, got ` +
+        `${rows.length} — a partial pool would silently bias the national mean, and a count at ` +
+        `the datasette \`_size\` cap means rows were truncated`,
+    );
+  }
+}
+
 
 export function doyToMonthDay(doy: number): { month: number; day: number } {
   const d = new Date(Date.UTC(2001, 0, 1));
@@ -194,6 +237,7 @@ export async function fetchEra5NationalWindowRow(month: number, day: number): Pr
   const rows = await dsGet<DailyWindowRow[]>(
     `daily_window.json?_shape=array&month__exact=${month}&day__exact=${day}&_size=50`
   );
+  assertNationalStationRows(rows, "daily_window");
   if (rows.length === 0) return null;
   const avg = (f: (r: DailyWindowRow) => number) =>
     rows.reduce((s, r) => s + (f(r) ?? 0), 0) / rows.length;
@@ -311,6 +355,7 @@ export async function fetchTodayStatus(date: string, loc: string | null): Promis
     const dsRows = await dsGet<Array<{ temperature_max_2m: number | null }>>(
       `daily.json?_shape=array&date__exact=${date}&_col=temperature_max_2m&_size=50`
     );
+    assertNationalStationRows(dsRows, "daily");
     const dsVals = dsRows.filter(r => r.temperature_max_2m != null).map(r => r.temperature_max_2m!);
     let todayTemp: number | null = dsVals.length > 0
       ? dsVals.reduce((a, b) => a + b) / dsVals.length
@@ -652,6 +697,7 @@ async function fetchNationalAnnualTrendRow(month: number, day: number): Promise<
   const rows = await dsGet<AnnualTrendRow[]>(
     `annual_trend.json?_shape=array&variable__exact=temperature_max&month__exact=${month}&day__exact=${day}&_size=50`
   );
+  assertNationalStationRows(rows, "annual_trend");
   if (!rows.length) return undefined;
   const avg = (f: (r: AnnualTrendRow) => number) => rows.reduce((s, r) => s + (f(r) ?? 0), 0) / rows.length;
 

--- a/code/ali-je-vroce-era5/api.ts
+++ b/code/ali-je-vroce-era5/api.ts
@@ -96,10 +96,10 @@ export function parseJsonColumn<T>(raw: string, column: string): T {
 // wrong number.
 //
 // The station count comes from `era5Coords`, populated by fetchMeta from
-// `stations.json?…&_size=30` (api.ts:267). NOTE: that `_size=30` is the SAME class
-// of latent cliff (18 rows today, margin 12) and bounds how far this assert can be
-// trusted — past 30 stations it truncates first and this "expected" undercounts.
-// It is out of T-5.2's `_size=50` scope; see the PROGRESS finding.
+// `stations.json?…&_size=30`. That query is the SAME class of latent cliff and,
+// being the SOURCE of this "expected", would truncate first and make every assert
+// below validate against a wrong count — so fetchMeta guards it too (asserts it
+// did not hit the `_size=30` cap; see the guard beside that query).
 //
 // The `_size=50` in the three query URLs is deliberately NOT removed: the offline
 // fixture layer keys on the EXACT request URL (fixtures/install.ts index.routes),
@@ -309,6 +309,21 @@ export async function fetchMeta(): Promise<SiteMeta> {
     era5_name: string; name: string; lat: number; lon: number;
     elevation: number; station_id: number | null;
   }>>("stations.json?_shape=array&_col=era5_name&_col=name&_col=lat&_col=lon&_col=elevation&_col=station_id&_size=30");
+
+  // T-5.2 — the station registry is the SOURCE of the station count that the three
+  // national-aggregate asserts (assertNationalStationRows) trust, so a silent
+  // truncation HERE would corrupt every one of them. This query is capped at
+  // `_size=30` (18 stations today, margin 12); a full page means rows were dropped.
+  // We cannot assert against a station count — this IS that source — so assert we
+  // did not hit the cap. `_size=30` is kept literal (the offline fixture layer keys
+  // on the exact URL); the throw surfaces via the section ErrorBoundary.
+  if (era5Stations.length >= 30) {
+    throw new Error(
+      `[T-5.2] stations.json: got ${era5Stations.length} rows at the \`_size=30\` cap — the ` +
+        `station registry was truncated, so every national aggregate would validate against a ` +
+        `wrong station count. Raise the cap and re-record the fixtures.`,
+    );
+  }
 
   // Coordinates + true elevation for Open-Meteo live temps (elevation-corrected)
   era5Coords = Object.fromEntries(

--- a/tests/unit/national-aggregation.test.ts
+++ b/tests/unit/national-aggregation.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeAll, describe, expect, it } from "vitest";
 
-import { fetchEra5NationalWindowRow } from "../../code/ali-je-vroce-era5/api.ts";
+import { fetchEra5NationalWindowRow, fetchMeta } from "../../code/ali-je-vroce-era5/api.ts";
 
 // T-3.4 — the Slovenia national ±window climatology (api.ts fetchEra5NationalWindowRow)
 // is the UNWEIGHTED MEAN of the per-station daily_window rows for a month/day.
@@ -21,6 +21,12 @@ import { fetchEra5NationalWindowRow } from "../../code/ali-je-vroce-era5/api.ts"
 //   mean p50 over 17 = (440.60 − 11.19) / 17 = 25.2594 °C   ← what T-4.6 will produce
 
 describe("fetchEra5NationalWindowRow — unweighted mean of the 18 stations", () => {
+  // T-5.2: the national aggregate now asserts its row count against the station
+  // registry, so fetchMeta must populate era5Coords first (it always does in the
+  // real page — meta loads before any national card). Served offline from
+  // tests/fixtures/http/climate-si/stations.json (18 rows).
+  beforeAll(async () => { await fetchMeta(); });
+
   it("averages all 18 stations, Kredarica included", async () => {
     const row = await fetchEra5NationalWindowRow(7, 21);
     expect(row).not.toBeNull();
@@ -36,5 +42,40 @@ describe("fetchEra5NationalWindowRow — unweighted mean of the 18 stations", ()
     expect(row!.station).toBe("era5:national");
     expect(row!.year_min).toBe(1950);
     expect(row!.year_max).toBe(2026);
+  });
+});
+
+// T-5.2 — the national row-count guard (assertNationalStationRows). datasette
+// silently drops rows past `_size`, so a national aggregate that comes back with
+// neither 0 nor the full station count — a partial pool, or a response truncated
+// at the cap — must throw and surface via the section ErrorBoundary rather than
+// silently averaging a biased subset. The station registry here holds 18; a
+// stubbed short response stands in for the truncated/partial case.
+describe("national aggregate rejects a short row count (T-5.2)", () => {
+  const realFetch = globalThis.fetch;              // the offline fixture shim
+  beforeAll(async () => { await fetchMeta(); });   // era5Coords = 18 (served offline)
+  afterEach(() => { globalThis.fetch = realFetch; });
+
+  function stubRows(n: number): void {
+    const body = JSON.stringify(
+      Array.from({ length: n }, () => ({
+        p5: 0, p10: 0, p20: 0, p50: 0, p80: 0, p95: 0,
+        n_samples: 0, year_min: 2000, year_max: 2000, distribution_json: "[]",
+      })),
+    );
+    globalThis.fetch = (async () =>
+      new Response(body, { status: 200, headers: { "content-type": "application/json" } })
+    ) as typeof fetch;
+  }
+
+  it("throws when the pool is partial (5 of 18 stations)", async () => {
+    stubRows(5);
+    await expect(fetchEra5NationalWindowRow(7, 21))
+      .rejects.toThrow(/daily_window: national aggregate expected 0 or 18 station rows, got 5/);
+  });
+
+  it("still accepts a legitimately empty day (0 rows → null, no throw)", async () => {
+    stubRows(0);
+    await expect(fetchEra5NationalWindowRow(2, 29)).resolves.toBeNull();
   });
 });


### PR DESCRIPTION
## T-5.2 — silent _size truncation guards

The datasette `_size` caps could silently drop rows. **Nothing was truncating in production** — the three `_size=50` sites slice national aggregates to 18 rows (<< 50). Added `assertNationalStationRows` (throws unless count === 0 || === stationCount, via the T-5.1 SectionError boundary).

Also guarded the **load-bearing registry query** (`stations.json` `_size=30`) — it's the *source* of the count the other asserts trust, margin only 12 over 18; now asserts it didn't hit the cap.

`_size` kept literal in URLs (exact-URL fixture keying); the assert is the loud guard on top. Pure guards → **snapshot byte-identical**.

Remaining same-class follow-up (noted, optional): calendar `_size=400`.

**Gates:** typecheck OK (8 allowlisted), test 47 (+2), snapshot identical, pytest 25.