### PR TITLE
T-4.19 + T-2.7: dead corr/method + features removal

### DIFF
--- a/code/ali-je-vroce-era5/api.ts
+++ b/code/ali-je-vroce-era5/api.ts
@@ -504,8 +504,6 @@ export interface RegressionParams {
   locs:   string[];
   var:    string;
   doy:    number;
-  corr:   "raw" | "corr";
-  method: "theilsen" | "ols";
 }
 
 export async function fetchRegression(p: RegressionParams): Promise<RegressionResponse> {
@@ -694,8 +692,7 @@ export interface CalendarData {
 }
 
 export async function fetchCalendar(
-  loc: string, variable: string,
-  _corr: "raw" | "corr", _method: "theilsen" | "ols"
+  loc: string, variable: string
 ): Promise<CalendarData> {
   const rows = await dsGet<CalendarRow[]>(
     `annual_trend.json?_shape=array&era5_name__exact=${encodeURIComponent(loc)}&variable__exact=${encodeURIComponent(variable)}&_col=month&_col=day&_col=trend10&_col=p_val&_size=400`

--- a/code/ali-je-vroce-era5/components/HeroCards.tsx
+++ b/code/ali-je-vroce-era5/components/HeroCards.tsx
@@ -74,7 +74,7 @@ export function HeroCards(props: Props) {
   const [resp, { refetch }] = createResource(
     () => ({ loc: loc(), doy: props.doy }),
     ({ loc, doy }) =>
-      fetchRegression({ locs: [loc], var: "temperature_max", doy, corr: "corr", method: "theilsen" }),
+      fetchRegression({ locs: [loc], var: "temperature_max", doy }),
   );
 
   return (

--- a/code/ali-je-vroce-era5/components/RegressionPanel.tsx
+++ b/code/ali-je-vroce-era5/components/RegressionPanel.tsx
@@ -48,11 +48,6 @@ function createStore(props: ProviderProps) {
     locs:   selLocs(),
     var:    selVar(),
     doy:    doy(),
-    // Retained to satisfy RegressionParams; fetchRegression ignores both (the
-    // annual_trend table is always Theil-Sen + TFPW MK with elevation correction
-    // baked in). The toolbar controls that once varied them were dead — see T-4.15.
-    corr:   "raw",
-    method: "theilsen",
   }));
   const [regData, { refetch: refetchReg }] = createResource(params, fetchRegression);
 
@@ -62,7 +57,7 @@ function createStore(props: ProviderProps) {
   }));
   const [calData, { refetch: refetchCal }] = createResource(
     calParams,
-    p => fetchCalendar(p.loc, p.var, "raw", "theilsen"),
+    p => fetchCalendar(p.loc, p.var),
   );
 
   const isPrecip   = () => selVar() === "precipitation_sum" || selVar() === "et0_evapotranspiration";

--- a/tests/snapshot/harness.tsx
+++ b/tests/snapshot/harness.tsx
@@ -885,7 +885,7 @@ export async function run(): Promise<RunResult> {
     // The year-round calendar is keyed on station + variable only; its 365 rows
     // do not move with the selected date, which is why it lives here and not in
     // `cases`. doy=1 only positions the selected-day marker.
-    const cal = await fetchCalendar(station, defaults.variable, "raw", "theilsen");
+    const cal = await fetchCalendar(station, defaults.variable);
     assertNoMisses(`by_station.${station}.calendar (fetch)`);
     const calUnit = await mount(
       `by_station.${station}.calendar`,


### PR DESCRIPTION
## T-4.19 + T-2.7 — dead-code sweep

Removed the dead corr/method traces T-4.15 left behind (6 touchpoints: `RegressionParams.corr`/`method`, `fetchCalendar`'s `_corr`/`_method`, params-memo literals, HeroCards call site, snapshot harness caller). Proven dead — `fetchRegression`/`fetchCalendar` ignore them, every caller passed fixed literals. Left the live `types.ts` `stats.method` (same name, different thing) untouched.

T-2.7 (`features` object) was already deleted in `8f0f173` — confirmed absent.

**Snapshot byte-identical, no re-record** — the deletions changed nothing rendered. Diff +4/−12.

**Gates:** typecheck OK (8 allowlisted, unchanged), test 47, snapshot identical, pytest 45.