### PR TITLE
T-6.6a: refresh-failure alerting

### DIFF
--- a/.github/actions/ensure-label/action.yml
+++ b/.github/actions/ensure-label/action.yml
@@ -1,0 +1,47 @@
+name: 'Ensure a GitHub label exists'
+description: >
+  Single source (T-6.6a) for idempotently ensuring a repository label exists
+  before something references it by name. `gh pr create --label` and
+  `gh issue create --label` both resolve label names to node IDs and FAIL
+  before creating anything if a name is unknown — so an unattended job that
+  references a not-yet-created label would push a branch (or do worse work)
+  and then abort at creation. This action creates the label if missing and is
+  a no-op if it already exists. Used by data-refresh.yaml for both the
+  `data-refresh` PR label and the `refresh-failure` alert label, so the two
+  callers share ONE definition (D-18/D-19 anti-duplication) rather than copying
+  the `gh label create … || true` line. Needs a token with issues:write (labels
+  live under the issues API); the caller passes it in.
+inputs:
+  name:
+    description: 'Label name to ensure.'
+    required: true
+  color:
+    description: 'Hex colour, no leading "#".'
+    required: true
+  description:
+    description: 'Label description.'
+    required: false
+    default: ''
+  token:
+    description: 'GITHUB_TOKEN (or equivalent) with issues:write.'
+    required: true
+runs:
+  using: 'composite'
+  steps:
+    - name: Ensure label
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+        LABEL_NAME: ${{ inputs.name }}
+        LABEL_COLOR: ${{ inputs.color }}
+        LABEL_DESC: ${{ inputs.description }}
+      # `gh label create` errors if the label already exists; that is the
+      # idempotent no-op case, so swallow it. Any other failure (e.g. missing
+      # permission) is also swallowed here BY DESIGN — a label that cannot be
+      # created must not fail the run before the real work; the subsequent
+      # `--label` reference is what surfaces a genuinely missing label loudly.
+      run: |
+        gh label create "$LABEL_NAME" \
+          --color "$LABEL_COLOR" \
+          --description "$LABEL_DESC" \
+          2>/dev/null || true

--- a/.github/workflows/data-refresh.yaml
+++ b/.github/workflows/data-refresh.yaml
@@ -162,6 +162,19 @@ jobs:
       # so no extra pinned supply-chain dependency. Unique dated branch per run means a
       # plain push, never a force-push. `git add` is scoped to the raw CSVs (the scope
       # step already proved nothing else changed). If gh/push fails, the run fails loudly.
+      # Ensure the PR label exists BEFORE `gh pr create --label` — gh resolves
+      # label names to node IDs and aborts before creating the PR if the name is
+      # unknown, which on a first run (empty repo) would fetch ~20 min, push the
+      # branch, then fail at creation and leave an orphan branch with no PR.
+      - name: Ensure data-refresh label
+        if: steps.scope.outputs.changed == 'true'
+        uses: ./.github/actions/ensure-label
+        with:
+          name: data-refresh
+          color: D5C9EF
+          description: "Automated: weekly raw ERA5-Land refresh PR"
+          token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Open pull request with raw appends
         id: open_pr
         if: steps.scope.outputs.changed == 'true'
@@ -250,6 +263,17 @@ jobs:
       # rather than opening a new one, so a stuck weekly refresh cannot produce 52
       # issues. The body names the failed step, links the run, and — critically —
       # states whether anything was written to origin (only the PR step pushes).
+      # Ensure the dedupe label exists via the SAME action the PR label uses, so
+      # there is one way to ensure a label, not two copies (D-18/D-19).
+      - name: Ensure refresh-failure label
+        if: failure() && steps.confirm.outcome == 'success'
+        uses: ./.github/actions/ensure-label
+        with:
+          name: refresh-failure
+          color: B60205
+          description: "Automated: a weekly data-refresh run failed"
+          token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Alert on refresh failure
         if: failure() && steps.confirm.outcome == 'success'
         env:
@@ -325,12 +349,8 @@ jobs:
           comment here rather than opening new issues.</sub>
           EOF
 
