### PR TITLE
fix(ali-je-vroce): match legacy percentiles on month-day, not full date

### DIFF
--- a/code/ali-je-vroce/helpers.ts
+++ b/code/ali-je-vroce/helpers.ts
@@ -126,8 +126,18 @@ export async function requestData(
       const dataAverage = (await resultAverage.json()) as RequestStationData;
       const averageTemperature = dataAverage.statistics.temperature_average_24h;
 
-      let timeUpdated = new Date(Number(dataAverage.statistics.timestamp));
+      const rawTimestamp = Number(dataAverage.statistics.timestamp);
+      // A null/absent/unparseable Vremenar timestamp coerces to 0 or NaN; under
+      // month-day matching that would silently return January percentiles all
+      // year, so reject it with a message distinct from "Percentiles not found".
+      if (!Number.isFinite(rawTimestamp) || rawTimestamp <= 0) {
+        throw new Error("Invalid observation timestamp from Vremenar");
+      }
+      let timeUpdated = new Date(rawTimestamp);
       const date = formatDateForQuery(timeUpdated);
+      // Match on month-day, not the full date: average_percentiles is a 365-slot
+      // climatology with an arbitrary year label (no 02-29 row → fall back to 02-28).
+      const monthDay = date.slice(5) === "02-29" ? "02-28" : date.slice(5);
 
       let timeMinDate = new Date(
         Number(dataAverage.statistics.timestamp_temperature_min_24h)
@@ -137,7 +147,7 @@ export async function requestData(
       );
 
       const resultPercentile = await fetch(
-        `${STAGE_DATA_BASE_URL}/temperature/temperature~2Eslovenia_historical~2Edaily~2Eaverage_percentiles.json?date__exact=${date}&station_id__exact=${stationID}&_col=p05&_col=p20&_col=p40&_col=p60&_col=p80&_col=p95`,
+        `${STAGE_DATA_BASE_URL}/temperature/temperature~2Eslovenia_historical~2Edaily~2Eaverage_percentiles.json?date__endswith=-${monthDay}&station_id__exact=${stationID}&_col=p05&_col=p20&_col=p40&_col=p60&_col=p80&_col=p95`,
          options.signal ? { signal: options?.signal } : undefined
       );
         const dataPercentile = await resultPercentile.json();


### PR DESCRIPTION
## Root cause

The legacy `/ali-je-vroce/` page looks up daily temperature percentiles with a **full-ISO exact-date** filter:

```
average_percentiles.json?date__exact=<today YYYY-MM-DD>&station_id__exact=<id>
```

But `temperature.slovenia_historical.daily.average_percentiles` is a **climatology**: percentile distributions computed over 1950–2025 for each day-of-year, stored as exactly one row per station per day-of-year (15 stations × 365 = 5,475 rows). The `date` column is a **label**, not data — the snapshot currently labels its 365 slots `2025-07-01 … 2026-06-30`.

The moment the calendar crosses that labelled year, `date__exact=<today>` matches **zero rows** for every station, and each one throws `"Percentiles not found"`. That is the live state today (2026-07-29): every date after `2026-06-30` misses.

## The fix

Match on **month-day** via the table JSON API's `date__endswith=-MM-DD` (no `execute-sql` permission needed, smallest diff from the existing `__exact` filter). This queries the climatology by day-of-year — what it actually is — so the lookup **never expires** and needs no data refresh.

Verified against `stage-data.podnebnik.org` (station 1495), exact patched URLs:
- `date__endswith=-07-29` → 1 row (today)
- `date__endswith=-01-15` → 1 row (winter)
- `date__endswith=-02-29` → **0 rows** (no slot) → code sends `-02-28` → 1 row

## Why month-day is permanent, not a stopgap

The percentiles are a day-of-year climatology; the year on `date` is arbitrary. Binding the lookup to that label was the bug — it couples a year-independent quantity to a specific year and breaks annually. Month-day matching removes that coupling entirely; it keeps working regardless of the calendar year and regardless of whether/when the climatology is regenerated.

(Distinct from the sibling **observations** table `slovenia_historical.daily`, which genuinely ends `2025-06-30` and would need a real data refresh — out of scope here.)

## The 4 known causes of "Percentiles not found"

`if (!values) throw new Error("Percentiles not found")` fires on **any** zero-row response. Causes:

1. **Stale climatology year-label** — full-ISO `date__exact` vs a snapshot labelled `2025-07-01..2026-06-30`; every date past the window misses. **← fixed here (permanent).**
2. **Bad Vremenar timestamp** — `statistics.timestamp` null → `Number(null)=0` → `1970-01-01`; absent/unparseable → `NaN` → `"NaN-NaN-NaN"`; either builds a date that matches nothing. **← now guarded (see below).**
3. **Datasette silent-empty on an unknown/renamed filter column** — returns HTTP 200 + empty array (not a 400), indistinguishable from a real miss.
4. **No row for that station_id + slot** — station absent from the table, or a genuinely missing day-of-year slot (e.g. 02-29).

## Timestamp guard (STEP 3)

Under month-day matching, the null→`1970-01-01` case (#2) becomes **more** dangerous: `1970-01-01` → month-day `01-01`, which **matches** and would silently return January percentiles all year round. So a null/absent/unparseable timestamp now throws `"Invalid observation timestamp from Vremenar"` — a message **distinct** from `"Percentiles not found"`, so the two failure modes are separable in logs.

## Feb-29 note

The 365-slot climatology has **no `02-29` row** (`date__endswith=-02-29` → 0 rows, verified). The fix maps 29 Feb → 28 Feb **explicitly and visibly**. `buildWindow()` (helpers.ts:268-286) was deliberately **not** reused: its non-leap 2001 baseline silently shifts `02-29` to `03-01` and never emits `'02-29'`, and it produces a multi-day window rather than the single-day equality this lookup needs.

`formatDateForQuery` and the historical/`buildWindow` path are untouched. One file changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)