### PR TITLE
T-5.19: Slovenian text pass — two grammar fixes, terminology and percentile wording

### DIFF
--- a/code/ali-je-vroce-era5/charts/Era5TropicalChart.tsx
+++ b/code/ali-je-vroce-era5/charts/Era5TropicalChart.tsx
@@ -23,7 +23,7 @@ const ERA5_CONFIGS: Record<string, Config> = {
       ` na leto · lapsna korekcija nadmorske višine · ERA5-Land`,
     tooltipNoun:      t("tropical.noun_days"),
     plainDesc:        (th) => t("tropical.plain_desc_days", { th: fmtInt(th) }),
-    plainNoun:        t("tropical.plain_noun_days"),
+    plainNounInstr:   t("tropical.instr_days"),
   },
   nights: {
     kind:             "nights",
@@ -35,7 +35,7 @@ const ERA5_CONFIGS: Record<string, Config> = {
       ` na leto · lapsna korekcija nadmorske višine · ERA5-Land`,
     tooltipNoun:      t("tropical.noun_nights"),
     plainDesc:        (th) => t("tropical.plain_desc_nights", { th: fmtInt(th) }),
-    plainNoun:        t("tropical.plain_noun_nights"),
+    plainNounInstr:   t("tropical.instr_nights"),
   },
 };
 