-          # Ensure the dedupe label exists (idempotent; needs issues: write).
-          gh label create refresh-failure \
-            --color B60205 \
-            --description "Automated: a weekly data-refresh run failed" \
-            2>/dev/null || true
-
+          # (The refresh-failure label is ensured by the preceding step, via the
+          # shared ensure-label action.)
           # Dedupe: comment on the open refresh-failure issue if one exists, else
           # open a new one.
           existing="$(gh issue list --label refresh-failure --state open \

--- a/.github/workflows/data-refresh.yaml
+++ b/.github/workflows/data-refresh.yaml
@@ -44,12 +44,14 @@ concurrency:
   group: data-refresh
   cancel-in-progress: false
 
-# Least privilege: only what opening a PR needs. `contents: write` creates the
-# refresh branch and commit; `pull-requests: write` opens the PR. No packages,
-# no id-token, no actions scope.
+# Least privilege: only what opening a PR and alerting needs. `contents: write`
+# creates the refresh branch and commit; `pull-requests: write` opens the PR;
+# `issues: write` lets the failure-alert step open (or comment on, and label) a
+# refresh-failure issue (T-6.6a). No packages, no id-token, no actions scope.
 permissions:
   contents: write
   pull-requests: write
+  issues: write
 
 jobs:
   refresh:
@@ -62,6 +64,7 @@ jobs:
       # dispatcher typed the exact confirmation string. Do not remove it until
       # the T-4.3b meteo pass has landed (same condition as enabling `schedule:`).
       - name: Require explicit confirmation
+        id: confirm
         env:
           CONFIRM: ${{ github.event.inputs.confirm }}
         run: |
@@ -79,11 +82,13 @@ jobs:
           echo "Confirmation received (spend-quota) — proceeding with the refresh."
 
       - name: Checkout repository
+        id: checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
       - name: Install the latest version of uv
+        id: setup_uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           version: "latest"
@@ -95,6 +100,7 @@ jobs:
       # Open-Meteo free-tier quota — never do that from a scheduled job.
       # DATA_DIR points the collector at the tracked raw CSVs (default is /app/data/si).
       - name: Refresh raw station data (differential)
+        id: fetch
         env:
           DATA_DIR: data/climate-si/data/raw
         run: uv run --project data/climate-si/sources python data/climate-si/sources/mk_collect.py
@@ -135,6 +141,7 @@ jobs:
 
       # Raw-input contract — the SAME definition validate-data.yaml runs on PRs.
       - name: Validate raw station inputs
+        id: validate_raw
         if: steps.scope.outputs.changed == 'true'
         uses: ./.github/actions/validate-raw-data
 
@@ -145,6 +152,7 @@ jobs:
       # BEFORE the first to_sql, so a violation aborts non-zero and no PR is opened.
       # Network-free: it computes only from the raw CSVs on disk. DB output is gitignored.
       - name: Validate derived pipeline (precompute + validate)
+        id: precompute
         if: steps.scope.outputs.changed == 'true'
         env:
           DATA_DIR: data/climate-si/data/raw
@@ -155,6 +163,7 @@ jobs:
       # plain push, never a force-push. `git add` is scoped to the raw CSVs (the scope
       # step already proved nothing else changed). If gh/push fails, the run fails loudly.
       - name: Open pull request with raw appends
+        id: open_pr
         if: steps.scope.outputs.changed == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -169,6 +178,11 @@ jobs:
           branch="data-refresh/${date_tag}-${RUN_ID}"
           run_url="${SERVER_URL}/${REPO}/actions/runs/${RUN_ID}"
 
+          # Record the branch name for the failure-alert step BEFORE the push, so
+          # that if a later command aborts, the alert can name the branch. Outputs
+          # written to $GITHUB_OUTPUT survive a subsequent step failure.
+          echo "branch=$branch" >> "$GITHUB_OUTPUT"
+
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git switch -c "$branch"
@@ -178,6 +192,11 @@ jobs:
           # persist-credentials:false left no git credential — push over an explicit
           # tokened URL (GH_TOKEN is masked in logs). A new branch each run = plain push.
           git push "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git" "$branch"
+
+          # The push landed. Record it so that if `gh pr create` below fails, the
+          # alert step reports a pushed-but-PR-less orphan branch, not "nothing
+          # written". This is the one partial state that leaves data on origin.
+          echo "pushed=true" >> "$GITHUB_OUTPUT"
 
           cat > /tmp/pr-body.md <<EOF
           ## Weekly raw data refresh
