### PR TITLE
T-5.14: explicit empty states for five silently-blank sections

### DIFF
--- a/code/ali-je-vroce-era5/AliJeVroceERA5.tsx
+++ b/code/ali-je-vroce-era5/AliJeVroceERA5.tsx
@@ -2,6 +2,7 @@ import { createSignal, createResource, createMemo, Show, Suspense, ErrorBoundary
 import { fetchMeta, fetchPageData, fetchSpeiHeatmap, fetchSpeiStationSeasonal, dateToDoy, ERA5_NATIONAL, BASELINE_LABEL } from "./api.ts";
 import { today as todayIso } from "./clock.ts";
 import { sectionErrorFallback } from "./components/SectionError.tsx";
+import { EmptyState } from "./components/EmptyState.tsx";
 import { TodayCard } from "./components/TodayCard.tsx";
 import { DistributionChart } from "./charts/DistributionChart.tsx";
 import { TodayTrendChart } from "./components/TodayTrendChart.tsx";
@@ -271,7 +272,7 @@ function Era5Charts() {
         </div>
         <ErrorBoundary fallback={sectionErrorFallback(refetchSpei, "160px")}>
           <Suspense fallback={<div class="h-40 animate-pulse bg-[var(--color-paper-2)] rounded-xl" />}>
-            <Show when={speiData()?.available}>
+            <Show when={speiData()?.available} fallback={<EmptyState minHeight="160px" />}>
               <SpeiHeatmapChart data={speiData()!} />
             </Show>
           </Suspense>
@@ -288,7 +289,7 @@ function Era5Charts() {
         </div>
         <ErrorBoundary fallback={sectionErrorFallback(refetchSpeiStation, "400px")}>
           <Suspense fallback={<div class="animate-pulse rounded-xl bg-[var(--color-paper-2)]" style={{ height: "400px" }} />}>
-            <Show when={speiStationData()?.available}>
+            <Show when={speiStationData()?.available} fallback={<EmptyState minHeight="400px" />}>
               <SpeiTrendChartLazy data={speiStationData()!} />
             </Show>
           </Suspense>

--- a/code/ali-je-vroce-era5/charts/Era5SeasonHeatmap.tsx
+++ b/code/ali-je-vroce-era5/charts/Era5SeasonHeatmap.tsx
@@ -1,6 +1,7 @@
 import { createResource, Show, Suspense, ErrorBoundary } from "solid-js";
 import { fetchSeasonHeatmap, isArsoLoc } from "../api.ts";
 import { sectionErrorFallback } from "../components/SectionError.tsx";
+import { EmptyState } from "../components/EmptyState.tsx";
 import { SeasonHeatmap } from "./SeasonHeatmap.tsx";
 
 interface Props {
@@ -29,6 +30,11 @@ export function Era5SeasonHeatmap(props: Props) {
         </Show>
         <Show when={data.loading && !display()}>
           <div class="h-40 animate-pulse bg-[var(--color-paper-2)] rounded-xl" />
+        </Show>
+        {/* T-5.14 — resolved to no rows: message, not a heading over blank space.
+            The !loading guard keeps it from flashing during a station refetch. */}
+        <Show when={!data.loading && (display()?.length ?? 0) === 0}>
+          <EmptyState minHeight="160px" />
         </Show>
       </Suspense>
     </ErrorBoundary>

--- a/code/ali-je-vroce-era5/charts/Era5TropicalChart.tsx
+++ b/code/ali-je-vroce-era5/charts/Era5TropicalChart.tsx
@@ -1,6 +1,7 @@
 import { createResource, createMemo, Show, ErrorBoundary } from "solid-js";
 import { fetchEra5Tropical, isArsoLoc, ERA5_NATIONAL } from "../api.ts";
 import { sectionErrorFallback } from "../components/SectionError.tsx";
+import { EmptyState } from "../components/EmptyState.tsx";
 import { TropHighchart } from "./TropicalChart.tsx";
 import type { Config } from "./TropicalChart.tsx";
 import { t, fmtNum, fmtInt, fmtSigned } from "../i18n/format.ts";
@@ -131,6 +132,12 @@ export function Era5TropicalChart(props: Props) {
           </Show>
           <Show when={data.loading && !display()}>
             <div style={{ height: "300px" }} class="animate-pulse bg-[var(--color-paper-2)] rounded" />
+          </Show>
+          {/* T-5.14 — resolved to no row (fetchEra5Tropical → null): message in the
+              card body, not the card chrome + title over an empty chart. The
+              !loading guard keeps it from flashing during a station refetch. */}
+          <Show when={!data.loading && !display()}>
+            <EmptyState minHeight="300px" />
           </Show>
         </div>
 

--- a/code/ali-je-vroce-era5/charts/YearRoundChart.tsx
+++ b/code/ali-je-vroce-era5/charts/YearRoundChart.tsx
@@ -1,5 +1,6 @@
 import { onMount, onCleanup, createEffect } from "solid-js";
 import type { CalendarData } from "../api.ts";
+import { EmptyState } from "../components/EmptyState.tsx";
 import { enableChartA11y } from "./highcharts-a11y.ts";
 import { t, fmtNum, fmtSigned, fmtDoy, fmtMonthShort } from "../i18n/format.ts";
 
@@ -50,6 +51,12 @@ export function YearRoundChart(props: Props) {
   }
 
   onMount(async () => {
+    // T-5.14 — with no rows the chart would draw an empty titled/legended frame
+    // ("a calendar of nothing"); skip the build and render the message instead
+    // (see the return below). RegYearRoundCard's <Show> is `keyed` on the
+    // resource object, so this component is re-created per station — reading
+    // props.data.rows.length once here is safe.
+    if (props.data.rows.length === 0) return;
     const Highcharts = (await import("highcharts")).default;
     await enableChartA11y(Highcharts);
 
@@ -161,5 +168,7 @@ export function YearRoundChart(props: Props) {
 
   onCleanup(() => { chart?.destroy(); chart = null; });
 
-  return <div ref={container} style={{ "min-height": "180px" }} />;
+  return props.data.rows.length === 0
+    ? <EmptyState minHeight="180px" />
+    : <div ref={container} style={{ "min-height": "180px" }} />;
 }

--- a/code/ali-je-vroce-era5/components/EmptyState.tsx
+++ b/code/ali-je-vroce-era5/components/EmptyState.tsx
@@ -1,0 +1,41 @@
+import type { JSXElement } from "solid-js";
+import { t } from "../i18n/format.ts";
+
+// T-5.14 — the ONE visible empty state for a section whose fetch resolved to no
+// rows. Distinct from SectionError: datasette returns 200 + [] for a genuinely
+// empty (or, for SPEI, a D-16-withheld) result, so `dsGet`'s !resp.ok guard
+// never fires and this is NOT an error — the reader sees a section heading with
+// nothing beneath it and no signal whether the page is broken or the data is
+// simply absent. This renders the shared `common.no_data` message where the body
+// would be, matching the lighter reg.no_data treatment (a centred, muted line —
+// no box; the boxed treatment is reserved for the error state).
+//
+// role="status" (polite) so a screen reader announces it when it appears after a
+// station change; the boxed error uses role="alert" (assertive) for the same
+// reason at a higher urgency.
+//
+// `style()` keys are kebab-case on purpose: Solid's style() calls setProperty(),
+// so a camelCase key is silently dropped (see CLAUDE.md "Solid's style()
+// silently ignores camelCase properties").
+export function EmptyState(props: { minHeight?: string | undefined }): JSXElement {
+  return (
+    <div
+      role="status"
+      style={{
+        flex:              "1",
+        display:           "flex",
+        "align-items":     "center",
+        "justify-content": "center",
+        "min-height":      props.minHeight ?? "160px",
+        padding:           "20px",
+        "text-align":      "center",
+        color:             "var(--color-ink-soft)",
+        "font-family":     "var(--font-sans)",
+        "font-size":       "13px",
+        "line-height":     "1.5",
+      }}
+    >
+      {t("common.no_data")}
+    </div>
+  );
+}

--- a/code/ali-je-vroce-era5/components/HeroCards.tsx
+++ b/code/ali-je-vroce-era5/components/HeroCards.tsx
@@ -1,6 +1,7 @@
 import { createResource, Show, ErrorBoundary } from "solid-js";
 import { fetchRegression } from "../api.ts";
 import { sectionErrorFallback } from "./SectionError.tsx";
+import { EmptyState } from "./EmptyState.tsx";
 import type { RegressionResult } from "../types.ts";
 import { t, fmtNum, fmtSigned } from "../i18n/format.ts";
 // T-5.5 — per-location content is centralised in the catalogue; read the raw
@@ -79,7 +80,7 @@ export function HeroCards(props: Props) {
 
   return (
     <ErrorBoundary fallback={sectionErrorFallback(refetch, "180px")}>
-      <Show when={resp()?.results?.length}>
+      <Show when={resp()?.results?.length} fallback={<EmptyState minHeight="180px" />}>
         <HeroCard res={resp()!.results[0]!} unit={resp()!.unit} dateLabel={resp()!.date_label} />
       </Show>
     </ErrorBoundary>

--- a/code/ali-je-vroce-era5/components/RegressionPanel.tsx
+++ b/code/ali-je-vroce-era5/components/RegressionPanel.tsx
@@ -244,7 +244,7 @@ export function RegScatterCard() {
             <Show when={s.regData()} keyed>
               {(d) => (
                 <Show when={d.results.length > 0} fallback={
-                  <div style={{ flex: "1", display: "flex", "align-items": "center", "justify-content": "center", color: "var(--color-ink-soft)", "font-size": "13px", "min-height": "280px" }}>
+                  <div role="status" style={{ flex: "1", display: "flex", "align-items": "center", "justify-content": "center", color: "var(--color-ink-soft)", "font-size": "13px", "min-height": "280px" }}>
                     {t("reg.no_data")}
                   </div>
                 }>

--- a/code/ali-je-vroce-era5/components/TodayCard.tsx
+++ b/code/ali-je-vroce-era5/components/TodayCard.tsx
@@ -302,7 +302,7 @@ function RankBadge(props: { info: RankInfo; dayLabel: string }) {
 function UnavailableCard() {
   return (
     <div class="today-card">
-      <p class="today-explain">{t("today.unavailable")}</p>
+      <p role="status" class="today-explain">{t("today.unavailable")}</p>
     </div>
   );
 }

--- a/code/ali-je-vroce-era5/i18n/sl.ts
+++ b/code/ali-je-vroce-era5/i18n/sl.ts
@@ -33,6 +33,11 @@ export const sl = {
     today: "danes",
     ci95: "95% CI",
     temp_c: "{temp} °C",
+    // T-5.14 — shared empty-state message for sections whose heading renders
+    // over a body that resolved to no rows (200 + []); covers the SPEI D-16
+    // withhold sentinel too. Neutral "this view" wording so it fits both the
+    // per-location sections and the national SPEI ones.
+    no_data: "Za ta prikaz ni podatkov.",
   },
 
   loading: "Nalaganje…",

--- a/tests/fixtures/snapshot.json
+++ b/tests/fixtures/snapshot.json
@@ -61,6 +61,7 @@
     ],
     "structural": [
       "Dashboard",
+      "EmptyState",
       "Era5Charts",
       "ErrorBoundary",
       "RegressionPanel",

--- a/tests/snapshot/sections.json
+++ b/tests/snapshot/sections.json
@@ -105,6 +105,7 @@
     "Show": "solid-js control flow.",
     "Suspense": "solid-js control flow.",
     "ErrorBoundary": "solid-js control flow (T-5.1). Wraps each section's fetch consumer so a failed fetch shows a visible SectionError instead of vanishing or blanking the page. Renders its children unchanged on success (no DOM wrapper), so it is transparent to the happy-path snapshot; the error branch is never exercised by the fixtures.",
+    "EmptyState": "The shared no-data message (EmptyState.tsx, T-5.14), used as the <Show> fallback for the two SPEI sections. Renders the static common.no_data string only when a fetch resolved to no rows; every snapshot case has data, so this branch is never exercised by the fixtures and it captures no numbers of its own.",
     "SiteMeta": "NOT a component. A type argument in createResource<SiteMeta> (AliJeVroceERA5.tsx:35) that the tag regex cannot distinguish from JSX. Classified explicitly rather than special-cased in the extractor, so the extractor stays dumb and auditable."
   },
 


### PR DESCRIPTION
Five sections rendered a heading over blank space when their fetch resolved to 200 with an
empty result. dsGet throws on non-200, so T-5.1's error paths hold — but T-5.13 established
that datasette answers a bad query with 200 and an empty body, so resp.ok never fires, and
each fetch turned that into a "no data" sentinel behind a truthiness Show with no fallback.
To a reader that is indistinguishable from a broken page.

Adds components/EmptyState.tsx, mirroring SectionError.tsx, with role="status" so the message
is announced on a station change. Wired into HeroCards, both SPEI sections, the season
heatmap and the tropical chart; season and tropical carry a !loading guard so the message
cannot flash during a refetch. The two pre-existing messages gain role="status" too, so all
seven are announced rather than five of seven.

One shared string, common.no_data = "Za ta prikaz ni podatkov." Hero, season and tropical are
per-location while both SPEI sections are national, so a location-worded shared string would
have been wrong for two of five. Splitting one string later is cheap; merging five is not.
Wording is provisional pending the content owners.

Note: SPEI's available:false is also the D-16 withhold sentinel, so a blank SPEI panel means
either "no rows" or "computed then rejected as unsound". Both honest, indistinguishable to a
reader, and worth knowing when debugging one.

The year-round calendar is fixed inside YearRoundChart rather than at its gate. Gating on
rows.length while keeping the keyed Show would have made the key a row count — near-always
365 or 366 — so switching station would not re-create the children and the chart would
silently keep showing the previous station's data.

All six empty states were forced through their path in a temporary jsdom test and confirmed
to render with role=status present.

Snapshot: 1 insertion, 0 deletions — "EmptyState" added to sections.structural. All 21 data
cases byte-identical. Adding a component to the mirrored file updates the harness in the same
commit.

Gates: typecheck 0, typecheck:gate 0 allowlisted, yarn test 52 including the text-integrity
guard over the new Slovenian, pytest 57, snapshot:check 21 cases identical. Untouched: dsGet,
fetch behaviour, error handling, Python, every published value.
