### PR TITLE
T-5.20: collapse the climate-context paragraph behind a details disclosure

### DIFF
--- a/code/ali-je-vroce-era5/components/TodayCard.tsx
+++ b/code/ali-je-vroce-era5/components/TodayCard.tsx
@@ -213,10 +213,17 @@ export function TodayCard(props: Props) {
             }
           </p>
 
-          {/* Climate context */}
-          <p class="today-context">
-            {t("today.context")}
-          </p>
+          {/* Climate context — collapsed by default behind a native <details>
+              disclosure, reusing the methodology panel's summary treatment
+              (T-5.20). Native <details>/<summary> is keyboard-operable and
+              announced as expandable with no ARIA of our own; the body stays in
+              the DOM (only visually collapsed), so the snapshot still sees it. */}
+          <details class="today-context-details">
+            <summary class="today-context-summary">{t("today.context_summary")}</summary>
+            <p class="today-context">
+              {t("today.context")}
+            </p>
+          </details>
 
           {/* Last 7 days */}
           <Show when={props.last7?.available && (props.last7?.days.length ?? 0) > 0}>

--- a/code/ali-je-vroce-era5/i18n/sl.ts
+++ b/code/ali-je-vroce-era5/i18n/sl.ts
@@ -95,6 +95,10 @@ export const sl = {
     explain_station: "Temperatura na postaji {station}, razvrstena glede na zapise ERA5-Land od leta {year_min} za isto ±7-dnevno okno.",
     explain_national: "Današnji vrh je najvišja napovedana temperatura, razvrstena glede na zapise ERA5-Land od leta {year_min} za isto ±7-dnevno okno.",
 
+    // T-5.20 — this 83-word climate background is collapsed behind a <details>
+    // disclosure (the same native mechanism as the methodology panel). The
+    // summary is the always-visible collapsed-state label.
+    context_summary: "Podnebno ozadje",
     context: "Slovenija leži na stičišču štirih podnebnih con — alpske, sredozemske, celinsko in panonske — stisnjenih v eno izmed podnebno najbolj raznolikih držav v Evropi. Srednja Evropa se segreva približno 1,5-krat hitreje od svetovnega povprečja. Temperature so v zadnjih 70 letih narasle za skoraj 2 °C. Pomlad v Alpah prihaja vse prej, sredozemske suše segajo vse globlje v notranjost, severovzhodni panonski del pa se sooča z vedno hujšimi vročinskimi vali. Kar je bilo leta 1980 tipično poletje, danes sodi med hladnejšo polovico nedavnih desetletij.",
 
     last7_title: "Zadnjih 7 dni",

--- a/styles/era5.css
+++ b/styles/era5.css
@@ -149,16 +149,31 @@
 /* ── Methodology block + trust furniture (T-6.1 / T-6.2) ──────────────────── */
 .methodology { padding-top: 8px; padding-bottom: 56px; margin-top: 24px; border-top: 1px solid var(--color-rule); }
 .methodology-details { max-width: 760px; }
-.methodology-summary {
+/* T-5.20 — the today-card climate-context disclosure reuses this exact summary
+   treatment, so the two <details> on the page read as one mechanism. One
+   definition, two callers. */
+.methodology-summary,
+.today-context-summary {
   font-family: var(--font-mono); font-size: 12px; font-weight: 600; letter-spacing: 0.08em;
   text-transform: uppercase; color: var(--color-ink-soft); cursor: pointer;
   padding: 14px 0; list-style: none; display: flex; align-items: center; gap: 8px;
 }
-.methodology-summary::-webkit-details-marker { display: none; }
-.methodology-summary::before { content: "▸"; font-size: 10px; transition: transform 0.15s; }
-.methodology-details[open] .methodology-summary::before { transform: rotate(90deg); }
-.methodology-summary:hover { color: var(--color-ink); }
-.methodology-summary:focus-visible { outline: 2px solid var(--color-accent); outline-offset: 3px; border-radius: 3px; }
+.methodology-summary::-webkit-details-marker,
+.today-context-summary::-webkit-details-marker { display: none; }
+.methodology-summary::before,
+.today-context-summary::before { content: "▸"; font-size: 10px; transition: transform 0.15s; }
+.methodology-details[open] .methodology-summary::before,
+.today-context-details[open] .today-context-summary::before { transform: rotate(90deg); }
+.methodology-summary:hover,
+.today-context-summary:hover { color: var(--color-ink); }
+.methodology-summary:focus-visible,
+.today-context-summary:focus-visible { outline: 2px solid var(--color-accent); outline-offset: 3px; border-radius: 3px; }
+
+/* Keep the disclosure aligned with the other centred blocks in .today-card-data,
+   and remove the summary's top padding so it doesn't double the column gap. */
+.today-context-details { max-width: 900px; width: 100%; }
+.today-context-details .today-context-summary { padding-top: 0; }
+.today-context-details[open] .today-context { margin-top: 8px; }
 
 .methodology-body { max-width: 720px; padding: 4px 0 8px; }
 .methodology-h    { font-family: var(--font-sans); font-size: 16px; font-weight: 600; color: var(--color-ink); margin: 22px 0 6px; }


### PR DESCRIPTION
The 83-word climate-context paragraph is now collapsed behind a native details element,
closed by default, matching the methodology panel.

The review note ("daljši tekst umakni ali daj expandable kot je methodology") named no
specific string, so step 1 enumerated six candidates in the today-card area and classified
each as essential — a reader needs it to interpret the number in front of them — or
supporting. today.context was the clear choice: general Slovenian climate background that
says nothing about the reader's number, and by a wide margin the longest block.

Two candidates were deliberately left open. dist.chart_explain explains what the KDE curve
and colour zones are, so collapsing it would make an unfamiliar chart less interpretable.
national_explain states which stations and which window the number is ranked against —
that is provenance, and it was made visible on purpose.

Built by reusing the pattern rather than the component: MethodologyPanel is welded to a
markdown parser and the trust furniture, so the details/summary shell was applied directly
and era5.css extended with grouped selectors. One rule set serves both disclosures, so they
read as one mechanism rather than two similar ones.

One new string, today.context_summary = "Podnebno ozadje", needed because a details element
requires a collapsed-state label and none of the existing strings supplied one.

Snapshot byte-identical, which was the predicted result: today.context is not captured by
the harness, and a native details keeps its body in the DOM so the captured neighbours
extract unchanged. A move here would have meant the text stopped rendering.

Keyboard operability is inferred from the native summary spec plus a confirmed focus-visible
outline and a working toggle, not from an injected keypress — the browser pane's synthetic
key events did not drive the native toggle. T-6.5 tier 1 verifies it directly.

Gates: typecheck 0, typecheck:gate 0 allowlisted, yarn test 53, snapshot identical
(21 cases, 0 misses), pytest 57.
