### PR TITLE
T-4.24: withhold tropical trends from non-converged fits, pin BLAS threading

### DIFF
--- a/code/ali-je-vroce-era5/charts/Era5TropicalChart.tsx
+++ b/code/ali-je-vroce-era5/charts/Era5TropicalChart.tsx
@@ -98,7 +98,14 @@ export function Era5TropicalChart(props: Props) {
   const noTrendReason = () => {
     const d = display();
     if (!d || d.trend.model_used) return null;
-    return t("tropical.no_trend", { instr: cfg().plainNounInstr, count: d.nonzero_count });
+    // T-4.24 — two distinct withhold reasons. The pipeline's insufficiency gate is
+    // <10 non-zero years (precompute_datasette.py:593); with ≥10 the withhold is a
+    // convergence/covariance failure instead, so the "at least 10 needed" wording
+    // would be false. Branch on the count the pipeline gates on so the message
+    // never contradicts the visible year count.
+    if (d.nonzero_count < 10)
+      return t("tropical.no_trend", { instr: cfg().plainNounInstr, count: d.nonzero_count });
+    return t("tropical.no_trend_unreliable");
   };
 
   return (

--- a/code/ali-je-vroce-era5/i18n/hero-content.ts
+++ b/code/ali-je-vroce-era5/i18n/hero-content.ts
@@ -252,6 +252,12 @@ Primerjalni vzorec za vsak koledarski dan je **združeno okno ±7 dni** čez vsa
 
 Štetje vročih dni in tropskih noči uporablja **stroge pragove (\`>\`, ne \`≥\`).** To je usklajeno s standardom ETCCDI/ECA&D (medtem ko npr. nemški DWD uporablja \`≥\`). Standard je dejansko sporen; izbrali smo \`>\`. Sprememba na \`≥\` bi premaknila štetje vsakega mejnega dne, zato je izbira zapisana zavestno.
 
+## Trend tropskih dni in noči
+
+Letni trend na grafih tropskih dni in noči je **model negativne binomske regresije (NB GLM)** čez letno število — primeren za štetne podatke z večjo razpršenostjo od Poissonove. Gre za **približek**, ne za dokončno napoved: prikazana stopnja rasti in projekcija do leta 2050 sta odvisni od izbranega praga in dolžine zaporedja.
+
+**Trenda ne prikažemo, kadar mu ne moremo zaupati.** Za nekatere kombinacije (redki dogodki, skoraj ravna letna vrsta) statistični model ne da zanesljivega rezultata — ne skonvergira ali pa ocena njegove negotovosti ni veljavna. V takih primerih trenda **ne objavimo** (letno štetje ostane prikazano), namesto da bi navedli navidezno natančno, a nezanesljivo številko. Enako velja, kadar je premalo let s podatki (potrebnih je vsaj 10). To je isto načelo kot pri indeksu suše SPEI: raje odklonimo objavo kot da objavimo negotovo vrednost.
+
 ## Znane omejitve
 
 - **Ni ARSO.** Vrednosti so reanaliza ERA5-Land, ne meritve postaj, in **niso neposredno primerljive** z objavami ARSO.
@@ -259,6 +265,7 @@ Primerjalni vzorec za vsak koledarski dan je **združeno okno ±7 dni** čez vsa
 - **ERA5-Land Tmin** je v mestih nezanesljiv (toplotni otok); zato stran privzeto ne vodi s Tmean/Tmin.
 - **Mrežna ločljivost** (~9 km) ne ujame lokalnih posebnosti pod to velikostjo.
 - **Najnovejše vrednosti** so lahko napoved (označene z »napoved«), dokler reanaliza ni na voljo.
+- **Trend tropskih dni/noči je približek** in ni na voljo za vse kombinacije praga in zaporedja: kjer se model ne ustali, trenda ne prikažemo (glej zgoraj).
 
 ---
 

--- a/code/ali-je-vroce-era5/i18n/sl.ts
+++ b/code/ali-je-vroce-era5/i18n/sl.ts
@@ -390,6 +390,14 @@ export const sl = {
     dir_less: "manj",
     plain: "{plainDesc} Postaja {station} kaže {sig}: grobe {dpd} {dir} {unit} na desetletje. {forward}",
     no_trend: "Premalo let z {instr} za izračun trenda ({count, plural, one{# leto} two{# leti} few{# leta} other{# let}} z vrednostjo > 0). Potrebnih je vsaj 10.",
+    // T-4.24 — a SECOND withhold reason. `no_trend` above is the honest message
+    // when there is too little data (<10 non-zero years). But the trend fit is now
+    // also withheld when the negative-binomial model does not converge or its
+    // covariance is unreliable (an ill-conditioned, near-flat series). Those series
+    // DO have enough years, so `no_trend`'s "at least 10 needed" would be false —
+    // showing "(45 z vrednostjo > 0). Potrebnih je vsaj 10." is self-contradictory.
+    // This message states the real reason without over-claiming.
+    no_trend_unreliable: "Trenda za to kombinacijo praga in zaporedja ni bilo mogoče zanesljivo oceniti (statistični model ni dal zanesljivega rezultata), zato ga ne prikazujemo. Letno štetje ostaja prikazano.",
     a11y: "Stolpčni prikaz letnega števila — {noun}, torej koliko {unit} na leto preseže izbrani temperaturni prag — z modelom trenda negativne binomske regresije in intervalom zaupanja; zadnji stolpec je leto v teku.",
   },
 

--- a/data/climate-si/sources/precompute_datasette.py
+++ b/data/climate-si/sources/precompute_datasette.py
@@ -598,6 +598,39 @@ def _tropical_trend(fit_years, fit_counts, years) -> dict:
         X_c    = sm.add_constant(years_arr - year_mean)
         fitted = sm.NegativeBinomial(fit_counts, X_c).fit(disp=False, maxiter=200)
 
+        # T-4.24: withhold on an UNTRUSTWORTHY fit, using the optimiser's own
+        # diagnostics — the convergence flag and whether the parameter covariance
+        # is finite and positive-definite. This is NOT a p-value threshold and NOT
+        # a perturbation test: the criterion is strictly "the optimiser did not
+        # produce a fit we can stand behind", judged by the fit itself.
+        #   Why this matters: for a handful of over-dispersed, near-flat count
+        # series the NB2 log-likelihood is almost flat in the slope, so BFGS does
+        # not converge and the Hessian is near-singular. Such a fit still yields
+        # numbers, but its p-value is meaningless — it swings across its whole
+        # range (0.0001 ↔ 0.9999) under a perturbation ten orders of magnitude
+        # below measurement precision, and that p drives a reader-facing
+        # significance verdict and whether a 2050 projection renders. So two builds
+        # of one commit could show a reader a different climate claim. We decline to
+        # publish a number we cannot stand behind — the same principle as D-16's
+        # SPEI withhold, applied to a second estimator. Reproducibility is pinned
+        # separately (BLAS/OpenMP threads fixed in the generate-db build), but that
+        # only makes the fit reproducible, not trustworthy; this gate is the real
+        # fix. A more robust estimator is the open follow-up (T-4.24 backlog note),
+        # not a v1 change.
+        #   NB: covariance singularity often surfaces instead as an exception in
+        # get_prediction() below (a LinAlgError caught by the except); this explicit
+        # check catches the arches/paths where the inverse comes back non-finite or
+        # non-PD without raising. Both routes end in the same {} withhold.
+        cov = np.asarray(fitted.cov_params(), dtype=float)
+        cov_ok = bool(np.all(np.isfinite(cov)))
+        if cov_ok:
+            cov_sym = 0.5 * (cov + cov.T)
+            cov_ok = bool(np.all(np.linalg.eigvalsh(cov_sym) > 0.0))
+        if not (bool(fitted.mle_retvals.get("converged", False)) and cov_ok):
+            reason = "did not converge" if not fitted.mle_retvals.get("converged", False) else "non-PD covariance"
+            print(f"  tropical NB fit withheld ({reason})", file=sys.stderr)
+            return {}
+
         x_dense = np.linspace(years[0], years[-1], len(years))
         X_dense = sm.add_constant(x_dense - year_mean)
         pred_df = fitted.get_prediction(X_dense).summary_frame(alpha=0.05)

--- a/data/climate-si/sources/tests/test_precompute.py
+++ b/data/climate-si/sources/tests/test_precompute.py
@@ -197,3 +197,94 @@ def test_spei_fit_success_returns_monotone_values(monkeypatch):
     assert result is not None
     assert len(result) == len(all_vals)
     assert all(result[i] <= result[i + 1] + 1e-9 for i in range(len(result) - 1))
+
+
+# ── Tropical NB trend withholds an UNTRUSTWORTHY fit (T-4.24) ─────────────────
+#
+# The fit is withheld — trend_json = {} — not only on too-little data (<10 non-zero
+# years) or an exception, but now also when the optimiser's OWN diagnostics say the
+# fit is not trustworthy: it did not converge, or its parameter covariance is not
+# finite/positive-definite. The criterion is deliberately NOT a p-value threshold
+# and NOT a perturbation test. These tests force each branch with a stubbed fit so
+# the gate is exercised without depending on a specific ill-conditioned series.
+
+
+class _StubFit:
+    def __init__(self, converged, cov):
+        self.mle_retvals = {"converged": converged}
+        self._cov = np.asarray(cov, dtype=float)
+
+    def cov_params(self):
+        return self._cov
+
+
+class _StubModel:
+    def __init__(self, converged, cov):
+        self._converged, self._cov = converged, cov
+
+    def fit(self, *a, **k):
+        return _StubFit(self._converged, self._cov)
+
+
+def _sufficient_series():
+    # Passes the <10-years / <10-nonzero insufficiency gate so the fit path runs.
+    years = list(range(2000, 2021))          # 21 years
+    counts = [c + 1 for c in range(21)]      # all non-zero, ascending
+    return years, counts
+
+
+def test_tropical_trend_withholds_when_not_converged(monkeypatch, capsys):
+    years, counts = _sufficient_series()
+    monkeypatch.setattr(
+        pc.sm, "NegativeBinomial",
+        lambda endog, exog: _StubModel(converged=False, cov=np.eye(3)),
+    )
+    result = pc._tropical_trend(years[:-1], counts[:-1], years)
+    assert result == {}, "a non-converged fit must be withheld, not published"
+    err = capsys.readouterr().err
+    assert "tropical NB fit withheld" in err and "did not converge" in err
+
+
+def test_tropical_trend_withholds_on_nonfinite_covariance(monkeypatch, capsys):
+    years, counts = _sufficient_series()
+    bad = np.eye(3); bad[0, 0] = np.nan
+    monkeypatch.setattr(
+        pc.sm, "NegativeBinomial",
+        lambda endog, exog: _StubModel(converged=True, cov=bad),
+    )
+    result = pc._tropical_trend(years[:-1], counts[:-1], years)
+    assert result == {}, "a non-finite covariance must be withheld"
+    assert "non-PD covariance" in capsys.readouterr().err
+
+
+def test_tropical_trend_withholds_on_non_pd_covariance(monkeypatch, capsys):
+    years, counts = _sufficient_series()
+    non_pd = np.array([[1.0, 0.0, 0.0], [0.0, -1.0, 0.0], [0.0, 0.0, 1.0]])  # neg eigenvalue
+    monkeypatch.setattr(
+        pc.sm, "NegativeBinomial",
+        lambda endog, exog: _StubModel(converged=True, cov=non_pd),
+    )
+    result = pc._tropical_trend(years[:-1], counts[:-1], years)
+    assert result == {}, "a non-positive-definite covariance must be withheld"
+    assert "non-PD covariance" in capsys.readouterr().err
+
+
+def test_tropical_trend_withholds_insufficient_data():
+    # <10 non-zero years -> withheld BEFORE any fit (the genuine-insufficiency path,
+    # unchanged by T-4.24). No stub: it must never reach the optimiser.
+    years = list(range(2000, 2021))
+    counts = [0] * 16 + [1, 2, 3, 4, 5]      # only 5 non-zero
+    assert pc._tropical_trend(years[:-1], counts[:-1], years) == {}
+
+
+def test_tropical_trend_success_returns_nb_model():
+    # Happy path: a realistic over-dispersed rising count series (the shape a real
+    # warming station shows) converges and publishes a trend. Hardcoded (no RNG) so
+    # the test is deterministic; a perfectly smooth series is degenerate for NB2
+    # (alpha -> 0) and would not converge — exactly the kind the gate now withholds.
+    years = list(range(1980, 2021))
+    counts = [4, 4, 5, 0, 5, 2, 7, 3, 8, 2, 7, 8, 3, 3, 7, 5, 5, 4, 13, 6, 6,
+              17, 8, 8, 4, 2, 15, 16, 18, 6, 13, 9, 12, 9, 10, 7, 9, 15, 13, 17, 31]
+    result = pc._tropical_trend(years[:-1], counts[:-1], years)
+    assert result.get("model_used") == "nb"
+    assert "p_value" in result and "rate_per_year" in result

--- a/deployment/Dockerfile.datasette
+++ b/deployment/Dockerfile.datasette
@@ -72,7 +72,20 @@ RUN ls -al /build/
 # still-committed emissions/temperature packages) exactly as before — building
 # var/sqlite and the datasette metadata/inspect files unchanged.
 RUN uv sync --project data/climate-si/sources --locked
+# T-4.24: pin BLAS/OpenMP to a single thread for the precompute. The tropical
+# negative-binomial trend fit is ill-conditioned for a few near-flat count series,
+# so its optimiser path is sensitive to floating-point reduction order — and with
+# multi-threaded OpenBLAS that order varies run-to-run on the SAME amd64 runner,
+# making `trend_json` non-reproducible between two builds of one commit (T-5.17
+# found this; two native-amd64 runs produced different trend_json hashes). Single
+# threaded, the reduction order is fixed and the build is reproducible. This is
+# NECESSARY but NOT sufficient — a reproducible fit can still be an untrustworthy
+# one, which is why _tropical_trend also withholds non-converged / singular fits.
+# generate-db is the ONLY place the numpy-heavy pipeline runs (T-5.9), so pinning
+# here covers every shipped value. The one-off cost is negligible at this data size.
 RUN DATA_DIR=/build/data/climate-si/data/raw \
+    OMP_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1 MKL_NUM_THREADS=1 \
+    NUMEXPR_NUM_THREADS=1 VECLIB_MAXIMUM_THREADS=1 \
     uv run --project data/climate-si/sources --no-sync \
         python data/climate-si/sources/precompute_datasette.py
 RUN DB_PATH=/build/data/climate-si/data/raw/climate-si.db \


### PR DESCRIPTION
This began as a reproducibility investigation and ended by removing eleven false
significance claims from the page.

All eleven non-converged negative-binomial fits were rendering a 2050 projection, ten of
them with p clamped to 0.0001 — maximally significant. The page was telling readers a
projection was statistically significant on the strength of a model that never converged.
Worst case: Nova Gorica nights at 22 C, +8.83 percent per year, 114 tropical nights by 2050.

The cause, proven rather than assumed: the NB2 likelihood is ill-conditioned — near-flat in
the slope, near-singular Hessian — with non-deterministic BLAS reduction order as the
carrier. Perturbing the optimiser start by a relative 1e-11 flipped ten series across the
withhold boundary and swung roughly seventeen p-values between the clamp floor and ceiling
while the rate barely moved. A p-value that traverses its entire range under a perturbation
ten orders below measurement precision is not a p-value. RNG, set ordering and threading as
a root cause were each ruled out by test.

Two changes. Thread pinning in the precompute step makes the build deterministic — necessary
but not sufficient, and the comment says so: pinning alone would freeze one arbitrary
optimiser trajectory as the published answer, turning a visible problem into an invisible
one. The substantive fix is that _tropical_trend now withholds when the fit is untrustworthy
by its own diagnostics: not converged, or a covariance that is non-finite or not
positive-definite. No p-value threshold, no perturbation test.

The frontend message was corrected too. Without it, a withheld series with 45 non-zero years
would have displayed the "fewer than 10 years" explanation, which is false. The new message
states that the computation did not produce a reliable result, never that the climate is
unclear.

METHODOLOGY.md and hero-content.ts move in the same commit, adding a section that names the
model, calls it an approximation, and ties the withhold to the same principle as the SPEI
withhold — this is that decision applied to a second estimator that had escaped it.

771 to 760 successful fits, exactly the eleven predicted rows now empty. The 389 genuine
insufficiency withholds are untouched. counts_json, years_json and nonzero_count are
byte-identical; the hash gate stays green with trend_json informational.

Note: no fixture moved and snapshot:check is identical, because none of the eleven series is
captured — the harness holds full grids for two stations only. That coverage gap is why they
shipped, and it is tracked separately.

Gates: pytest 67 to 72, validate.py 9 tables, validate_raw 18, typecheck:gate 0, yarn test
69, snapshot identical, hash gate green.
