### PR TITLE
T-5.23: make RegressionChart's tooltip read live data

### DIFF
--- a/code/ali-je-vroce-era5/charts/RegressionChart.tsx
+++ b/code/ali-je-vroce-era5/charts/RegressionChart.tsx
@@ -1,6 +1,7 @@
 import { onMount, onCleanup, createEffect } from "solid-js";
 import type { RegressionResponse } from "../types.ts";
 import { enableChartA11y } from "./highcharts-a11y.ts";
+import { regressionTooltipHtml } from "./regression-tooltip.ts";
 import { t, fmtNum } from "../i18n/format.ts";
 
 interface Props {
@@ -95,9 +96,14 @@ export function RegressionChart(props: Props) {
       },
       tooltip: {
         shared: false,
+        // Read the unit through `() => props.data`, not the captured `d`, so the
+        // tooltip reflects the current data at hover time and cannot go stale (T-5.23).
         formatter(this: Highcharts.Point) {
-          const loc = (this.series.name ?? "").replace(/_/g, " ");
-          return t("regchart.tooltip", { loc, x: this.x, y: fmtNum(this.y as number, 2), unit: d.unit });
+          return regressionTooltipHtml(() => props.data, {
+            seriesName: this.series.name ?? "",
+            x:          this.x as number,
+            y:          this.y as number,
+          });
         },
       },
       xAxis: { type: "linear", title: { text: null }, gridLineWidth: 0, tickInterval: 10 },

--- a/code/ali-je-vroce-era5/charts/regression-tooltip.ts
+++ b/code/ali-je-vroce-era5/charts/regression-tooltip.ts
@@ -1,0 +1,33 @@
+// T-5.23 — the regression-chart tooltip string. Pure logic, split out of
+// RegressionChart.tsx so it can be unit-tested without the solid/Highcharts import
+// chain (CLAUDE.md: put pure logic in a helper and test the helper directly), and so
+// the UNIT is read through a getter — the component passes `() => props.data`, so the
+// formatter reads the CURRENT unit at hover time rather than a value captured when the
+// chart was built.
+//
+// The rule this encodes (from T-5.22's chart audit): capturing props into a local
+// `const` inside a formatter is unsafe (it freezes at mount), reading it through props
+// at call time is safe. RegressionChart used to close over `const d = props.data` and
+// read `d.unit`. That was latent-only — `unit` is an invariant "°C" (api.ts) and the
+// chart remounts on every data change (a `keyed` <Show> in RegressionPanel) — but it
+// is the same shape T-5.22 had to fix in DistributionChart, so it is neutralised here
+// by construction rather than left to a future contributor.
+
+import type { RegressionResponse } from "../types.ts";
+import { t, fmtNum } from "../i18n/format.ts";
+
+// The hovered point's identity (series name, x, y) comes from the Highcharts Point;
+// the unit comes from the chart's data, read live through `getData`.
+export interface RegressionTooltipPoint {
+  seriesName: string;
+  x:          number;
+  y:          number;
+}
+
+export function regressionTooltipHtml(
+  getData: () => Pick<RegressionResponse, "unit">,
+  point:   RegressionTooltipPoint,
+): string {
+  const loc = (point.seriesName ?? "").replace(/_/g, " ");
+  return t("regchart.tooltip", { loc, x: point.x, y: fmtNum(point.y, 2), unit: getData().unit });
+}

--- a/tests/unit/regression-tooltip.test.ts
+++ b/tests/unit/regression-tooltip.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import { regressionTooltipHtml } from "../../code/ali-je-vroce-era5/charts/regression-tooltip.ts";
+
+// T-5.23 — RegressionChart's tooltip formatter used to close over `const d = props.data`
+// and read `d.unit`, the same frozen-closure shape T-5.22 fixed in DistributionChart.
+// It was unreachable in the current app (the unit is an invariant "°C" and the chart
+// remounts on every data change via a keyed <Show>), so it is proven here rather than by
+// a live location switch: the fix passes a getter and the helper reads the unit through
+// it at render time. The snapshot cannot see this — its harness stubs Highcharts and
+// never renders a tooltip.
+describe("regressionTooltipHtml", () => {
+  const point = { seriesName: "Ljubljana", x: 2024, y: 1.234 };
+
+  it("interpolates loc, x, y and the current unit", () => {
+    const html = regressionTooltipHtml(() => ({ unit: "°C" }), point);
+    expect(html).toContain("Ljubljana");
+    expect(html).toContain("2024");
+    expect(html).toContain("°C");
+  });
+
+  it("turns underscores in the series name into spaces", () => {
+    const html = regressionTooltipHtml(() => ({ unit: "°C" }), { ...point, seriesName: "Murska_Sobota" });
+    expect(html).toContain("Murska Sobota");
+    expect(html).not.toContain("Murska_Sobota");
+  });
+
+  // The liveness property this ticket exists for: the unit is read from the getter when
+  // the tooltip renders, not captured when the formatter was built. A mutable holder
+  // stands in for the data prop; changing it between renders must change the output. The
+  // pre-fix shape (`const d = props.data; … d.unit`) would freeze on the first value and
+  // fail this test.
+  it("tracks a unit that changes between renders — no frozen capture", () => {
+    let data = { unit: "°C" };
+    const getData = () => data;
+
+    const first = regressionTooltipHtml(getData, point);
+    data = { unit: "mm" }; // the data behind the chart changes
+    const second = regressionTooltipHtml(getData, point);
+
+    expect(first).toContain("°C");
+    expect(second).toContain("mm");
+    expect(second).not.toContain("°C");
+  });
+});


### PR DESCRIPTION
RegressionChart's tooltip formatter now reads live data instead of a value captured at mount.

This is prophylactic, not a repair, and the ticket's premise turned out to be wrong. It
assumed the pattern was structurally identical to the live bug fixed in T-5.22. The capture
has the same shape — onMount takes const d = props.data, the formatter reads d.unit, and the
createEffect never refreshes tooltip — but the mounting differs, and that is what decides
liveness. RegressionChart sits under a keyed Show over a createResource returning a fresh
object per fetch, and a keyed Show compares by reference and remounts its child on every
change (verified in Solid's source). DistributionChart is non-keyed and genuinely persists,
which is why the bug was live there.

That refines the rule from T-5.22: capturing props into a local const is unsafe only when
the component persists across data changes. Capture and persistence together are what create
the defect.

Doubly unreachable here: unit is a hardcoded "°C" in fetchRegression, the variable selector
moves ylabel rather than unit, and the component remounts anyway.

The closure was audited in full rather than only the field named in the ticket — T-5.22's
turned out to hold cutoffs as well, which was the more serious half. Here only unit was
captured. SpeiScatterChart was re-audited and cleared: it genuinely remounts under a keyed
Show and correctly has no createEffect.

Fixed with the structural form rather than by adding tooltip to the effect list, which would
re-register a new frozen closure on every change. Rendered output is unchanged.

Proven by test rather than by switching, since the value cannot vary in the app: the test
mutates a stand-in holder between renders and asserts the output tracks it, which the
pre-fix shape would fail. snapshot:check is blind to tooltips and is not cited as evidence.

Gates: typecheck 0, typecheck:gate 0 allowlisted, yarn test 66 to 69, snapshot identical,
pytest 57.
