### PR TITLE
T-5.3b: codegen the frontend column contract from datapackage.yaml

### DIFF
--- a/code/ali-je-vroce-era5/api.ts
+++ b/code/ali-je-vroce-era5/api.ts
@@ -4,6 +4,14 @@ import type {
 } from "./types.ts";
 import type { SpeiData } from "./charts/SpeiHeatmap.tsx";
 import type { SpeiStationData } from "./charts/SpeiTrendChart.tsx";
+// T-5.3b (D-18 Half 2): the datasette column contract, codegen'd from
+// data/climate-si/datapackage.yaml (code/ali-je-vroce-era5/generated/datasette-schema.ts).
+// The `*Col` unions type-check the `_col=` projections below; `DsTropical` types the
+// tropical read. A column renamed in datapackage regenerates that file and turns any
+// stale name here into a compile error rather than a silent live-page break.
+import type {
+  StationsCol, DailyCol, SeasonHeatmapCol, SpeiCol, SpeiStationCol, AnnualTrendCol, DsTropical,
+} from "./generated/datasette-schema.ts";
 // The category palette lives with the percentile helpers salvaged from the
 // deleted ARSO path (T-2.2 / D-2); see percentile.ts for why they were kept.
 // `cdfPercentile` is the T-4.1 / D-6 honest percentile (CDF of the served KDE).
@@ -64,6 +72,33 @@ async function dsGet<T>(path: string): Promise<T> {
   const resp = await fetch(`${DS}/${path}`);
   if (!resp.ok) throw new Error(`Datasette ${resp.status}: ${path}`);
   return resp.json() as Promise<T>;
+}
+
+// ── `_col=` column projections (T-5.3b / D-18) ──────────────────────────────────
+//
+// Each datasette query below that uses `_col=` selects a SUBSET of its table's
+// columns. The subset and its ORDER are declared here as tuples type-checked against
+// the generated column unions (StationsCol, DailyCol, …). A column renamed in
+// datapackage.yaml regenerates those unions, and the now-invalid string literal below
+// fails `yarn typecheck` — closing the pipeline→frontend seam D-18 opened.
+//
+// THE ORDER IS THE URL ORDER, NOT datapackage's field order. The 2,040 fixtures are
+// keyed on the exact request URL (tests/fixtures/index.json; T-5.2 kept `_size`
+// literal for the same reason), so `dsCols` must reproduce the recorded query string
+// byte-for-byte. Where a call site's historical column order differs from
+// datapackage's declaration order, THIS TUPLE PRESERVES THE URL — reordering to match
+// datapackage would miss every fixture for no benefit.
+const STATIONS_COLS       = ["era5_name", "name", "lat", "lon", "elevation", "station_id"] as const satisfies readonly StationsCol[];
+const DAILY_TODAY_COLS    = ["temperature_max_2m"] as const satisfies readonly DailyCol[];
+const DAILY_LAST7_COLS    = ["date", "temperature_max_2m", "month", "day"] as const satisfies readonly DailyCol[];
+const SEASON_HEATMAP_COLS = ["x", "y", "season", "avg", "percentile", "cat", "rank", "total", "color", "n_days"] as const satisfies readonly SeasonHeatmapCol[];
+const SPEI_COLS           = ["y", "spei", "balance", "cat", "rank", "total", "color", "season", "n_days"] as const satisfies readonly SpeiCol[];
+const SPEI_STATION_COLS   = ["era5_name", "series", "years_json", "spei_json", "trend_json"] as const satisfies readonly SpeiStationCol[];
+const CALENDAR_COLS       = ["month", "day", "trend10", "p_val"] as const satisfies readonly AnnualTrendCol[];
+
+/** Render an ordered column tuple as a datasette `_col=a&_col=b&…` query fragment. */
+function dsCols(cols: readonly string[]): string {
+  return cols.map(c => `_col=${c}`).join("&");
 }
 
 // T-5.1: guard for the datasette `*_json` columns (distribution_json, scatter_json,
@@ -308,7 +343,7 @@ export async function fetchMeta(): Promise<SiteMeta> {
   const era5Stations = await dsGet<Array<{
     era5_name: string; name: string; lat: number; lon: number;
     elevation: number; station_id: number | null;
-  }>>("stations.json?_shape=array&_col=era5_name&_col=name&_col=lat&_col=lon&_col=elevation&_col=station_id&_size=30");
+  }>>(`stations.json?_shape=array&${dsCols(STATIONS_COLS)}&_size=30`);
 
   // T-5.2 — the station registry is the SOURCE of the station count that the three
   // national-aggregate asserts (assertNationalStationRows) trust, so a silent
