### PR TITLE
T-5.16: translate the Highcharts screen-reader strings to Slovenian

### DIFF
--- a/code/ali-je-vroce-era5/charts/highcharts-a11y.ts
+++ b/code/ali-je-vroce-era5/charts/highcharts-a11y.ts
@@ -39,16 +39,56 @@ export function enableChartA11y(HC: any): Promise<void> {
         // view-data-table proxy present in the SR region. Purely additive; no
         // rendered pixel changes (T-5.4a).
         exporting: { enabled: false },
-        // T-5.5 — the export-data "view as data table" affordance strings, sourced
-        // from the catalogue (hc.*). Extracted AS-IS: the values are still the
-        // English Highcharts defaults, centralised here and FLAGGED for a Slovenian
-        // translation pass (D-8). Setting them to their own defaults is a no-op on
-        // the rendered output today.
+        // T-5.16 — Slovenian screen-reader strings (D-8). Two groups:
+        //
+        //  • Top-level `lang.*` (viewData/…): the export CONTEXT-MENU labels. With
+        //    `exporting.enabled:false` above, the menu is never drawn, so these do
+        //    not surface today — translated and kept only in case the menu is ever
+        //    enabled. See the note in i18n/sl.ts.
+        //  • `lang.accessibility.*`: the strings the a11y info region ACTUALLY
+        //    announces (built regardless of the export menu, InfoRegionsComponent).
+        //    Highcharts deep-merges this partial tree over its defaults, so anything
+        //    omitted below keeps the English default on purpose (see next comment).
         lang: {
           viewData:    t("hc.viewData"),
           hideData:    t("hc.hideData"),
           downloadCSV: t("hc.downloadCSV"),
           downloadXLS: t("hc.downloadXLS"),
+          accessibility: {
+            defaultChartTitle:   t("hc.a11y.defaultChartTitle"),
+            chartContainerLabel: t("hc.a11y.chartContainerLabel"),
+            svgContainerLabel:   t("hc.a11y.svgContainerLabel"),
+            table: {
+              viewAsDataTableButtonText: t("hc.a11y.viewAsDataTableButtonText"),
+              tableSummary:              t("hc.a11y.tableSummary"),
+            },
+            screenReaderSection: {
+              endOfChartMarker: t("hc.a11y.endOfChartMarker"),
+            },
+            series: {
+              nullPointValue: t("hc.a11y.nullPointValue"),
+            },
+            axis: {
+              defaultAxisNames: {
+                categories: t("hc.a11y.axisCategories"),
+                time:       t("hc.a11y.axisTime"),
+                values:     t("hc.a11y.axisValues"),
+              },
+            },
+            // DELIBERATELY LEFT TO THE ENGLISH DEFAULTS (T-5.16, scope = Tier 1 only):
+            // the chart-type descriptions (lang.accessibility.chartTypes.*), axis-range
+            // descriptions (axis.xAxisDescription*, rangeFromTo, timeRange*, …) and
+            // series summaries (series.summary.*). These are count-templated with
+            // Highcharts' own binary singular/plural (`{#eq n 1}point{else}points{/eq}`),
+            // evaluated inside Highcharts at render — NOT through our t()/Intl.PluralRules.
+            // Slovenian has FOUR grammatical numbers (1 / 2 / 3–4 / 5+); a binary form is
+            // grammatically wrong for most counts, on a surface where the listener cannot
+            // see the number to reconstruct the meaning. A correct translation is not
+            // expressible through this mechanism, so English (grammatical, familiar) is
+            // the lesser harm. This is a DECISION, not an oversight — do not "finish the
+            // job" and ship the ungrammatical binary-plural version. If Highcharts ever
+            // gains a proper plural-rule mechanism, this is where to revisit it.
+          },
         },
       });
     })();

--- a/code/ali-je-vroce-era5/i18n/sl.ts
+++ b/code/ali-je-vroce-era5/i18n/sl.ts
@@ -23,7 +23,7 @@ import { climateRisks, heroContext } from "./hero-content.ts";
 //    nominative-count forms, correct for the only value that occurs (18 → "postaj")
 //    and a reasonable default otherwise. A native pass should confirm N=1,2.
 //  • Phrase-level English that was translated mechanically but may want polish:
