### PR TITLE
T-5.8: resolve all 8 allowlisted Highcharts typings (allowlist now zero)

### DIFF
--- a/code/ali-je-vroce-era5/charts/DistributionChart.tsx
+++ b/code/ali-je-vroce-era5/charts/DistributionChart.tsx
@@ -52,7 +52,7 @@ function buildOptions(r: TodayStatus): Highcharts.Options {
       animation:       false,
       style:           { fontFamily: "Space Grotesk, system-ui, sans-serif" },
     },
-    title:   { text: undefined },
+    title:   { text: "" },
     credits: { enabled: false },
     legend:  { enabled: false },
     // T-5.4a — screen-reader summary (Slovenian copy awaiting operator review)
@@ -108,7 +108,7 @@ function buildOptions(r: TodayStatus): Highcharts.Options {
       ],
     },
     yAxis: {
-      title:         { text: null },
+      title:         { text: undefined },
       labels:        { enabled: false },
       gridLineWidth: 0,
       lineWidth:     0,

--- a/code/ali-je-vroce-era5/charts/RegressionChart.tsx
+++ b/code/ali-je-vroce-era5/charts/RegressionChart.tsx
@@ -1,7 +1,7 @@
 import { onMount, onCleanup, createEffect } from "solid-js";
 import type { RegressionResponse } from "../types.ts";
 import { enableChartA11y } from "./highcharts-a11y.ts";
-import { t, fmtNum, fmtSigned } from "../i18n/format.ts";
+import { t, fmtNum } from "../i18n/format.ts";
 
 interface Props {
   data:    RegressionResponse;
@@ -36,7 +36,7 @@ export function RegressionChart(props: Props) {
         enableMouseTracking: false,
         showInLegend: false,
         zIndex: 1,
-      } as Highcharts.SeriesArearangeOptions);
+      } as Highcharts.SeriesOptionsType);
 
       // Trend line
       series.push({
@@ -80,7 +80,7 @@ export function RegressionChart(props: Props) {
         margin: [10, 20, 40, 60],
         animation: false,
       },
-      title:         null,
+      title:         { text: "" },
       credits:       { enabled: false },
       // T-5.4a — screen-reader summary (Slovenian copy awaiting operator review).
       // Was `{ enabled: false }` (only to silence the missing-module warning); the
@@ -95,11 +95,9 @@ export function RegressionChart(props: Props) {
       },
       tooltip: {
         shared: false,
-        formatter(this: Highcharts.TooltipFormatterContextObject) {
-          const pt = this.point as any;
+        formatter(this: Highcharts.Point) {
           const loc = (this.series.name ?? "").replace(/_/g, " ");
-          const base = t("regchart.tooltip", { loc, x: this.x, y: fmtNum(this.y as number, 2), unit: d.unit });
-          return base + (pt.anomaly != null ? t("regchart.tooltip_anomaly", { a: fmtSigned(pt.anomaly, 2) }) : "");
+          return t("regchart.tooltip", { loc, x: this.x, y: fmtNum(this.y as number, 2), unit: d.unit });
         },
       },
       xAxis: { type: "linear", title: { text: null }, gridLineWidth: 0, tickInterval: 10 },

--- a/code/ali-je-vroce-era5/charts/TodayGauge.tsx
+++ b/code/ali-je-vroce-era5/charts/TodayGauge.tsx
@@ -48,7 +48,7 @@ export function TodayGauge(props: Props) {
         margin:          [0, 0, 0, 0],
         animation:       { duration: 900, easing: "easeOutQuint" },
       },
-      title:         null,
+      title:         { text: "" },
       credits:       { enabled: false },
       tooltip:       { enabled: false },
       exporting:     { enabled: false },
@@ -58,7 +58,10 @@ export function TodayGauge(props: Props) {
         endAngle:    90,
         center:      ["50%", "92%"],
         size:        "150%",
-        background:  undefined,
+        // [] renders no pane band, identical to the prior `undefined`: Highcharts'
+        // merge overwrites the gauge's default `{}` background with the empty array,
+        // and Pane.render's splat([]) loop runs zero times (T-5.8).
+        background:  [],
       },
       yAxis: {
         min:              0,

--- a/code/ali-je-vroce-era5/charts/YearRoundChart.tsx
+++ b/code/ali-je-vroce-era5/charts/YearRoundChart.tsx
@@ -66,8 +66,8 @@ export function YearRoundChart(props: Props) {
         backgroundColor: "transparent",
         style:           { fontFamily: "Space Grotesk, system-ui, sans-serif" },
       },
-      title:    { text: undefined },
-      subtitle: { text: undefined },
+      title:    { text: "" },
+      subtitle: { text: "" },
       credits:  { enabled: false },
       legend:   { enabled: false },
       // T-5.4a — screen-reader summary (Slovenian copy awaiting operator review)
@@ -98,7 +98,7 @@ export function YearRoundChart(props: Props) {
         }],
       },
       yAxis: {
-        title:      { text: null },
+        title:      { text: undefined },
         labels: {
           format: "{value}",
           style:  { fontSize: "9px", fontFamily: "'JetBrains Mono', monospace", color: "#6B655B" },

--- a/code/ali-je-vroce-era5/components/TodayLast7Chart.tsx
+++ b/code/ali-je-vroce-era5/components/TodayLast7Chart.tsx
@@ -46,7 +46,7 @@ export function TodayLast7Chart(props: Props) {
         borderWidth:     0,
         animation:       false,
       },
-      title:   { text: null },
+      title:   { text: "" },
       credits: { enabled: false },
       legend:  { enabled: false },
       // T-5.4a — screen-reader summary (Slovenian copy awaiting operator review)
@@ -73,7 +73,7 @@ export function TodayLast7Chart(props: Props) {
         min:           0,
         max:           CAT_LABELS.length - 1,
         tickPositions: [0, 1, 2, 3, 4],
-        title:         { text: null },
+        title:         { text: undefined },
         labels: {
           style:        { color: INK, fontFamily: "'JetBrains Mono', monospace", fontSize: "10px", fontWeight: "600", textOverflow: "none", whiteSpace: "nowrap" },
           align:        "right",

--- a/code/ali-je-vroce-era5/components/TodayTrendChart.tsx
+++ b/code/ali-je-vroce-era5/components/TodayTrendChart.tsx
@@ -58,7 +58,7 @@ function TrendHighchart(props: ChartProps) {
         backgroundColor: "transparent",
         animation:       false,
       },
-      title:   { text: null },
+      title:   { text: "" },
       credits: { enabled: false },
       legend:  { enabled: false },
       // T-5.4a — screen-reader summary (Slovenian copy awaiting operator review)
@@ -95,7 +95,7 @@ function TrendHighchart(props: ChartProps) {
         }],
       },
       yAxis: {
-        title:         { text: null },
+        title:         { text: undefined },
         labels:        { format: "{value}°C", style: { color: INK_SOFT, ...MONO } },
         gridLineColor: "rgba(14,14,12,0.06)",
       },

--- a/code/ali-je-vroce-era5/i18n/sl.ts
+++ b/code/ali-je-vroce-era5/i18n/sl.ts
@@ -191,7 +191,6 @@ export const sl = {
   // RegressionChart (Highcharts)
   regchart: {
     tooltip: "<b>{loc}</b><br/>{x}: <b>{y}</b> {unit}",
-    tooltip_anomaly: "<br/>anomalija: {a}",
     baseline_label: "POVPREČJE {count, plural, one{# leta} two{# let} few{# let} other{# let}}: {baseline}",
     a11y: "Razsevni diagram letnih vrednosti izbrane spremenljivke z regresijsko linijo trenda in 95-odstotnim intervalom zaupanja; črtkana črta označuje povprečje referenčnega obdobja.",
   },

--- a/scripts/typecheck-gate.mjs
+++ b/scripts/typecheck-gate.mjs
@@ -1,13 +1,14 @@
 #!/usr/bin/env node
 // Typecheck gate for CI (ticket T-3.7).
 //
-// `tsc --noEmit` on this repo exits 2 on exactly 8 Highcharts typings errors
-// that are deliberately NOT suppressed (see T-5.8). A bare `yarn typecheck` in
-// CI would therefore always "fail", and a `|| true` would let a real 9th error
-// slip through as an old one gets fixed. This gate instead asserts the live
-// error set is EXACTLY the allowlist in tests/typecheck-allowlist.txt, keyed by
-// file, line, column and error code. Any drift — a new error, a different one,
-// OR one of the 8 disappearing — fails, loudly, and says what to do.
+// `tsc --noEmit` on this repo exits 0 as of T-5.8, which resolved the last of
+// the tolerated Highcharts typings errors — tests/typecheck-allowlist.txt is now
+// empty. This gate asserts the live error set is EXACTLY that allowlist, keyed by
+// file, line, column and error code; with the list empty it asserts ZERO errors.
+// Any drift — a new error, or a future re-added allowlist entry disappearing —
+// fails, loudly, and says what to do. (History: the allowlist once carried 8
+// deliberately-unsuppressed Highcharts 12.6.0 mismatches; a bare `|| true` would
+// have let a real regression slip through as one got fixed, hence this gate.)
 //
 // Exit 0: live set == allowlist. Exit 1: any difference (or tsc crashed).
 

--- a/tests/typecheck-allowlist.txt
+++ b/tests/typecheck-allowlist.txt
@@ -1,27 +1,22 @@
 # Typecheck allowlist — the ONLY TypeScript errors CI tolerates.
 #
-# `yarn typecheck` (tsc --noEmit, strict, noUncheckedIndexedAccess,
-# exactOptionalPropertyTypes) exits 2 on exactly these 8 errors. They are
-# Highcharts 12.6.0 typings-vs-runtime mismatches, deliberately NOT suppressed
-# (no `any`, no `@ts-ignore`) — see ticket T-5.8, which fixes them properly.
+# EMPTY as of T-5.8. `yarn typecheck` (tsc --noEmit, strict,
+# noUncheckedIndexedAccess, exactOptionalPropertyTypes) now exits 0: the eight
+# Highcharts 12.6.0 typings errors this file used to carry were resolved at their
+# root (null/undefined title suppression rewritten as `text: ""`, the yAxis title
+# null → undefined, the gauge pane `background: undefined` → `[]`, the arearange
+# cast retargeted to the exported `SeriesOptionsType`, and the tooltip formatter
+# retyped `this: Highcharts.Point` with its dead anomaly branch removed). No
+# `any`, no `@ts-ignore`, no config relaxed.
 #
 # The CI gate (`yarn typecheck:gate`, scripts/typecheck-gate.mjs) asserts the
 # live error set is EXACTLY this list — keyed by file, line, column and error
-# code. Any difference fails the build:
-#   * a 9th error, or a different error, is a regression — fix your code;
-#   * fixing/moving one of the 8 (e.g. a Highcharts bump, or T-5.8) also fails,
-#     ON PURPOSE — update this file in the same commit so the gate tracks reality.
+# code. With the list empty it asserts ZERO tolerated errors: any TypeScript
+# error at all now fails the build. If a future Highcharts bump reintroduces a
+# genuinely un-fixable typings-vs-runtime mismatch, add it here in the same
+# commit (with the reasoning in the commit message), keyed `path(line,col): TSxxxx`.
 #
 # Format: one entry per line, `path(line,col): TSxxxx`. Blank lines and lines
 # starting with `#` are ignored. Regenerate the canonical list with:
 #   yarn typecheck 2>&1 | grep -E '^\S.*\([0-9]+,[0-9]+\): error TS' \
 #     | sed -E 's/: error (TS[0-9]+).*/: \1/'
-
-code/ali-je-vroce-era5/charts/DistributionChart.tsx(46,10): TS2352
-code/ali-je-vroce-era5/charts/RegressionChart.tsx(39,23): TS2724
-code/ali-je-vroce-era5/charts/RegressionChart.tsx(77,33): TS2352
-code/ali-je-vroce-era5/charts/RegressionChart.tsx(98,36): TS2694
-code/ali-je-vroce-era5/charts/TodayGauge.tsx(44,41): TS2352
-code/ali-je-vroce-era5/charts/YearRoundChart.tsx(58,41): TS2352
-code/ali-je-vroce-era5/components/TodayLast7Chart.tsx(40,41): TS2352
-code/ali-je-vroce-era5/components/TodayTrendChart.tsx(53,41): TS2352


### PR DESCRIPTION
Resolves every allowlisted TypeScript error at its root. tests/typecheck-allowlist.txt
is now comments-only, so typecheck:gate asserts zero tolerated errors and any new one
fails CI. yarn typecheck exits 0.

Step 1 found the suspected latent bug, though not by the predicted mechanism. The
tooltip formatter was fine — runtime this IS the Point and this.point self-references.
The deadness was upstream: buildSeries maps scatter data to {x,y,color,marker} and drops
the anomaly field, so pt.anomaly was always undefined and the anomaly line had never
rendered since the initial integration. Removed rather than restored — restoring would
add a number to a public page as a side effect of a typings cleanup. The label and a
now-unused import go with it.

Remaining seven: one genuine typings gap (SeriesArearangeOptions is a non-exported
augmentation interface; cast retargeted to the exported SeriesOptionsType) and six
null-title suppressions converted to empty-string/undefined/empty-array forms.
Runtime-identical per Highcharts source: pick(textStr,'') collapses null, undefined and
'' alike, and Pane.render draws no band for [] just as for undefined.

The config was not weakened: no any, no blanket ts-ignore, no tsconfig relaxation. The
as Highcharts.Options casts were kept and are load-bearing — removing DistributionChart's
surfaces five pre-existing TS2375 errors on plotOptions.zones.

NOTE FOR REVIEW: the snapshot harness stubs Highcharts, so snapshot:check cannot see
chart-option changes. Byte-identical does not verify the six suppression fixes; they need
a visual check on the preview.

Gates: typecheck exit 0, typecheck:gate 0 allowlisted, yarn test 52, snapshot
byte-identical (18 cases, 0 misses), pytest 54.