@@ -368,7 +403,7 @@ export async function fetchTodayStatus(date: string, loc: string | null): Promis
     if (!w) return { available: false };
 
     const dsRows = await dsGet<Array<{ temperature_max_2m: number | null }>>(
-      `daily.json?_shape=array&date__exact=${date}&_col=temperature_max_2m&_size=50`
+      `daily.json?_shape=array&date__exact=${date}&${dsCols(DAILY_TODAY_COLS)}&_size=50`
     );
     assertNationalStationRows(dsRows, "daily");
     const dsVals = dsRows.filter(r => r.temperature_max_2m != null).map(r => r.temperature_max_2m!);
@@ -405,7 +440,7 @@ export async function fetchTodayStatus(date: string, loc: string | null): Promis
   let isPreliminary = false;
 
   const rows = await dsGet<Array<{ temperature_max_2m: number }>>(
-    `daily.json?_shape=array&era5_name__exact=${encodeURIComponent(era5Name)}&date__exact=${date}&_col=temperature_max_2m&_size=1`
+    `daily.json?_shape=array&era5_name__exact=${encodeURIComponent(era5Name)}&date__exact=${date}&${dsCols(DAILY_TODAY_COLS)}&_size=1`
   );
   if (rows[0]?.temperature_max_2m != null) {
     todayTemp = rows[0].temperature_max_2m;
@@ -449,7 +484,7 @@ export async function fetchLast7(date: string, loc: string | null): Promise<Last
   const rows = await dsGet<Array<{
     date: string; temperature_max_2m: number; month: number; day: number;
   }>>(
-    `daily.json?_shape=array&era5_name__exact=${encodeURIComponent(era5Name)}&date__lte=${date}&_sort_desc=date&_size=7&_col=date&_col=temperature_max_2m&_col=month&_col=day`
+    `daily.json?_shape=array&era5_name__exact=${encodeURIComponent(era5Name)}&date__lte=${date}&_sort_desc=date&_size=7&${dsCols(DAILY_LAST7_COLS)}`
   );
   if (!rows.length) return { available: false, days: [] };
 
@@ -494,7 +529,7 @@ export async function fetchPageData(
 export async function fetchSeasonHeatmap(loc?: string | null): Promise<SeasonHeatmapRow[]> {
   const era5Name = loc ?? "Ljubljana";
   return dsGet<SeasonHeatmapRow[]>(
-    `season_heatmap.json?_shape=array&era5_name__exact=${encodeURIComponent(era5Name)}&_col=x&_col=y&_col=season&_col=avg&_col=percentile&_col=cat&_col=rank&_col=total&_col=color&_col=n_days&_size=500`
+    `season_heatmap.json?_shape=array&era5_name__exact=${encodeURIComponent(era5Name)}&${dsCols(SEASON_HEATMAP_COLS)}&_size=500`
   );
 }
 
@@ -600,7 +635,7 @@ export async function fetchEra5Tropical(
   // the section's ErrorBoundary can show a visible error, instead of being swallowed
   // into `null` and rendering as an empty section. A genuinely empty result set
   // (no matching row) still returns null — that is legitimate "no data", not a fault.
-  const rows = await dsGet<Array<{ years_json: string; counts_json: string; nonzero_count: number; trend_json: string }>>(
+  const rows = await dsGet<Array<Pick<DsTropical, "years_json" | "counts_json" | "nonzero_count" | "trend_json">>>(
     `tropical.json?_shape=array&era5_name__exact=${encodeURIComponent(loc)}` +
     `&kind__exact=${kind}&threshold__exact=${threshold}&streak__exact=${streak}&_size=1`
   );
@@ -630,7 +665,7 @@ export async function fetchSpeiHeatmap(): Promise<SpeiData> {
     y: number; spei: number; balance: number; cat: string; rank: number;
     total: number; color: string; season: string; n_days: number;
   }>>(
-    `spei.json?_shape=array&_col=y&_col=spei&_col=balance&_col=cat&_col=rank&_col=total&_col=color&_col=season&_col=n_days&_size=2000`
+    `spei.json?_shape=array&${dsCols(SPEI_COLS)}&_size=2000`
   );
   if (!rows.length) return empty;
   const years = rows.map(r => r.y);
@@ -655,7 +690,7 @@ export async function fetchSpeiStationSeasonal(): Promise<SpeiStationData> {
   const rows = await dsGet<Array<{
     era5_name: string; series: string; years_json: string; spei_json: string; trend_json: string;
   }>>(
-    `spei_station.json?_shape=array&_col=era5_name&_col=series&_col=years_json&_col=spei_json&_col=trend_json&_size=1000`
+    `spei_station.json?_shape=array&${dsCols(SPEI_STATION_COLS)}&_size=1000`
   );
   if (!rows.length) return empty;
   const stations: SpeiStationData["stations"] = {};
@@ -695,7 +730,7 @@ export async function fetchCalendar(
   loc: string, variable: string
 ): Promise<CalendarData> {
   const rows = await dsGet<CalendarRow[]>(
-    `annual_trend.json?_shape=array&era5_name__exact=${encodeURIComponent(loc)}&variable__exact=${encodeURIComponent(variable)}&_col=month&_col=day&_col=trend10&_col=p_val&_size=400`
+    `annual_trend.json?_shape=array&era5_name__exact=${encodeURIComponent(loc)}&variable__exact=${encodeURIComponent(variable)}&${dsCols(CALENDAR_COLS)}&_size=400`
   );
   return { loc, var: variable, unit: "°C", method_label: "Theil-Sen + TFPW MK", rows };
 }

--- a/code/ali-je-vroce-era5/generated/datasette-schema.ts
+++ b/code/ali-je-vroce-era5/generated/datasette-schema.ts
@@ -1,0 +1,252 @@
+// AUTO-GENERATED — DO NOT EDIT BY HAND.
+//
+// Source of truth: data/climate-si/datapackage.yaml (D-18, T-5.3a/b).
+// Regenerate with:
+//   uv run --project data/climate-si/sources python data/climate-si/sources/generate_frontend_schema.py
+// Generator: data/climate-si/sources/generate_frontend_schema.py
+//
+// Per datasette table this file declares a row interface (Ds<Table>), a
+// column tuple (<TABLE>_COLUMNS, `as const`) and a column union (<Table>Col).
+// api.ts / types.ts consume these so a datapackage column rename that is not
+// mirrored into the frontend becomes a `yarn typecheck` error, not a live
+// page break. A pytest freshness gate keeps this file in sync with datapackage.
+//
+// `daily_percentiles` is declared in datapackage but fetched zero times, so it
+// is intentionally excluded here (exclusion from the generator, NOT removal from
+// the datasette — D-18).
+
+export interface DsAnnualTrend {
+  era5_name: string;
+  station_id: number;
+  variable: string;
+  month: number;
+  day: number;
+  day_label: string;
+  year_min: number;
+  year_max: number;
+  trend10: number;
+  p_val: number;
+  tau: number;
+  n_years: number;
+  proj_end_year: number;
+  slope: number;
+  intercept: number;
+  slope_hi: number;
+  intercept_hi: number;
+  slope_lo: number;
+  intercept_lo: number;
+  scatter_json: string;
+}
+
+export const ANNUAL_TREND_COLUMNS = [
+  "era5_name",
+  "station_id",
+  "variable",
+  "month",
+  "day",
+  "day_label",
+  "year_min",
+  "year_max",
+  "trend10",
+  "p_val",
+  "tau",
+  "n_years",
+  "proj_end_year",
+  "slope",
+  "intercept",
+  "slope_hi",
+  "intercept_hi",
+  "slope_lo",
+  "intercept_lo",
+  "scatter_json",
+] as const;
+export type AnnualTrendCol = (typeof ANNUAL_TREND_COLUMNS)[number];
+
+export interface DsDaily {
+  station_id: number;
+  era5_name: string;
+  date: string;
+  year: number;
+  month: number;
+  day: number;
+  temperature_max_2m: number;
+  temperature_average_2m: number;
+  temperature_min_2m: number;
+}
+
+export const DAILY_COLUMNS = [
+  "station_id",
+  "era5_name",
+  "date",
+  "year",
+  "month",
+  "day",
+  "temperature_max_2m",
+  "temperature_average_2m",
+  "temperature_min_2m",
+] as const;
+export type DailyCol = (typeof DAILY_COLUMNS)[number];
+
+export interface DsDailyWindow {
+  era5_name: string;
+  station_id: number;
+  month: number;
+  day: number;
+  p5: number;
+  p10: number;
+  p20: number;
+  p50: number;
+  p80: number;
+  p95: number;
+  n_samples: number;
+  year_min: number;
+  year_max: number;
+  distribution_json: string;
+}
+
+export const DAILY_WINDOW_COLUMNS = [
+  "era5_name",
+  "station_id",
+  "month",
+  "day",
+  "p5",
+  "p10",
+  "p20",
+  "p50",
+  "p80",
+  "p95",
+  "n_samples",
+  "year_min",
+  "year_max",
+  "distribution_json",
+] as const;
+export type DailyWindowCol = (typeof DAILY_WINDOW_COLUMNS)[number];
+
+export interface DsSeasonHeatmap {
+  era5_name: string;
+  station_id: number;
+  x: number;
+  y: number;
+  season: string;
+  avg: number;
+  percentile: number;
+  cat: string;
+  rank: number;
+  total: number;
+  color: string;
+  n_days: number;
+}
+
+export const SEASON_HEATMAP_COLUMNS = [
+  "era5_name",
+  "station_id",
+  "x",
+  "y",
+  "season",
+  "avg",
+  "percentile",
+  "cat",
+  "rank",
+  "total",
+  "color",
+  "n_days",
+] as const;
+export type SeasonHeatmapCol = (typeof SEASON_HEATMAP_COLUMNS)[number];
+
+export interface DsStations {
+  era5_name: string;
+  name: string;
+  official_name: string;
+  name_locative: string;
+  station_id: number;
+  xml_id: string;
+  lat: number;
+  lon: number;
+  elevation: number;
+  elevation_era5_m: number;
+}
+
+export const STATIONS_COLUMNS = [
+  "era5_name",
+  "name",
+  "official_name",
+  "name_locative",
+  "station_id",
+  "xml_id",
+  "lat",
+  "lon",
+  "elevation",
+  "elevation_era5_m",
+] as const;
+export type StationsCol = (typeof STATIONS_COLUMNS)[number];
+
+export interface DsTropical {
+  era5_name: string;
+  station_id: number;
+  kind: string;
+  threshold: number;
+  streak: number;
+  years_json: string;
+  counts_json: string;
+  nonzero_count: number;
+  trend_json: string;
+}
+
+export const TROPICAL_COLUMNS = [
+  "era5_name",
+  "station_id",
+  "kind",
+  "threshold",
+  "streak",
+  "years_json",
+  "counts_json",
+  "nonzero_count",
+  "trend_json",
+] as const;
+export type TropicalCol = (typeof TROPICAL_COLUMNS)[number];
+
+export interface DsSpei {
+  x: number;
+  y: number;
+  spei: number;
+  balance: number;
+  cat: string;
+  rank: number;
+  total: number;
+  color: string;
+  season: string;
+  n_days: number;
+}
+
+export const SPEI_COLUMNS = [
+  "x",
+  "y",
+  "spei",
+  "balance",
+  "cat",
+  "rank",
+  "total",
+  "color",
+  "season",
+  "n_days",
+] as const;
+export type SpeiCol = (typeof SPEI_COLUMNS)[number];
+
+export interface DsSpeiStation {
+  era5_name: string;
+  station_id: number;
+  series: string;
+  years_json: string;
+  spei_json: string;
+  trend_json: string;
+}
+
+export const SPEI_STATION_COLUMNS = [
+  "era5_name",
+  "station_id",
+  "series",
+  "years_json",
+  "spei_json",
+  "trend_json",
+] as const;
+export type SpeiStationCol = (typeof SPEI_STATION_COLUMNS)[number];

--- a/code/ali-je-vroce-era5/types.ts
+++ b/code/ali-je-vroce-era5/types.ts
@@ -1,3 +1,5 @@
+import type { DsAnnualTrend, DsDailyWindow } from "./generated/datasette-schema.ts";
+
 /** Today's status for one location — assembled in api.ts:218 from datasette rows
  *  plus the Open-Meteo live max. Never a sidecar payload (T-2.3, D-1). */
 export interface TodayStatus {
@@ -43,44 +45,31 @@ export interface Last7 {
   }>;
 }
 
-/** Datasette climate-si annual_trend row (slim: line params, not point arrays) */
-export interface AnnualTrendRow {
-  era5_name:       string;
-  month:           number;
-  day:             number;
-  day_label:       string;
-  year_min:        number;
-  year_max:        number;
-  trend10:         number;
-  p_val:           number;
-  tau:             number;
-  n_years:         number;
-  proj_end_year:   number;
-  scatter_json:    string;
+/** Datasette climate-si annual_trend row (slim projection: line params, not point
+ *  arrays). Columns are Pick'd from the generated datapackage contract (T-5.3b, D-18)
+ *  so a column renamed in datapackage.yaml — regenerating datasette-schema.ts —
+ *  becomes a compile error here. The declared `station_id` and `variable` columns are
+ *  intentionally NOT picked: the frontend reads neither as a row field (`variable` is
+ *  only ever a URL filter value), so renaming them cannot break a read. */
+export type AnnualTrendRow = Pick<
+  DsAnnualTrend,
+  | "era5_name" | "month" | "day" | "day_label" | "year_min" | "year_max"
+  | "trend10" | "p_val" | "tau" | "n_years" | "proj_end_year" | "scatter_json"
   // fitted line parameters — central + upper/lower CI (y = slope·x + intercept)
-  slope:           number;
-  intercept:       number;
-  slope_hi:        number;
-  intercept_hi:    number;
-  slope_lo:        number;
-  intercept_lo:    number;
-}
+  | "slope" | "intercept" | "slope_hi" | "intercept_hi" | "slope_lo" | "intercept_lo"
+>;
 
-/** Datasette si_daily_window row */
-export interface DailyWindowRow {
-  station:           string;
-  month:             number;
-  day:               number;
-  p5:                number;
-  p10:               number;
-  p20:               number;
-  p50:               number;
-  p80:               number;
-  p95:               number;
-  n_samples:         number;
-  year_min:          number;
-  year_max:          number;
-  distribution_json: string;
+/** Datasette climate-si daily_window row. The p5..p95 cutoffs and metadata are Pick'd
+ *  from the generated datapackage contract (T-5.3b) so a rename breaks compilation.
+ *  `station` is synthesized client-side from the era5_name column (api.ts
+ *  fetchDailyWindow / fetchEra5NationalWindowRow) and is NOT a datasette column. */
+export interface DailyWindowRow extends Pick<
+  DsDailyWindow,
+  | "month" | "day"
+  | "p5" | "p10" | "p20" | "p50" | "p80" | "p95"
+  | "n_samples" | "year_min" | "year_max" | "distribution_json"
+> {
+  station: string;
 }
 
 /** Site metadata — built client-side in api.ts:173 from the datasette stations

--- a/data/climate-si/sources/generate_frontend_schema.py
+++ b/data/climate-si/sources/generate_frontend_schema.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""Codegen the frontend datasette column contract from datapackage.yaml (T-5.3b, D-18 Half 2).
+
+`data/climate-si/datapackage.yaml` is the AUTHORITATIVE per-table column declaration
+(D-18, T-5.3a): `validate.py` already derives every derived table's column *set* from
+it. This script closes the other end of the seam — it emits a TypeScript module
+(`code/ali-je-vroce-era5/generated/datasette-schema.ts`) with, per table:
+
+  * a row interface `Ds<Table>`            — every declared column, typed
+  * a column tuple `<TABLE>_COLUMNS`       — the declared column names, `as const`
+  * a column union  `<Table>Col`           — `typeof <TABLE>_COLUMNS[number]`
+
+The frontend (`api.ts`, `types.ts`) consumes these instead of hand-maintained row
+shapes and bare `_col=` string literals. A column renamed in datapackage.yaml then
+regenerates this file, and any frontend site still naming the old column fails
+`yarn typecheck` — instead of building green and breaking the live page (dsGet<T> is
+an unchecked cast, api.ts:63-66; snapshot:check replays URL-keyed fixtures without a
+live datasette). A pytest freshness gate (tests/test_frontend_schema.py) fails if the
+committed file drifts from this generator's output.
+
+`daily_percentiles` is DECLARED in datapackage but fetched ZERO times by the frontend
+(T-5.3b Step 1d). It is excluded from the generated contract so no dead types are
+emitted — this is exclusion FROM THE GENERATOR ONLY, not removal from the datasette
+(the table stays a public resource; its removal is its own ticket, D-18).
+
+Regenerate with:
+
+    uv run --project data/climate-si/sources \
+        python data/climate-si/sources/generate_frontend_schema.py
+
+Writing to stdout instead (e.g. to diff): pass --stdout.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import yaml
+
+# Tables declared in datapackage but NOT part of the frontend contract. Excluding a
+# table here does NOT remove it from the datasette (D-18) — it only keeps dead types
+# out of the generated module. `daily_percentiles`: declared, fetched zero times.
+EXCLUDED_TABLES = {"daily_percentiles"}
+
+# frictionless field type -> TypeScript type. Datasette serves `date` columns as ISO
+# "YYYY-MM-DD" strings, so they map to `string`, not a Date.
+TS_TYPE = {
+    "string": "string",
+    "date": "string",
+    "number": "number",
+    "integer": "number",
+}
+
+DATAPACKAGE = Path(__file__).resolve().parent.parent / "datapackage.yaml"
+# repo root: sources -> climate-si -> data -> <root>
+OUTPUT = (
+    Path(__file__).resolve().parents[3]
+    / "code" / "ali-je-vroce-era5" / "generated" / "datasette-schema.ts"
+)
+
+REGEN_CMD = (
+    "uv run --project data/climate-si/sources "
+    "python data/climate-si/sources/generate_frontend_schema.py"
+)
+
+
+def _pascal(table: str) -> str:
+    return "".join(part.capitalize() for part in table.split("_"))
+
+
+def _load_tables(dp_path: Path) -> list[tuple[str, list[tuple[str, str]]]]:
+    """Return [(table, [(col, frictionless_type), …]), …] in datapackage order,
+    excluding EXCLUDED_TABLES."""
+    with open(dp_path) as f:
+        dp = yaml.safe_load(f)
+    tables: list[tuple[str, list[tuple[str, str]]]] = []
+    for res in dp.get("resources", []):
+        name = res["name"]
+        if name in EXCLUDED_TABLES:
+            continue
+        fields = res.get("schema", {}).get("fields")
+        if fields is None:
+            raise ValueError(f"datapackage.yaml resource {name!r} has no schema.fields")
+        cols = [(fld["name"], fld["type"]) for fld in fields]
+        tables.append((name, cols))
+    return tables
+
+
+def generate(dp_path: Path = DATAPACKAGE) -> str:
+    tables = _load_tables(dp_path)
+
+    out: list[str] = []
+    out.append("// AUTO-GENERATED — DO NOT EDIT BY HAND.")
+    out.append("//")
+    out.append("// Source of truth: data/climate-si/datapackage.yaml (D-18, T-5.3a/b).")
+    out.append("// Regenerate with:")
+    out.append(f"//   {REGEN_CMD}")
+    out.append("// Generator: data/climate-si/sources/generate_frontend_schema.py")
+    out.append("//")
+    out.append("// Per datasette table this file declares a row interface (Ds<Table>), a")
+    out.append("// column tuple (<TABLE>_COLUMNS, `as const`) and a column union (<Table>Col).")
+    out.append("// api.ts / types.ts consume these so a datapackage column rename that is not")
+    out.append("// mirrored into the frontend becomes a `yarn typecheck` error, not a live")
+    out.append("// page break. A pytest freshness gate keeps this file in sync with datapackage.")
+    out.append("//")
+    out.append(f"// `daily_percentiles` is declared in datapackage but fetched zero times, so it")
+    out.append("// is intentionally excluded here (exclusion from the generator, NOT removal from")
+    out.append("// the datasette — D-18).")
+    out.append("")
+
+    for table, cols in tables:
+        pascal = _pascal(table)
+        upper = table.upper()
+
+        out.append(f"export interface Ds{pascal} {{")
+        for col, ftype in cols:
+            ts = TS_TYPE.get(ftype)
+            if ts is None:
+                raise ValueError(
+                    f"{table}.{col}: unmapped datapackage field type {ftype!r}")
+            out.append(f"  {col}: {ts};")
+        out.append("}")
+        out.append("")
+
+        out.append(f"export const {upper}_COLUMNS = [")
+        for col, _ in cols:
+            out.append(f'  "{col}",')
+        out.append("] as const;")
+        out.append(f"export type {pascal}Col = (typeof {upper}_COLUMNS)[number];")
+        out.append("")
+
+    # Drop the trailing blank line left by the per-table loop so the file ends with
+    # exactly one newline.
+    while out and out[-1] == "":
+        out.pop()
+    return "\n".join(out) + "\n"
+
+
+def main(argv: list[str]) -> int:
+    content = generate()
+    if "--stdout" in argv:
+        sys.stdout.write(content)
+        return 0
+    OUTPUT.parent.mkdir(parents=True, exist_ok=True)
+    OUTPUT.write_text(content)
+    sys.stderr.write(f"wrote {OUTPUT}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/data/climate-si/sources/tests/test_frontend_schema.py
+++ b/data/climate-si/sources/tests/test_frontend_schema.py
@@ -1,0 +1,53 @@
+"""Freshness gate for the codegen'd frontend datasette contract (T-5.3b, D-18 Half 2).
+
+`generate_frontend_schema.py` emits code/ali-je-vroce-era5/generated/datasette-schema.ts
+from datapackage.yaml. This test is the CI freshness assert the ticket calls for:
+`generate && git diff --exit-code`, expressed as "the committed file equals the
+generator's current output". It rides the existing pytest gate rather than adding a
+workflow. If datapackage.yaml changes and the generated file is not regenerated, this
+fails — naming the regeneration command."""
+
+import yaml  # noqa: E402
+
+from generate_frontend_schema import (  # noqa: E402
+    DATAPACKAGE,
+    EXCLUDED_TABLES,
+    OUTPUT,
+    REGEN_CMD,
+    generate,
+)
+
+
+def test_generated_schema_matches_datapackage():
+    """The committed .ts equals a fresh generation. This is the drift gate."""
+    assert OUTPUT.exists(), (
+        f"{OUTPUT} is missing — regenerate with:\n    {REGEN_CMD}")
+    expected = generate()
+    actual = OUTPUT.read_text()
+    assert actual == expected, (
+        "code/ali-je-vroce-era5/generated/datasette-schema.ts is STALE relative to "
+        f"datapackage.yaml.\nRegenerate with:\n    {REGEN_CMD}")
+
+
+def test_every_non_excluded_table_is_emitted():
+    """Every datapackage resource except the excluded set gets a row interface, so a
+    table added to datapackage cannot silently miss the frontend contract."""
+    with open(DATAPACKAGE) as f:
+        dp = yaml.safe_load(f)
+    content = generate()
+    for res in dp.get("resources", []):
+        table = res["name"]
+        pascal = "".join(p.capitalize() for p in table.split("_"))
+        marker = f"export interface Ds{pascal} {{"
+        if table in EXCLUDED_TABLES:
+            assert marker not in content, (
+                f"{table} is excluded but still appears in the generated contract")
+        else:
+            assert marker in content, f"{table} missing from the generated contract"
+
+
+def test_daily_percentiles_is_excluded():
+    """daily_percentiles is declared in datapackage but fetched zero times, so it is
+    excluded from the generator (NOT removed from the datasette — D-18)."""
+    assert "daily_percentiles" in EXCLUDED_TABLES
+    assert "DailyPercentiles" not in generate()


### PR DESCRIPTION
D-18 Half 2 — closes the pipeline-to-frontend seam. A column renamed in
datapackage.yaml and mirrored through Python but not into code/ali-je-vroce-era5/ is now
a compile error on the PR instead of a green build and a broken live page.

Generates per-table row types and the column tuples that build _col= from datapackage,
committed and marked DO-NOT-EDIT, with a freshness gate riding existing pytest CI.
daily_percentiles is excluded from the generator (fetched zero times) — exclusion from
the generator, not removal from the datasette.

Primary gate: all 152 constructed request URLs across 15 shapes are byte-identical,
captured before any edit and re-diffed after. Empty diff, 0 fixture misses, no re-record.
The adversarial review re-derived those URLs independently — reimplementing the column
join in Python from the tuple literals and diffing against main — rather than trusting
the baseline file.

Both guards proven to fire, not merely to pass: a simulated rename of a projected column
and a full-fetch column failed typecheck with 13 errors through two distinct mechanisms.
The freshness gate fails on a hand-edited generated file.

Compile-time only by design — no runtime validation added to dsGet, no fetch or
error-handling change, and no dependence on datasette's untested response to an unknown
_col. dsGet is byte-identical to main.

Known residual, tracked separately: URL filter column names remain bare literals, so a
filter-only column could rename silently.

Gates: typecheck 8 allowlisted (unchanged), yarn test 52, snapshot byte-identical (18
cases, 0 misses), pytest 51 to 54.