-//    reg.no_data, reg.year_round_footer, hc.* (Highcharts lang, kept English AS-IS).
+//    reg.no_data, reg.year_round_footer.
 
 export const sl = {
   common: {
@@ -428,16 +428,41 @@ export const sl = {
     site_title: "Podnebnik · Ali je vroče?",
   },
 
-  // ── Highcharts `lang` — extracted AS-IS (English library defaults). D-8 is
-  // Slovenian-only, so these want translation, but the operator instruction for
-  // T-5.5 was to CENTRALISE them here without re-wording. FLAGGED for a Highcharts
-  // a11y-lang translation pass. Only the export-data "view as data table" affordance
-  // (exporting hidden, T-5.4a) surfaces these to a screen-reader today.
+  // ── Highcharts `lang` strings, translated to Slovenian (T-5.16, D-8).
+  //
+  // Group B (viewData/hideData/downloadCSV/downloadXLS) are the EXPORT CONTEXT-MENU
+  // item labels (Highcharts top-level `lang.*`). They are UNREACHABLE on this page:
+  // the a11y bootstrap ships `exporting: { enabled: false }` (T-5.4a), so the context
+  // menu is never rendered and these strings never surface to a screen reader. They
+  // are translated and retained so they are correct IF the export menu is ever
+  // enabled — not because they are heard today. (Earlier this block was left English
+  // with a comment claiming it was the surfaced affordance; that was wrong and sent
+  // T-5.16's inventory to the wrong key — see `hc.a11y.viewAsDataTableButtonText`.)
+  //
+  // `hc.a11y.*` (Group A) are the `lang.accessibility.*` strings a screen reader
+  // ACTUALLY reaches: the info region a11y module reads them regardless of the
+  // export menu. `{title}` / `{chartTitle}` are HIGHCHARTS format-string variables,
+  // passed through verbatim (`t()` leaves unknown `{name}` untouched, format.ts:129).
+  // Scope is Tier 1 only (static, first-heard strings); the templated chart-type /
+  // axis / series-summary strings are DELIBERATELY left to English defaults — see the
+  // omission comment in charts/highcharts-a11y.ts for why.
   hc: {
-    viewData: "View data table",
-    hideData: "Hide data table",
-    downloadCSV: "Download CSV",
-    downloadXLS: "Download XLS",
+    viewData: "Prikaži podatkovno tabelo",
+    hideData: "Skrij podatkovno tabelo",
+    downloadCSV: "Prenesi CSV",
+    downloadXLS: "Prenesi XLS",
+    a11y: {
+      defaultChartTitle:         "Graf",
+      chartContainerLabel:       "{title}. Interaktivni prikaz podatkov.",
+      svgContainerLabel:         "Interaktivni graf",
+      viewAsDataTableButtonText: "Prikaži kot podatkovno tabelo, {chartTitle}",
+      tableSummary:              "Tabelarni prikaz grafa.",
+      endOfChartMarker:          "Konec interaktivnega grafa.",
+      nullPointValue:            "Ni vrednosti",
+      axisCategories:            "kategorije",
+      axisTime:                  "čas",
+      axisValues:                "vrednosti",
+    },
   },
 } as const;
 

--- a/tests/unit/highcharts-a11y.test.ts
+++ b/tests/unit/highcharts-a11y.test.ts
@@ -1,0 +1,60 @@
+// T-5.16 — proof that the Slovenian screen-reader strings actually reach Highcharts.
+//
+// `enableChartA11y` builds a `lang` object from the catalogue and hands it to
+// `HC.setOptions`. This test captures that exact object (the same one real
+// Highcharts would deep-merge over its English defaults) and asserts the
+// Slovenian values are present, at the correct nested `lang.accessibility.*`
+// paths, and sourced through `t()`. A translation that is wired but not verified
+// is not known to work (T-5.16 Step 4).
+//
+// The three side-effect module imports inside enableChartA11y are mocked: they
+// are browser-oriented and irrelevant here — we only care about the lang object.
+
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("highcharts/modules/exporting", () => ({ default: {} }));
+vi.mock("highcharts/modules/export-data", () => ({ default: {} }));
+vi.mock("highcharts/modules/accessibility", () => ({ default: {} }));
+
+import { enableChartA11y } from "../../code/ali-je-vroce-era5/charts/highcharts-a11y.ts";
+import { t } from "../../code/ali-je-vroce-era5/i18n/format.ts";
+
+describe("T-5.16 — Highcharts a11y lang strings", () => {
+  it("merges the Slovenian accessibility strings into HC.setOptions at the right paths", async () => {
+    let captured: any;
+    const fakeHC = { setOptions: (o: any) => { captured = o; } };
+
+    await enableChartA11y(fakeHC);
+
+    const lang = captured.lang;
+    const a11y = lang.accessibility;
+
+    // Group A — the strings a screen reader actually reaches (lang.accessibility.*).
+    expect(a11y.defaultChartTitle).toBe("Graf");
+    expect(a11y.chartContainerLabel).toBe("{title}. Interaktivni prikaz podatkov.");
+    expect(a11y.svgContainerLabel).toBe("Interaktivni graf");
+    expect(a11y.table.viewAsDataTableButtonText).toBe("Prikaži kot podatkovno tabelo, {chartTitle}");
+    expect(a11y.table.tableSummary).toBe("Tabelarni prikaz grafa.");
+    expect(a11y.screenReaderSection.endOfChartMarker).toBe("Konec interaktivnega grafa.");
+    expect(a11y.series.nullPointValue).toBe("Ni vrednosti");
+    expect(a11y.axis.defaultAxisNames.categories).toBe("kategorije");
+    expect(a11y.axis.defaultAxisNames.time).toBe("čas");
+    expect(a11y.axis.defaultAxisNames.values).toBe("vrednosti");
+
+    // Group B — the (currently unreachable) export-menu strings, still translated.
+    expect(lang.viewData).toBe("Prikaži podatkovno tabelo");
+    expect(lang.hideData).toBe("Skrij podatkovno tabelo");
+    expect(lang.downloadCSV).toBe("Prenesi CSV");
+    expect(lang.downloadXLS).toBe("Prenesi XLS");
+
+    // The values genuinely flow through the catalogue via t(), not hardcoded here.
+    expect(a11y.table.viewAsDataTableButtonText).toBe(t("hc.a11y.viewAsDataTableButtonText"));
+    expect(a11y.chartContainerLabel).toBe(t("hc.a11y.chartContainerLabel"));
+    expect(lang.viewData).toBe(t("hc.viewData"));
+
+    // And none of the translated surface is still English.
+    expect(a11y.chartContainerLabel).not.toMatch(/interactive chart/i);
+    expect(a11y.table.viewAsDataTableButtonText).not.toMatch(/view as data table/i);
+    expect(lang.downloadCSV).not.toMatch(/download/i);
+  });
+});


### PR DESCRIPTION
The Highcharts screen-reader strings now announce in Slovenian. 14 strings, Tier 1 only.

The finding that reshaped the ticket: the four strings T-5.5 centralised
(hc.viewData/hideData/downloadCSV/downloadXLS) were dead from introduction. They are export
context-menu labels, and T-5.4a shipped exporting:{enabled:false} in the same commit, so the
menu is never rendered and they never reach a screen reader. What the device pass actually
heard was the untranslated lang.accessibility.* tree, chiefly viewAsDataTableButtonText. A
code comment asserting those four were the surfaced affordance is what pointed the earlier
inventory at a key the page never reaches; both comments now state the truth.

Chart-type, axis-range and series-summary descriptions are deliberately left in English,
with an omission comment explaining why: Slovenian has four grammatical numbers and
Highcharts offers a binary singular-plural at best, so a literal translation is
ungrammatical for most counts on a surface where the listener cannot see the number. An
agreement-safe rewording is grammatical but not natural speech. The comment exists so the
job is not later "finished" into the ungrammatical version.

Caught before shipping: with all nine chart titles falsy after T-5.8, getChartTitle returns
defaultChartTitle in every announcement, so a brand-dropped container label would have read
"Graf. Interaktivni graf." on every chart. Reworded to "{title}. Interaktivni prikaz
podatkov." rather than dropping the interpolation, which would have discarded any real title
a chart later gains and collided with svgContainerLabel.

The four export strings are translated and retained so the menu is correct if ever enabled.

tests/unit/highcharts-a11y.test.ts captures the exact object handed to HC.setOptions and
asserts every value at its correct nested path, that it flows through t(), and that no
English remains.

Accepted outcome: the page now announces mixed Slovenian and English by design.

Gates: typecheck 0, typecheck:gate 0 allowlisted, yarn test 53, snapshot byte-identical
(expected — screen-reader strings, harness stubs Highcharts), pytest 57.
