### PR TITLE
T-5.7e: guard the station-metadata seam (si.yaml stays ERA5-only)

### DIFF
--- a/data/climate-si/sources/precompute_datasette.py
+++ b/data/climate-si/sources/precompute_datasette.py
@@ -123,6 +123,44 @@ STATION_META: dict[str, dict] = {
     "Ratece":        {"official_name": "Rateče",               "name_locative": "v Ratečah",           "xml_id": None},
 }
 
+# ── Station-metadata completeness guard (T-5.7e) ────────────────────────────────
+# si.yaml is the single source for the station LIST and its geographic fields
+# (name/lat/lon/elevation/elevation_era5_m — enforced against the built table by
+# validate._check_stations_match_config). The four ARSO/Vremenar identity columns
+# (official_name, name_locative, station_id, xml_id) live in the two dicts above by
+# design (D-9 split: registry identity is pipeline metadata, not country geo config).
+# That leaves one silent-drift path: `build_stations` falls back to display-name
+# defaults / NULL when a si.yaml station is missing from STATION_META, so a station
+# added to si.yaml without a metadata entry would ship a fabricated official_name /
+# name_locative with no error. This guard closes that path — it runs during the
+# image-build precompute (via build_stations) and raises BEFORE any table is written.
+
+def assert_station_metadata_complete() -> None:
+    """Every si.yaml station must have an explicit STATION_META entry (no silent
+    display-name fallback); every ERA5_TO_STATION_ID key must be a known station
+    (ERA5-only stations legitimately carry no station_id, so subset — not equality)."""
+    names = {loc["name"] for loc in CONFIG["stations"]}
+    meta_keys = set(STATION_META)
+    missing_meta = names - meta_keys
+    orphan_meta  = meta_keys - names
+    if missing_meta:
+        raise ValueError(
+            f"STATION_META is missing entries for si.yaml station(s): "
+            f"{sorted(missing_meta)} — add official_name/name_locative/xml_id in "
+            f"precompute_datasette.py rather than letting build_stations fabricate them."
+        )
+    if orphan_meta:
+        raise ValueError(
+            f"STATION_META has entries for unknown station(s) not in si.yaml: "
+            f"{sorted(orphan_meta)} — remove them or restore the station in si.yaml."
+        )
+    orphan_ids = set(ERA5_TO_STATION_ID) - names
+    if orphan_ids:
+        raise ValueError(
+            f"ERA5_TO_STATION_ID maps unknown station(s) not in si.yaml: "
+            f"{sorted(orphan_ids)}."
+        )
+
 # ── Data loading ───────────────────────────────────────────────────────────────
 
 def load_all() -> pd.DataFrame:
@@ -185,6 +223,7 @@ def window_filter(loc_data: pd.DataFrame, month: int, day: int, half: int) -> pd
 # ── 1. stations table ──────────────────────────────────────────────────────────
 
 def build_stations(data: pd.DataFrame) -> pd.DataFrame:
+    assert_station_metadata_complete()   # T-5.7e: no silent metadata fallback
     rows = []
     for loc_cfg in CONFIG["stations"]:
         name = loc_cfg["name"]

--- a/data/climate-si/sources/tests/test_station_metadata.py
+++ b/data/climate-si/sources/tests/test_station_metadata.py
@@ -1,0 +1,56 @@
+"""T-5.7e — station-metadata completeness guard.
+
+si.yaml is the single source for the station list + geographic fields; the four
+ARSO/Vremenar identity columns stay in precompute's STATION_META /
+ERA5_TO_STATION_ID dicts by design (D-9 split). `assert_station_metadata_complete`
+closes the one silent-drift path left by that split: a si.yaml station missing a
+STATION_META entry would otherwise ship a fabricated official_name/name_locative.
+"""
+
+import pytest
+
+import precompute_datasette as pc
+
+
+def test_current_config_is_complete():
+    # The shipped si.yaml + dicts must pass — this is the invariant build_stations
+    # (and therefore the image build) relies on.
+    pc.assert_station_metadata_complete()
+
+
+def test_every_yaml_station_has_station_meta():
+    # Structural restatement of the guard's core: no display-name fallback path.
+    names = {loc["name"] for loc in pc.CONFIG["stations"]}
+    assert names <= set(pc.STATION_META)
+
+
+def test_station_id_map_is_a_subset_not_equality():
+    # ERA5-only stations legitimately carry no station_id, so the map is a strict
+    # subset of the station list — never all 18.
+    names = {loc["name"] for loc in pc.CONFIG["stations"]}
+    assert set(pc.ERA5_TO_STATION_ID) <= names
+    assert set(pc.ERA5_TO_STATION_ID) != names
+
+
+def test_missing_station_meta_raises(monkeypatch):
+    trimmed = dict(pc.STATION_META)
+    trimmed.pop("Kredarica")
+    monkeypatch.setattr(pc, "STATION_META", trimmed)
+    with pytest.raises(ValueError, match=r"STATION_META is missing.*Kredarica"):
+        pc.assert_station_metadata_complete()
+
+
+def test_orphan_station_meta_raises(monkeypatch):
+    extra = dict(pc.STATION_META)
+    extra["Atlantis"] = {"official_name": "Atlantis", "name_locative": "v Atlantidi", "xml_id": None}
+    monkeypatch.setattr(pc, "STATION_META", extra)
+    with pytest.raises(ValueError, match=r"STATION_META has entries for unknown.*Atlantis"):
+        pc.assert_station_metadata_complete()
+
+
+def test_orphan_station_id_raises(monkeypatch):
+    extra = dict(pc.ERA5_TO_STATION_ID)
+    extra["Atlantis"] = 9999
+    monkeypatch.setattr(pc, "ERA5_TO_STATION_ID", extra)
+    with pytest.raises(ValueError, match=r"ERA5_TO_STATION_ID maps unknown.*Atlantis"):
+        pc.assert_station_metadata_complete()


### PR DESCRIPTION
## T-5.7e — station-metadata seam guard

Premise was stale: AUDIT §4.7's station-list drift was already closed by T-5.7a–c (`stations` table is build-generated from `si.yaml` geo fields, parity enforced by validate.py). Residual scope: 4 identity columns (`official_name, name_locative, station_id, xml_id`) come from hardcoded Python dicts.

These are **ARSO/Vremenar identity fields, kept out of `si.yaml` (which stays ERA5-only)**. Per decision: guard the seam, don't merge. Added `assert_station_metadata_complete()` in `build_stations` — raises at build if a `si.yaml` station is missing metadata, **closing a silent-fabrication path** (missing station used to get invented `official_name`/`name_locative`/`xml_id`). Guard: `STATION_META` keys === si.yaml set; `ERA5_TO_STATION_ID` a subset (9 ERA5-only stations have `station_id=None`).

**Byte-identical:** no-op on current data (`df.equals()==True`, same sha256). +6 tests.

**Gates:** pytest 31 (+6), typecheck OK (8 allowlisted), snapshot identical, validate.py clean.