@@ -98,7 +98,7 @@ export function Era5TropicalChart(props: Props) {
   const noTrendReason = () => {
     const d = display();
     if (!d || d.trend.model_used) return null;
-    return t("tropical.no_trend", { plainNoun: cfg().plainNoun, count: d.nonzero_count });
+    return t("tropical.no_trend", { instr: cfg().plainNounInstr, count: d.nonzero_count });
   };
 
   return (

--- a/code/ali-je-vroce-era5/charts/TropicalChart.tsx
+++ b/code/ali-je-vroce-era5/charts/TropicalChart.tsx
@@ -43,7 +43,7 @@ export interface Config {
   subLabel:         (th: number, st: number) => string;
   tooltipNoun:      string;
   plainDesc:        (th: number) => string;
-  plainNoun:        string;
+  plainNounInstr:   string;  // instrumental-plural noun for no_trend ("z {instr}")
 }
 
 const INK      = "#0E0E0C";

--- a/code/ali-je-vroce-era5/components/TodayCard.tsx
+++ b/code/ali-je-vroce-era5/components/TodayCard.tsx
@@ -17,7 +17,10 @@ const CATEGORIES: Record<string, string> = {
 };
 
 // T-5.5 — category descriptions live in the catalogue (today.desc_{arso,era5}_*),
-// parameterised on {d} / {country} / {record_years} / {year_min}.
+// parameterised on {d} / {record_years} / {year_min}.
+// T-5.19 — the former {country} placeholder was always fed the nominative
+// "Slovenija", producing the ungrammatical "v Slovenija"; the locative "v Sloveniji"
+// is now baked into the two desc_*_nope strings, so no country param is passed.
 function catDesc(catKey: string, r: TodayStatus): string {
   const isArso = r.loc ? isArsoLoc(r.loc) : false;
   const d = fmtDayLabel(r.day_label ?? "");
@@ -27,7 +30,6 @@ function catDesc(catKey: string, r: TodayStatus): string {
   const yearMax = r.year_max ?? todayYear();
   return t(`today.desc_${isArso ? "arso" : "era5"}_${catKey}`, {
     d,
-    country: "Slovenija",
     year_min: yearMin,
     record_years: yearMax - yearMin + 1,
   });

--- a/code/ali-je-vroce-era5/i18n/sl.ts
+++ b/code/ali-je-vroce-era5/i18n/sl.ts
@@ -81,14 +81,14 @@ export const sl = {
     // ARSO cutoffs vs ERA5 record — kept as separate templates as in TodayCard.
     desc_arso_freezing: "Med najhladnejšimi {d} v naših zapisih ARSO.",
     desc_arso_cold: "Hladneje od večine izmerjenih {d}.",
-    desc_arso_nope: "Točno takšno, kot {d} v {country} ponavadi je.",
+    desc_arso_nope: "Točno takšno, kot {d} v Sloveniji ponavadi je.",
     desc_arso_hot: "Med najtoplejšimi {d} v naših zapisih.",
-    desc_arso_hell: "Izjemna vročina — vrh 5 % vseh {d} glede na meritve ARSO.",
+    desc_arso_hell: "Izjemna vročina — med najtoplejšimi 5 % vseh {d} glede na meritve ARSO.",
     desc_era5_freezing: "Med najhladnejšimi {d} v naših {record_years} letih zapisov.",
     desc_era5_cold: "Hladneje od večine izmerjenih {d}.",
-    desc_era5_nope: "Točno takšno, kot {d} v {country} ponavadi je.",
+    desc_era5_nope: "Točno takšno, kot {d} v Sloveniji ponavadi je.",
     desc_era5_hot: "Med najtoplejšimi {d} v naših zapisih.",
-    desc_era5_hell: "Izjemna vročina — vrh 5 % vseh {d} od {year_min}.",
+    desc_era5_hell: "Izjemna vročina — med najtoplejšimi 5 % vseh {d} od {year_min}.",
 
     national_explain: "Povprečje najvišjih dnevnih temperatur {count, plural, one{# slovenske postaje} two{# slovenskih postaj} few{# slovenskih postaj} other{# slovenskih postaj}} (nadmorska višina {elMin}–{elMax} m), razvrščeno glede na zapise ERA5-Land od leta {yearMin} za isto ±7-dnevno okno.",
     explain_arso: "Temperatura na ARSO postaji {label}, razvrstena glede na percentilne zapise ARSO meritev.",
@@ -116,7 +116,7 @@ export const sl = {
 
     chart_title_nat: "Dnevne najvišje temperature v Sloveniji za dva tedna okoli {day} od {year_min}",
     chart_title_station: "Dnevne najvišje temperature na postaji {station} za dva tedna okoli {day} od {year_min}",
-    chart_explain: "Krivulja prikazuje, kako pogosto se je pojavila vsaka vrhunska temperatura na dneve, kot je danes, v vseh letih. Barve označujejo klimatološke cone — od hladne modre prek tipičnega bežastega pasu do ekstremne rdeče.",
+    chart_explain: "Krivulja prikazuje, kako pogosto se je pojavila vsaka najvišja temperatura na dneve, kot je danes, v vseh letih. Barve označujejo klimatološke cone — od hladne modre prek tipičnega bežastega pasu do ekstremne rdeče.",
     // {region} = "Slovenija" | "Danes"
     foot2: "{region}: {temp} °C · {pct}. percentil · mediana {median} °C · {count, plural, one{# opazovanje} two{# opazovanji} few{# opazovanja} other{# opazovanj}} · {year_min}–{year_max}",
     foot2_region_nat: "Slovenija",
@@ -343,8 +343,17 @@ export const sl = {
     unit_nights: "noči",
     noun_days: "Tropski dnevi",
     noun_nights: "Tropske noči",
+    // T-5.19 — `plain_noun_days`/`plain_noun_nights` are the nominative-singular
+    // forms; they are now UNUSED (their only consumer, no_trend, moved to the
+    // pre-declined instrumental forms below). Left in place, not deleted, per the
+    // ticket — removal is its own change.
     plain_noun_days: "tropski dan",
     plain_noun_nights: "tropska noč",
+    // Instrumental-plural forms for no_trend's "z {instr}" — Slovene morphology the
+    // old "z {plainNoun}i" concatenation could not produce (it rendered the
+    // ungrammatical "z tropski dani" / "z tropska noči").
+    instr_days: "tropskimi dnevi",
+    instr_nights: "tropskimi nočmi",
     ctrl_threshold: "Prag:",
     ctrl_streak_days: "Min. zap. dni:",
     ctrl_streak_nights: "Min. zap. noči:",
@@ -367,7 +376,7 @@ export const sl = {
     dir_more: "več",
     dir_less: "manj",
     plain: "{plainDesc} Postaja {station} kaže {sig}: grobe {dpd} {dir} {unit} na desetletje. {forward}",
-    no_trend: "Premalo let z {plainNoun}i za izračun trenda ({count, plural, one{# leto} two{# leti} few{# leta} other{# let}} z vrednostjo > 0). Potrebnih je vsaj 10.",
+    no_trend: "Premalo let z {instr} za izračun trenda ({count, plural, one{# leto} two{# leti} few{# leta} other{# let}} z vrednostjo > 0). Potrebnih je vsaj 10.",
     a11y: "Stolpčni prikaz letnega števila — {noun}, torej koliko {unit} na leto preseže izbrani temperaturni prag — z modelom trenda negativne binomske regresije in intervalom zaupanja; zadnji stolpec je leto v teku.",
   },
 

--- a/tests/fixtures/snapshot.json
+++ b/tests/fixtures/snapshot.json
@@ -30197,7 +30197,7 @@
           "header": "Tropski dnevi · Kredarica",
           "coverage": "77 let · 0 z vrednostjo > 0",
           "paragraphs": [
-            "Premalo let z tropski dani za izračun trenda (0 let z vrednostjo > 0). Potrebnih je vsaj 10."
+            "Premalo let z tropskimi dnevi za izračun trenda (0 let z vrednostjo > 0). Potrebnih je vsaj 10."
           ]
         },
         "current_year_bar": {
@@ -30663,7 +30663,7 @@
           "header": "Tropske noči · Kredarica",
           "coverage": "77 let · 0 z vrednostjo > 0",
           "paragraphs": [
-            "Premalo let z tropska noči za izračun trenda (0 let z vrednostjo > 0). Potrebnih je vsaj 10."
+            "Premalo let z tropskimi nočmi za izračun trenda (0 let z vrednostjo > 0). Potrebnih je vsaj 10."
           ]
         },
         "current_year_bar": {
@@ -31893,7 +31893,7 @@
           },
           "category_label": "Normalno",
           "category_color": "rgb(231, 217, 184)",
-          "description": "Točno takšno, kot 21. jul. v Slovenija ponavadi je.",
+          "description": "Točno takšno, kot 21. jul. v Sloveniji ponavadi je.",
           "percentile": "38",
           "percentile_label": "percentil",
           "samples": "20.682 vzorcev",
@@ -32851,7 +32851,7 @@
       "today_chart_copy": {
         "_note": "Raw JSX in AliJeVroceERA5.tsx:99-112, mirrored by TodayChartCopy in harness.tsx and checked against the source by main.mjs assertMirroredCopy.",
         "title": "Dnevne najvišje temperature v Sloveniji za dva tedna okoli 21. jul. od 1950",
-        "explain": "Krivulja prikazuje, kako pogosto se je pojavila vsaka vrhunska temperatura na dneve, kot je danes, v vseh letih. Barve označujejo klimatološke cone — od hladne modre prek tipičnega bežastega pasu do ekstremne rdeče.",
+        "explain": "Krivulja prikazuje, kako pogosto se je pojavila vsaka najvišja temperatura na dneve, kot je danes, v vseh letih. Barve označujejo klimatološke cone — od hladne modre prek tipičnega bežastega pasu do ekstremne rdeče.",
         "footer": "Slovenija: 23,8 °C · 38. percentil · mediana 24,5 °C · 20.682 opazovanj · 1950–2026"
       },
       "today_trend": {
@@ -35251,7 +35251,7 @@
           },
           "category_label": "Normalno",
           "category_color": "rgb(231, 217, 184)",
-          "description": "Točno takšno, kot 21. jul. v Slovenija ponavadi je.",
+          "description": "Točno takšno, kot 21. jul. v Sloveniji ponavadi je.",
           "percentile": "49",
           "percentile_label": "percentil",
           "samples": "1149 vzorcev",
@@ -36400,7 +36400,7 @@
       "today_chart_copy": {
         "_note": "Raw JSX in AliJeVroceERA5.tsx:99-112, mirrored by TodayChartCopy in harness.tsx and checked against the source by main.mjs assertMirroredCopy.",
         "title": "Dnevne najvišje temperature na postaji Ljubljana za dva tedna okoli 21. jul. od 1950",
-        "explain": "Krivulja prikazuje, kako pogosto se je pojavila vsaka vrhunska temperatura na dneve, kot je danes, v vseh letih. Barve označujejo klimatološke cone — od hladne modre prek tipičnega bežastega pasu do ekstremne rdeče.",
+        "explain": "Krivulja prikazuje, kako pogosto se je pojavila vsaka najvišja temperatura na dneve, kot je danes, v vseh letih. Barve označujejo klimatološke cone — od hladne modre prek tipičnega bežastega pasu do ekstremne rdeče.",
         "footer": "Danes: 24,9 °C · 49. percentil · mediana 24,9 °C · 1149 opazovanj · 1950–2026"
       },
       "today_trend": {
@@ -38800,7 +38800,7 @@
           },
           "category_label": "Normalno",
           "category_color": "rgb(231, 217, 184)",
-          "description": "Točno takšno, kot 21. jul. v Slovenija ponavadi je.",
+          "description": "Točno takšno, kot 21. jul. v Sloveniji ponavadi je.",
           "percentile": "28",
           "percentile_label": "percentil",
           "samples": "1149 vzorcev",
@@ -39949,7 +39949,7 @@
       "today_chart_copy": {
         "_note": "Raw JSX in AliJeVroceERA5.tsx:99-112, mirrored by TodayChartCopy in harness.tsx and checked against the source by main.mjs assertMirroredCopy.",
         "title": "Dnevne najvišje temperature na postaji Kredarica za dva tedna okoli 21. jul. od 1950",
-        "explain": "Krivulja prikazuje, kako pogosto se je pojavila vsaka vrhunska temperatura na dneve, kot je danes, v vseh letih. Barve označujejo klimatološke cone — od hladne modre prek tipičnega bežastega pasu do ekstremne rdeče.",
+        "explain": "Krivulja prikazuje, kako pogosto se je pojavila vsaka najvišja temperatura na dneve, kot je danes, v vseh letih. Barve označujejo klimatološke cone — od hladne modre prek tipičnega bežastega pasu do ekstremne rdeče.",
         "footer": "Danes: 9,0 °C · 28. percentil · mediana 11,2 °C · 1149 opazovanj · 1950–2026"
       },
       "today_trend": {
@@ -42349,7 +42349,7 @@
           },
           "category_label": "Peklensko",
           "category_color": "rgb(150, 44, 26)",
-          "description": "Izjemna vročina — vrh 5 % vseh 29. jul. od 1950.",
+          "description": "Izjemna vročina — med najtoplejšimi 5 % vseh 29. jul. od 1950.",
           "percentile": "97",
           "percentile_label": "percentil",
           "samples": "20.538 vzorcev",
@@ -43307,7 +43307,7 @@
       "today_chart_copy": {
         "_note": "Raw JSX in AliJeVroceERA5.tsx:99-112, mirrored by TodayChartCopy in harness.tsx and checked against the source by main.mjs assertMirroredCopy.",
         "title": "Dnevne najvišje temperature v Sloveniji za dva tedna okoli 29. jul. od 1950",
-        "explain": "Krivulja prikazuje, kako pogosto se je pojavila vsaka vrhunska temperatura na dneve, kot je danes, v vseh letih. Barve označujejo klimatološke cone — od hladne modre prek tipičnega bežastega pasu do ekstremne rdeče.",
+        "explain": "Krivulja prikazuje, kako pogosto se je pojavila vsaka najvišja temperatura na dneve, kot je danes, v vseh letih. Barve označujejo klimatološke cone — od hladne modre prek tipičnega bežastega pasu do ekstremne rdeče.",
         "footer": "Slovenija: 32,5 °C · 97. percentil · mediana 24,7 °C · 20.538 opazovanj · 1950–2026"
       },
       "today_trend": {
@@ -45707,7 +45707,7 @@
           },
           "category_label": "Peklensko",
           "category_color": "rgb(150, 44, 26)",
-          "description": "Izjemna vročina — vrh 5 % vseh 29. jul. od 1950.",
+          "description": "Izjemna vročina — med najtoplejšimi 5 % vseh 29. jul. od 1950.",
           "percentile": "99",
           "percentile_label": "percentil",
           "samples": "1141 vzorcev",
@@ -46856,7 +46856,7 @@
       "today_chart_copy": {
         "_note": "Raw JSX in AliJeVroceERA5.tsx:99-112, mirrored by TodayChartCopy in harness.tsx and checked against the source by main.mjs assertMirroredCopy.",
         "title": "Dnevne najvišje temperature na postaji Ljubljana za dva tedna okoli 29. jul. od 1950",
-        "explain": "Krivulja prikazuje, kako pogosto se je pojavila vsaka vrhunska temperatura na dneve, kot je danes, v vseh letih. Barve označujejo klimatološke cone — od hladne modre prek tipičnega bežastega pasu do ekstremne rdeče.",
+        "explain": "Krivulja prikazuje, kako pogosto se je pojavila vsaka najvišja temperatura na dneve, kot je danes, v vseh letih. Barve označujejo klimatološke cone — od hladne modre prek tipičnega bežastega pasu do ekstremne rdeče.",
         "footer": "Danes: 34,8 °C · 99. percentil · mediana 25,0 °C · 1141 opazovanj · 1950–2026"
       },
       "today_trend": {
@@ -49256,7 +49256,7 @@
           },
           "category_label": "Peklensko",
           "category_color": "rgb(150, 44, 26)",
-          "description": "Izjemna vročina — vrh 5 % vseh 29. jul. od 1950.",
+          "description": "Izjemna vročina — med najtoplejšimi 5 % vseh 29. jul. od 1950.",
           "percentile": "95",
           "percentile_label": "percentil",
           "samples": "1141 vzorcev",
@@ -50405,7 +50405,7 @@
       "today_chart_copy": {
         "_note": "Raw JSX in AliJeVroceERA5.tsx:99-112, mirrored by TodayChartCopy in harness.tsx and checked against the source by main.mjs assertMirroredCopy.",
         "title": "Dnevne najvišje temperature na postaji Kredarica za dva tedna okoli 29. jul. od 1950",
-        "explain": "Krivulja prikazuje, kako pogosto se je pojavila vsaka vrhunska temperatura na dneve, kot je danes, v vseh letih. Barve označujejo klimatološke cone — od hladne modre prek tipičnega bežastega pasu do ekstremne rdeče.",
+        "explain": "Krivulja prikazuje, kako pogosto se je pojavila vsaka najvišja temperatura na dneve, kot je danes, v vseh letih. Barve označujejo klimatološke cone — od hladne modre prek tipičnega bežastega pasu do ekstremne rdeče.",
         "footer": "Danes: 16,8 °C · 95. percentil · mediana 11,3 °C · 1141 opazovanj · 1950–2026"
       },
       "today_trend": {
@@ -53763,7 +53763,7 @@
       "today_chart_copy": {
         "_note": "Raw JSX in AliJeVroceERA5.tsx:99-112, mirrored by TodayChartCopy in harness.tsx and checked against the source by main.mjs assertMirroredCopy.",
         "title": "Dnevne najvišje temperature v Sloveniji za dva tedna okoli 15. jul. od 1950",
-        "explain": "Krivulja prikazuje, kako pogosto se je pojavila vsaka vrhunska temperatura na dneve, kot je danes, v vseh letih. Barve označujejo klimatološke cone — od hladne modre prek tipičnega bežastega pasu do ekstremne rdeče.",
+        "explain": "Krivulja prikazuje, kako pogosto se je pojavila vsaka najvišja temperatura na dneve, kot je danes, v vseh letih. Barve označujejo klimatološke cone — od hladne modre prek tipičnega bežastega pasu do ekstremne rdeče.",
         "footer": "Slovenija: 28,0 °C · 78. percentil · mediana 24,3 °C · 20.790 opazovanj · 1950–2026"
       },
       "today_trend": {
@@ -57312,7 +57312,7 @@
       "today_chart_copy": {
         "_note": "Raw JSX in AliJeVroceERA5.tsx:99-112, mirrored by TodayChartCopy in harness.tsx and checked against the source by main.mjs assertMirroredCopy.",
         "title": "Dnevne najvišje temperature na postaji Ljubljana za dva tedna okoli 15. jul. od 1950",
-        "explain": "Krivulja prikazuje, kako pogosto se je pojavila vsaka vrhunska temperatura na dneve, kot je danes, v vseh letih. Barve označujejo klimatološke cone — od hladne modre prek tipičnega bežastega pasu do ekstremne rdeče.",
+        "explain": "Krivulja prikazuje, kako pogosto se je pojavila vsaka najvišja temperatura na dneve, kot je danes, v vseh letih. Barve označujejo klimatološke cone — od hladne modre prek tipičnega bežastega pasu do ekstremne rdeče.",
         "footer": "Danes: 29,7 °C · 90. percentil · mediana 24,7 °C · 1155 opazovanj · 1950–2026"
       },
       "today_trend": {
@@ -60861,7 +60861,7 @@
       "today_chart_copy": {
         "_note": "Raw JSX in AliJeVroceERA5.tsx:99-112, mirrored by TodayChartCopy in harness.tsx and checked against the source by main.mjs assertMirroredCopy.",
         "title": "Dnevne najvišje temperature na postaji Kredarica za dva tedna okoli 15. jul. od 1950",
-        "explain": "Krivulja prikazuje, kako pogosto se je pojavila vsaka vrhunska temperatura na dneve, kot je danes, v vseh letih. Barve označujejo klimatološke cone — od hladne modre prek tipičnega bežastega pasu do ekstremne rdeče.",
+        "explain": "Krivulja prikazuje, kako pogosto se je pojavila vsaka najvišja temperatura na dneve, kot je danes, v vseh letih. Barve označujejo klimatološke cone — od hladne modre prek tipičnega bežastega pasu do ekstremne rdeče.",
         "footer": "Danes: 13,9 °C · 80. percentil · mediana 10,9 °C · 1155 opazovanj · 1950–2026"
       },
       "today_trend": {
@@ -65816,7 +65816,7 @@
           },
           "category_label": "Normalno",
           "category_color": "rgb(231, 217, 184)",
-          "description": "Točno takšno, kot 1. mar. v Slovenija ponavadi je.",
+          "description": "Točno takšno, kot 1. mar. v Sloveniji ponavadi je.",
           "percentile": "78",
           "percentile_label": "percentil",
           "samples": "1174 vzorcev",
@@ -66947,7 +66947,7 @@
       "today_chart_copy": {
         "_note": "Raw JSX in AliJeVroceERA5.tsx:99-112, mirrored by TodayChartCopy in harness.tsx and checked against the source by main.mjs assertMirroredCopy.",
         "title": "Dnevne najvišje temperature na postaji Ljubljana za dva tedna okoli 1. mar. od 1950",
-        "explain": "Krivulja prikazuje, kako pogosto se je pojavila vsaka vrhunska temperatura na dneve, kot je danes, v vseh letih. Barve označujejo klimatološke cone — od hladne modre prek tipičnega bežastega pasu do ekstremne rdeče.",
+        "explain": "Krivulja prikazuje, kako pogosto se je pojavila vsaka najvišja temperatura na dneve, kot je danes, v vseh letih. Barve označujejo klimatološke cone — od hladne modre prek tipičnega bežastega pasu do ekstremne rdeče.",
         "footer": "Danes: 10,9 °C · 78. percentil · mediana 7,2 °C · 1174 opazovanj · 1950–2026"
       },
       "today_trend": {
@@ -69347,7 +69347,7 @@
           },
           "category_label": "Normalno",
           "category_color": "rgb(231, 217, 184)",
-          "description": "Točno takšno, kot 28. feb. v Slovenija ponavadi je.",
+          "description": "Točno takšno, kot 28. feb. v Sloveniji ponavadi je.",
           "percentile": "69",
           "percentile_label": "percentil",
           "samples": "1174 vzorcev",
@@ -70496,7 +70496,7 @@
       "today_chart_copy": {
         "_note": "Raw JSX in AliJeVroceERA5.tsx:99-112, mirrored by TodayChartCopy in harness.tsx and checked against the source by main.mjs assertMirroredCopy.",
         "title": "Dnevne najvišje temperature na postaji Ljubljana za dva tedna okoli 28. feb. od 1950",
-        "explain": "Krivulja prikazuje, kako pogosto se je pojavila vsaka vrhunska temperatura na dneve, kot je danes, v vseh letih. Barve označujejo klimatološke cone — od hladne modre prek tipičnega bežastega pasu do ekstremne rdeče.",
+        "explain": "Krivulja prikazuje, kako pogosto se je pojavila vsaka najvišja temperatura na dneve, kot je danes, v vseh letih. Barve označujejo klimatološke cone — od hladne modre prek tipičnega bežastega pasu do ekstremne rdeče.",
         "footer": "Danes: 9,4 °C · 69. percentil · mediana 7,1 °C · 1174 opazovanj · 1950–2026"
       },
       "today_trend": {
@@ -72896,7 +72896,7 @@
           },
           "category_label": "Normalno",
           "category_color": "rgb(231, 217, 184)",
-          "description": "Točno takšno, kot 1. mar. v Slovenija ponavadi je.",
+          "description": "Točno takšno, kot 1. mar. v Sloveniji ponavadi je.",
           "percentile": "68",
           "percentile_label": "percentil",
           "samples": "1174 vzorcev",
@@ -74045,7 +74045,7 @@
       "today_chart_copy": {
         "_note": "Raw JSX in AliJeVroceERA5.tsx:99-112, mirrored by TodayChartCopy in harness.tsx and checked against the source by main.mjs assertMirroredCopy.",
         "title": "Dnevne najvišje temperature na postaji Ljubljana za dva tedna okoli 1. mar. od 1950",
-        "explain": "Krivulja prikazuje, kako pogosto se je pojavila vsaka vrhunska temperatura na dneve, kot je danes, v vseh letih. Barve označujejo klimatološke cone — od hladne modre prek tipičnega bežastega pasu do ekstremne rdeče.",
+        "explain": "Krivulja prikazuje, kako pogosto se je pojavila vsaka najvišja temperatura na dneve, kot je danes, v vseh letih. Barve označujejo klimatološke cone — od hladne modre prek tipičnega bežastega pasu do ekstremne rdeče.",
         "footer": "Danes: 9,4 °C · 68. percentil · mediana 7,2 °C · 1174 opazovanj · 1950–2026"
       },
       "today_trend": {
@@ -77594,7 +77594,7 @@
       "today_chart_copy": {
         "_note": "Raw JSX in AliJeVroceERA5.tsx:99-112, mirrored by TodayChartCopy in harness.tsx and checked against the source by main.mjs assertMirroredCopy.",
         "title": "Dnevne najvišje temperature na postaji Ljubljana za dva tedna okoli 1. jan. od 1950",
-        "explain": "Krivulja prikazuje, kako pogosto se je pojavila vsaka vrhunska temperatura na dneve, kot je danes, v vseh letih. Barve označujejo klimatološke cone — od hladne modre prek tipičnega bežastega pasu do ekstremne rdeče.",
+        "explain": "Krivulja prikazuje, kako pogosto se je pojavila vsaka najvišja temperatura na dneve, kot je danes, v vseh letih. Barve označujejo klimatološke cone — od hladne modre prek tipičnega bežastega pasu do ekstremne rdeče.",
         "footer": "Danes: 8,4 °C · 91. percentil · mediana 3,3 °C · 1148 opazovanj · 1950–2026"
       },
       "today_trend": {
@@ -79994,7 +79994,7 @@
           },
           "category_label": "Normalno",
           "category_color": "rgb(231, 217, 184)",
-          "description": "Točno takšno, kot 31. dec. v Slovenija ponavadi je.",
+          "description": "Točno takšno, kot 31. dec. v Sloveniji ponavadi je.",
           "percentile": "34",
           "percentile_label": "percentil",
           "samples": "1147 vzorcev",
@@ -81143,7 +81143,7 @@
       "today_chart_copy": {
         "_note": "Raw JSX in AliJeVroceERA5.tsx:99-112, mirrored by TodayChartCopy in harness.tsx and checked against the source by main.mjs assertMirroredCopy.",
         "title": "Dnevne najvišje temperature na postaji Ljubljana za dva tedna okoli 31. dec. od 1950",
-        "explain": "Krivulja prikazuje, kako pogosto se je pojavila vsaka vrhunska temperatura na dneve, kot je danes, v vseh letih. Barve označujejo klimatološke cone — od hladne modre prek tipičnega bežastega pasu do ekstremne rdeče.",
+        "explain": "Krivulja prikazuje, kako pogosto se je pojavila vsaka najvišja temperatura na dneve, kot je danes, v vseh letih. Barve označujejo klimatološke cone — od hladne modre prek tipičnega bežastega pasu do ekstremne rdeče.",
         "footer": "Danes: 1,5 °C · 34. percentil · mediana 3,3 °C · 1147 opazovanj · 1950–2026"
       },
       "today_trend": {
@@ -83535,7 +83535,7 @@
           },
           "category_label": "Peklensko",
           "category_color": "rgb(150, 44, 26)",
-          "description": "Izjemna vročina — vrh 5 % vseh 3. avg. od 1950.",
+          "description": "Izjemna vročina — med najtoplejšimi 5 % vseh 3. avg. od 1950.",
           "percentile": "99",
           "percentile_label": "percentil",
           "samples": "1140 vzorcev",
@@ -84684,7 +84684,7 @@
       "today_chart_copy": {
         "_note": "Raw JSX in AliJeVroceERA5.tsx:99-112, mirrored by TodayChartCopy in harness.tsx and checked against the source by main.mjs assertMirroredCopy.",
         "title": "Dnevne najvišje temperature na postaji Ljubljana za dva tedna okoli 3. avg. od 1950",
-        "explain": "Krivulja prikazuje, kako pogosto se je pojavila vsaka vrhunska temperatura na dneve, kot je danes, v vseh letih. Barve označujejo klimatološke cone — od hladne modre prek tipičnega bežastega pasu do ekstremne rdeče.",
+        "explain": "Krivulja prikazuje, kako pogosto se je pojavila vsaka najvišja temperatura na dneve, kot je danes, v vseh letih. Barve označujejo klimatološke cone — od hladne modre prek tipičnega bežastega pasu do ekstremne rdeče.",
         "footer": "Danes: 35,6 °C · 99. percentil · mediana 25,1 °C · 1140 opazovanj · 1950–2026"
       },
       "today_trend": {
@@ -87076,7 +87076,7 @@
           },
           "category_label": "Peklensko",
           "category_color": "rgb(150, 44, 26)",
-          "description": "Izjemna vročina — vrh 5 % vseh 3. avg. od 1950.",
+          "description": "Izjemna vročina — med najtoplejšimi 5 % vseh 3. avg. od 1950.",
           "percentile": "100",
           "percentile_label": "percentil",
           "samples": "1140 vzorcev",
@@ -88225,7 +88225,7 @@
       "today_chart_copy": {
         "_note": "Raw JSX in AliJeVroceERA5.tsx:99-112, mirrored by TodayChartCopy in harness.tsx and checked against the source by main.mjs assertMirroredCopy.",
         "title": "Dnevne najvišje temperature na postaji Kredarica za dva tedna okoli 3. avg. od 1950",
-        "explain": "Krivulja prikazuje, kako pogosto se je pojavila vsaka vrhunska temperatura na dneve, kot je danes, v vseh letih. Barve označujejo klimatološke cone — od hladne modre prek tipičnega bežastega pasu do ekstremne rdeče.",
+        "explain": "Krivulja prikazuje, kako pogosto se je pojavila vsaka najvišja temperatura na dneve, kot je danes, v vseh letih. Barve označujejo klimatološke cone — od hladne modre prek tipičnega bežastega pasu do ekstremne rdeče.",
         "footer": "Danes: 21,7 °C · 100. percentil · mediana 11,4 °C · 1140 opazovanj · 1950–2026"
       },
       "today_trend": {
@@ -91766,7 +91766,7 @@
       "today_chart_copy": {
         "_note": "Raw JSX in AliJeVroceERA5.tsx:99-112, mirrored by TodayChartCopy in harness.tsx and checked against the source by main.mjs assertMirroredCopy.",
         "title": "Dnevne najvišje temperature na postaji Ljubljana za dva tedna okoli 7. feb. od 1950",
-        "explain": "Krivulja prikazuje, kako pogosto se je pojavila vsaka vrhunska temperatura na dneve, kot je danes, v vseh letih. Barve označujejo klimatološke cone — od hladne modre prek tipičnega bežastega pasu do ekstremne rdeče.",
+        "explain": "Krivulja prikazuje, kako pogosto se je pojavila vsaka najvišja temperatura na dneve, kot je danes, v vseh letih. Barve označujejo klimatološke cone — od hladne modre prek tipičnega bežastega pasu do ekstremne rdeče.",
         "footer": "Danes: −5,8 °C · 3. percentil · mediana 4,8 °C · 1155 opazovanj · 1950–2026"
       },
       "today_trend": {
@@ -95328,7 +95328,7 @@
       "today_chart_copy": {
         "_note": "Raw JSX in AliJeVroceERA5.tsx:99-112, mirrored by TodayChartCopy in harness.tsx and checked against the source by main.mjs assertMirroredCopy.",
         "title": "Dnevne najvišje temperature na postaji Kredarica za dva tedna okoli 7. jan. od 1950",
-        "explain": "Krivulja prikazuje, kako pogosto se je pojavila vsaka vrhunska temperatura na dneve, kot je danes, v vseh letih. Barve označujejo klimatološke cone — od hladne modre prek tipičnega bežastega pasu do ekstremne rdeče.",
+        "explain": "Krivulja prikazuje, kako pogosto se je pojavila vsaka najvišja temperatura na dneve, kot je danes, v vseh letih. Barve označujejo klimatološke cone — od hladne modre prek tipičnega bežastega pasu do ekstremne rdeče.",
         "footer": "Danes: −23,7 °C · 0. percentil · mediana −8,8 °C · 1154 opazovanj · 1950–2026"
       },
       "today_trend": {


### PR DESCRIPTION
Slovenian text pass over the first section, bundling four wording items because all are
i18n/sl.ts, all needed one editorial round, and all move snapshot string leaves.

Two live grammar errors fixed, both visible to every Slovene reader.

"v Slovenija" -> "v Sloveniji" (sl.ts:84,89). The {country} placeholder sat after a locative
preposition but was fed a hardcoded nominative at its single call site, so this rendered on
every location's normal-category description, not just the national view. The dead
parameter is removed. An earlier assumption that name_locative already handled this proved
false — that column never reaches the frontend at all.

The tropical no_trend string concatenated "z {plainNoun}i", producing "z tropski dani" and
"z tropska noči" where Slovene instrumental plural requires "tropskimi dnevi" and
"tropskimi nočmi". Fixed with new, honestly-named keys rather than repurposing the existing
ones, whose names would then have described the wrong thing. String concatenation doing
morphology only works for nouns whose declension matches the hardcoded suffix.

"vrhunska" -> "najvišja" (sl.ts:119), the sole occurrence, confirmed by grep across both
catalogue files. The mountain-summit use of "vrh" in hero-content is unrelated and left.

"vrh 5 % vseh {d}" -> "med najtoplejšimi 5 % vseh {d}" (sl.ts:86,91). Plain language rather
than "nad 95. percentilom", since the exact percentile is already shown numerically in the
gauge.

The station dropdown is unchanged: it is a native select, whose text cannot differ between
collapsed and expanded states, and its label already matches D-7 with a derived station
count.

Snapshot: 32 leaves moved, all strings, zero numeric — verified rather than assumed.

Gates: typecheck 0, typecheck:gate 0 allowlisted, yarn test 53 including the text-integrity
guard over the new prose, snapshot green, pytest 57.