@@ -210,3 +229,119 @@ jobs:
             --title "Weekly raw data refresh (${date_tag})" \
             --body-file /tmp/pr-body.md \
             --label data-refresh
+
+      # --- Failure alerting (T-6.6a) ------------------------------------------
+      # D-19 makes the refresh validate in-job and open NO PR on failure, which
+      # makes "a real failure" indistinguishable from "no new data this week"
+      # unless a human happens to watch the run. This step closes that gap and is
+      # the HARD prerequisite (D-19) for ever uncommenting the `schedule:` block.
+      #
+      # Fires on ANY real failure (fetch, scope-assert, validate-raw, precompute,
+      # PR-open, or an infra failure of checkout/setup-uv). Deliberately does NOT
+      # fire in two cases:
+      #   * the confirmation guard aborted — `steps.confirm.outcome != 'success'`
+      #     means someone dispatched without typing `spend-quota`; that is a user
+      #     error, not an incident, and alerting on it would train people to
+      #     ignore these issues (D-19 second clause, ticket step 1b);
+      #   * the job SUCCEEDED — which includes the legitimate "nothing changed,
+      #     no PR" path, where the scope step exits 0 and the job is green, so
+      #     `failure()` is false and this step never runs.
+      # Dedupe: repeat failures COMMENT on the one open `refresh-failure` issue
+      # rather than opening a new one, so a stuck weekly refresh cannot produce 52
+      # issues. The body names the failed step, links the run, and — critically —
+      # states whether anything was written to origin (only the PR step pushes).
+      - name: Alert on refresh failure
+        if: failure() && steps.confirm.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
+          CHECKOUT_OUTCOME: ${{ steps.checkout.outcome }}
+          SETUP_UV_OUTCOME: ${{ steps.setup_uv.outcome }}
+          FETCH_OUTCOME: ${{ steps.fetch.outcome }}
+          SCOPE_OUTCOME: ${{ steps.scope.outcome }}
+          VALIDATE_RAW_OUTCOME: ${{ steps.validate_raw.outcome }}
+          PRECOMPUTE_OUTCOME: ${{ steps.precompute.outcome }}
+          OPEN_PR_OUTCOME: ${{ steps.open_pr.outcome }}
+          PR_BRANCH: ${{ steps.open_pr.outputs.branch }}
+          PR_PUSHED: ${{ steps.open_pr.outputs.pushed }}
+        run: |
+          set -euo pipefail
+
+          # Which step failed — the first in run order whose outcome is 'failure'
+          # (earlier steps are 'success', later ones 'skipped').
+          if [ "$CHECKOUT_OUTCOME" = "failure" ]; then
+            failed="Checkout repository (infrastructure)"
+          elif [ "$SETUP_UV_OUTCOME" = "failure" ]; then
+            failed="Install uv (infrastructure)"
+          elif [ "$FETCH_OUTCOME" = "failure" ]; then
+            failed="Refresh raw station data (mk_collect.py, differential fetch)"
+          elif [ "$SCOPE_OUTCOME" = "failure" ]; then
+            failed="Assert only raw CSVs changed / detect scope"
+          elif [ "$VALIDATE_RAW_OUTCOME" = "failure" ]; then
+            failed="Validate raw station inputs (validate_raw.py)"
+          elif [ "$PRECOMPUTE_OUTCOME" = "failure" ]; then
+            failed="Validate derived pipeline (precompute_datasette.py)"
+          elif [ "$OPEN_PR_OUTCOME" = "failure" ]; then
+            failed="Open pull request with raw appends"
+          else
+            failed="Unknown — no step reported failure; read the run log"
+          fi
+
+          # Was anything written to origin? Only the PR step pushes; it records
+          # branch + pushed via step outputs. Every earlier failure leaves changes
+          # solely in the ephemeral runner working tree, which is discarded — so
+          # nothing persists to the repository.
+          if [ "${PR_PUSHED:-}" = "true" ]; then
+            raw_state="⚠️ **A branch WAS pushed to origin: \`${PR_BRANCH}\`.** It carries this run's raw-CSV commit, but because the failure was in the PR step **no pull request was opened** — the branch is orphaned. Inspect it, then delete if unwanted: \`git push origin --delete ${PR_BRANCH}\`."
+          elif [ -n "${PR_BRANCH:-}" ]; then
+            raw_state="The push did **not** complete. Branch \`${PR_BRANCH}\` existed only in the discarded runner — **nothing was written to the repository.**"
+          else
+            raw_state="**Nothing was written to the repository.** mk_collect.py may have modified raw CSVs in the runner's working tree, but that tree is ephemeral and is discarded with the runner — no branch reached origin."
+          fi
+
+          cat > "${RUNNER_TEMP}/issue-body.md" <<EOF
+          ## Weekly data refresh FAILED
+
+          The \`Weekly data refresh\` run did not complete. Under D-19 the refresh
+          validates in-job and opens **no PR** on failure, so this would otherwise
+          be silent — hence this issue.
+
+          - **Failed step:** ${failed}
+          - **Run:** ${RUN_URL} (attempt ${RUN_ATTEMPT})
+          - **Raw data / branch state:** ${raw_state}
+
+          ### What an on-call person should do
+          1. Open the run log above and read the failed step.
+          2. If a branch was pushed (see above), inspect or delete it — it is
+             behind no PR and is not cleaned up automatically.
+          3. mk_collect.py writes one CSV per station, so a mid-fetch failure can
+             leave partial appends in the (now-discarded) runner tree; once the
+             cause is fixed, a fresh differential re-dispatch is safe.
+
+          ---
+          <sub>Opened automatically by \`.github/workflows/data-refresh.yaml\`
+          (T-6.6a). Deduped by the \`refresh-failure\` label — repeat failures
+          comment here rather than opening new issues.</sub>
+          EOF
+
+          # Ensure the dedupe label exists (idempotent; needs issues: write).
+          gh label create refresh-failure \
+            --color B60205 \
+            --description "Automated: a weekly data-refresh run failed" \
+            2>/dev/null || true
+
+          # Dedupe: comment on the open refresh-failure issue if one exists, else
+          # open a new one.
+          existing="$(gh issue list --label refresh-failure --state open \
+            --json number --jq '.[0].number // empty')"
+          if [ -n "$existing" ]; then
+            echo "Existing open refresh-failure issue #${existing} — commenting."
+            gh issue comment "$existing" --body-file "${RUNNER_TEMP}/issue-body.md"
+          else
+            echo "No open refresh-failure issue — creating one."
+            gh issue create \
+              --title "Weekly data refresh failed" \
+              --body-file "${RUNNER_TEMP}/issue-body.md" \
+              --label refresh-failure
+          fi


### PR DESCRIPTION
D-19 made the weekly refresh validate in-job and open no PR on failure, which
makes 'validation failed' indistinguishable from 'no new data this week'. This closes
that gate — alerting is a hard prerequisite for ever enabling the schedule.

Opens a deduped GitHub issue on failure via first-party gh: comments on an existing
open issue rather than opening a second, so a weekly failure cannot produce 52 issues.
The body names the failed step, links the run, and states whether raw data was written
— open_pr emits branch= before the push and pushed=true after, so an orphan pushed
branch is distinguishable from nothing-written.

Routing is if: failure() && steps.confirm.outcome == 'success'. A bare failure() would
raise an incident every time someone clicks Run without typing the confirmation string,
and an alert channel that cries wolf gets muted. Silent by design: guard abort, nothing
changed, cancellation.

Second commit fixes a latent T-5.7d bug: open_pr passed --label data-refresh, which
does not exist in this repo, and gh resolves label names before creating the PR. A
first real run would have spent ~20 minutes of reserved Open-Meteo quota, pushed the
branch, then aborted at PR creation. Both labels are now ensured through one composite
action rather than duplicated logic.

Not built, deliberately: detecting a run that never happens. An in-repo heartbeat or
canary is itself a scheduled workflow subject to the same 60-day auto-disable it would
detect, so the monitor must be external. Recommendation recorded for T-6.6b; only
needed when the schedule is enabled.

Never executed. actionlint clean, zizmor --offline clean. Gates: typecheck 8
allowlisted, yarn test 52, snapshot byte-identical, pytest 51.