### PR TITLE
T-4.21: gate SeaLevelWidget out of v1 (enforce D-10)

### DIFF
--- a/code/ali-je-vroce-era5/AliJeVroceERA5.tsx
+++ b/code/ali-je-vroce-era5/AliJeVroceERA5.tsx
@@ -17,7 +17,11 @@ const HeroCardsPanel         = lazy(() => import("./components/HeroCards.tsx").t
 const Era5TropicalChart      = lazy(() => import("./charts/Era5TropicalChart.tsx").then(m => ({ default: m.Era5TropicalChart })));
 const SpeiHeatmapChart       = lazy(() => import("./charts/SpeiHeatmap.tsx").then(m => ({ default: m.SpeiHeatmap })));
 const SpeiTrendChartLazy     = lazy(() => import("./charts/SpeiTrendChart.tsx").then(m => ({ default: m.SpeiTrendChart })));
-const SeaLevelChart          = lazy(() => import("./charts/SeaLevelWidget.tsx").then(m => ({ default: m.SeaLevelWidget })));
+// T-4.21 / D-10 — the sea-level widget is GATED OUT of v1 (unsound per-cm factors,
+// D-10b; SRTM DEM can't support the increments, D-10c). Import + mount removed so it
+// renders nothing and makes no /data/flood asset requests. Deferred, not deleted:
+// charts/SeaLevelWidget.tsx and scripts/floodmap/ are kept for re-entry. To unpark
+// when D-10b/c clear, restore the lazy import here and the section below (see PROGRESS).
 
 // T-5.5 — the datasette `day_label` is an internal "Mon D" key; render its month
 // as a Slovenian short date via the formatter rather than a hand-built string.
@@ -315,18 +319,11 @@ function Era5Charts() {
         </Suspense>
       </section>
 
-      {/* Sea level rise — Koper (IPCC AR6 projections, static) */}
-      <section class="sec-p" style={{ "padding-bottom": "40px" }}>
-        <div class="sec-h" style={{ "padding-inline": "0", "padding-top": "8px" }}>
-          {t("sections.sea_level")}
-        </div>
-        <div class="sec-hs2" style={{ "margin-bottom": "16px" }}>
-          {t("sections.sea_level_sub")}
-        </div>
-        <Suspense fallback={<div class="animate-pulse rounded-xl bg-[#071e26]" style={{ height: "500px" }} />}>
-          <SeaLevelChart />
-        </Suspense>
-      </section>
+      {/* T-4.21 / D-10 — Sea level rise — Koper section GATED OUT of v1. The whole
+          <section> (header sections.sea_level / sub sections.sea_level_sub + the
+          SeaLevelChart mount) was removed so the known-unsound widget is not public
+          and fetches no /data/flood assets. i18n strings (i18n/sl.ts) and si.yaml
+          sea_level_section are intentionally LEFT as-is for reversible re-entry. */}
     </Show>
   );
 }

--- a/tests/fixtures/snapshot.json
+++ b/tests/fixtures/snapshot.json
@@ -69,9 +69,7 @@
       "Suspense",
       "TropControls"
     ],
-    "excluded": [
-      "SeaLevelChart"
-    ]
+    "excluded": []
   },
   "global": {
     "meta": {

--- a/tests/snapshot/sections.json
+++ b/tests/snapshot/sections.json
@@ -108,17 +108,23 @@
     "SiteMeta": "NOT a component. A type argument in createResource<SiteMeta> (AliJeVroceERA5.tsx:35) that the tag regex cannot distinguish from JSX. Classified explicitly rather than special-cased in the extractor, so the extractor stays dumb and auditable."
   },
 
-  "excluded": {
-    "SeaLevelChart": {
-      "mounted_at": "AliJeVroceERA5.tsx:304",
-      "reason": "NOT SNAPSHOTTED. Its displayed figures — flooded hectares and affected buildings per sea-level increment — come from the same-origin /data/flood-stats.json plus the per-cm factors 20.77 ha and 14.13 buildings (SeaLevelWidget.tsx:56-57,109), none of which are part of the T-1.2 ERA5 fixture set. It also eagerly constructs 24 image preloads and a Leaflet map against external tiles.",
-      "consequence": "Every number the sea-level widget displays is currently OUTSIDE the regression net. A Phase 2 or Phase 3 change that moved one of them would produce an empty T-1.1 diff.",
-      "tickets": [
-        "T-4.11 (D-10c) — BLOCKING: the widget renders 10 cm increments from a SRTM-derived DEM whose vertical error is metre-scale, so the lower half of its range sits inside the DEM's own error. The widget does not launch on the current DEM, and may be cut from v1 entirely.",
-        "T-4.10 (D-10b) — the 20.77 / 14.13 factors and the AR6 per-SSP tables are unattributed.",
-        "T-5.6 — the widget is 162 KB and is to be lazy-loaded on interaction."
-      ],
-      "if_the_widget_ships": "Extend the T-1.2 fixture matrix to cover /data/flood-stats.json, then add a global.sea_level unit here. Do not baseline it before T-4.11 resolves — the numbers are expected to change or disappear."
-    }
-  }
+  "excluded": {},
+
+  "_sea_level_excluded_note": [
+    "T-4.21 removed the SeaLevelChart mount from AliJeVroceERA5.tsx — the sea-level",
+    "widget is GATED OUT of v1 per D-10 (unsound per-cm factors D-10b; SRTM DEM unfit",
+    "for 10cm increments D-10c). Its former 'excluded' entry was dropped here because",
+    "the tag no longer appears in the page and assertSections() fails on a stale bucket",
+    "key (scripts/snapshot/main.mjs:153).",
+    "",
+    "It was never snapshotted: its figures — flooded hectares / affected buildings per",
+    "increment — came from /data/flood-stats.json plus the per-cm factors 20.77 ha and",
+    "14.13 buildings (SeaLevelWidget.tsx:56-57,109), none in the T-1.2 ERA5 fixture set.",
+    "",
+    "ON UNPARK (D-10b/c resolved, widget cleared to launch): restore the mount in",
+    "AliJeVroceERA5.tsx, re-add a SeaLevelChart entry under 'excluded' here (or a",
+    "global.sea_level 'covered' unit if the fixture matrix is extended to cover",
+    "/data/flood-stats.json). Tickets: T-4.11 (D-10c, DEM), T-4.10 (D-10b, factors +",
+    "unattributed AR6 tables), T-4.12 (flood asset passthrough), T-5.6 (lazy-load 162KB)."
+  ]
 }


### PR DESCRIPTION
## T-4.21 — enforce D-10: SeaLevelWidget not in v1

The widget was rendering live on stage and 404ing its flood assets. D-10 (reconfirmed) says it does not ship in v1 — unsound per-cm factors + unfit DEM. The `sea_level_section` flag is dead config (nothing reads it), so gated via mount removal (approach b).

**Changes:** removed the lazy import + sea-level `<section>` from `AliJeVroceERA5.tsx` (dated T-4.21/D-10 comments left for unpark); `SeaLevelWidget.tsx` + `scripts/floodmap/` kept (deferred); flag + i18n strings untouched. `sections.json` excluded-entry dropped, reasoning preserved as a note.

**Verification:** no source `import()`s SeaLevelWidget → widget never mounts → zero `/data/flood/` requests (static module-graph guarantee). Snapshot moved only `sections.excluded → []`; no rendered value moved.

Reversible: unpark steps recorded. Unpark with T-4.12/4.10/4.11 when D-10b/c resolve.

**Gates:** typecheck OK (8 allowlisted), test 47, snapshot identical post-record, pytest 45.