### PR TITLE
T-5.26: one category vocabulary across the page

### DIFF
--- a/code/ali-je-vroce-era5/i18n/sl.ts
+++ b/code/ali-je-vroce-era5/i18n/sl.ts
@@ -15,7 +15,9 @@ import { climateRisks, heroContext } from "./hero-content.ts";
 // fmtSigned); "#" inside a plural form renders the grouped integer.
 //
 // ── FLAGGED FOR CONTENT REVIEW (not resolved here) ────────────────────────────
-//  • Register/wording: "Peklensko" / "Izjemna vročina" (today.cat_hell), the
+//  • Register/wording: the five category NAMES are now unified and neutral
+//    (T-5.26 / D-25 — "Zmrzujoče"/"Peklensko" RETIRED; see the CAT block below).
+//    Still flagged: the "Izjemna vročina" phrasing in today.desc_*_hell, and the
 //    "stoletni"/"Sto let" verdict framing (hero.verdict_*) overstating the ~76-yr
 //    record — both deferred from T-5.4a.
 //  • The governed-genitive numeral agreement in "povprečje/vseh {N} postaj" is
@@ -24,6 +26,34 @@ import { climateRisks, heroContext } from "./hero-content.ts";
 //    and a reasonable default otherwise. A native pass should confirm N=1,2.
 //  • Phrase-level English that was translated mechanically but may want polish:
 //    reg.no_data, reg.year_round_footer.
+
+// ── T-5.26 (D-25): the ONE category vocabulary ────────────────────────────────
+// The five percentile bands — split identically at p10/p20/p80/p95 by
+// `categorizeEra5` (api.ts) and the distribution zones (charts/) — are named in
+// exactly ONE place: here. Every consumer reads THESE five words:
+//   • the today card            (today.cat_*)
+//   • the "Zadnjih 7 dni" strip  (last7.cat_* — Y-axis + tooltip + a11y)
+//   • the distribution chart     (dist.zone_* — legend + tooltip)
+//   • the season heatmap         (season.cat_* — words + percentile-range suffix)
+// so the same band can never again be named two ways. T-5.21 found it named two
+// ways, with "Hladno" denoting DIFFERENT bands in the card vs the chart.
+//
+// Register is NEUTRAL by decision, not accident (D-25): a category label sits next
+// to a number where a measurement is expected, so the editorialising "Zmrzujoče"
+// (<p10) and "Peklensko" (>p95) are RETIRED in favour of the chart's plain words.
+// The page keeps its vivid framing where it belongs — in the title "Ali je vroče?".
+// A designer revisiting this should know the plain word was chosen ON PURPOSE.
+//
+// Keyed by percentile band, low→high. NOTE: the internal CategoryKey identifiers
+// (freezing/cold/nope/hot/hell in api.ts + CAT_COLORS) are band IDs, not the
+// display register — freezing→"Hladno", hell→"Ekstremno".
+const CAT = {
+  below_p10: "Hladno",     // < p10
+  p10_p20:   "Sveže",      // p10–p20
+  p20_p80:   "Normalno",   // p20–p80
+  p80_p95:   "Vroče",      // p80–p95
+  above_p95: "Ekstremno",  // > p95
+} as const;
 
 export const sl = {
   common: {
@@ -72,11 +102,13 @@ export const sl = {
     arso_group: "ARSO postaje",
     era5_group: "ERA5 postaje",
 
-    cat_freezing: "Zmrzujoče",
-    cat_cold: "Hladno",
-    cat_nope: "Normalno",
-    cat_hot: "Vroče",
-    cat_hell: "Peklensko",
+    // T-5.26/D-25: neutral labels from the single CAT source (freezing→"Hladno",
+    // hell→"Ekstremno"). The key names are the legacy CategoryKey band IDs.
+    cat_freezing: CAT.below_p10,
+    cat_cold: CAT.p10_p20,
+    cat_nope: CAT.p20_p80,
+    cat_hot: CAT.p80_p95,
+    cat_hell: CAT.above_p95,
 
     // ARSO cutoffs vs ERA5 record — kept as separate templates as in TodayCard.
     desc_arso_freezing: "Med najhladnejšimi {d} v naših zapisih ARSO.",
@@ -129,11 +161,13 @@ export const sl = {
 
   // DistributionChart
   dist: {
-    zone_cold: "Hladno",
-    zone_cool: "Sveže",
-    zone_normal: "Normalno",
-    zone_hot: "Vroče",
-    zone_extreme: "Ekstremno",
+    // T-5.26/D-25: from the single CAT source (unchanged words — the chart already
+    // used the neutral vocabulary; now it and the card share one definition).
+    zone_cold: CAT.below_p10,
+    zone_cool: CAT.p10_p20,
+    zone_normal: CAT.p20_p80,
+    zone_hot: CAT.p80_p95,
+    zone_extreme: CAT.above_p95,
     tooltip: "{temp} °C · {zone}",
     // T-5.21/T-5.22: second tooltip line — approximate frequency of days in the hovered
     // whole-degree bin. "približno" labels it as an estimate (the count rides on a
@@ -153,13 +187,15 @@ export const sl = {
 
   // TodayLast7Chart
   last7: {
-    cat_freezing: "Zmrzujoče",
-    cat_cold: "Hladno",
-    cat_nope: "Normalno",
-    cat_hot: "Vroče",
-    cat_hell: "Peklensko",
+    // T-5.26/D-25: neutral labels from the single CAT source (freezing→"Hladno",
+    // hell→"Ekstremno"), so the strip's Y-axis matches the card and the chart.
+    cat_freezing: CAT.below_p10,
+    cat_cold: CAT.p10_p20,
+    cat_nope: CAT.p20_p80,
+    cat_hot: CAT.p80_p95,
+    cat_hell: CAT.above_p95,
     tooltip: "{label}: {cat} · {temp} °C ({pct}. percentil)",
-    a11y: "Gibanje toplotne kategorije v zadnjih sedmih dneh — vsaka točka je en dan, uvrščen od zmrzujoče do peklensko glede na zgodovinske percentile.",
+    a11y: `Gibanje toplotne kategorije v zadnjih sedmih dneh — vsaka točka je en dan, uvrščen od ${CAT.below_p10.toLowerCase()} do ${CAT.above_p95.toLowerCase()} glede na zgodovinske percentile.`,
   },
 
   // TodayTrendChart (annual trend + projection)
@@ -259,11 +295,13 @@ export const sl = {
     label_Summer: "Poletje",
     label_Spring: "Pomlad",
     label_Winter: "Zima",
-    cat_cold: "Hladno (<10. pct)",
-    cat_cool: "Sveže (10–20. pct)",
-    cat_normal: "Normalno (20–80. pct)",
-    cat_hot: "Vroče (80–95. pct)",
-    cat_extreme: "Ekstremno (>95. pct)",
+    // T-5.26/D-25: the band word comes from the single CAT source; this surface
+    // appends the explicit percentile range. Same words as everywhere else.
+    cat_cold: `${CAT.below_p10} (<10. pct)`,
+    cat_cool: `${CAT.p10_p20} (10–20. pct)`,
+    cat_normal: `${CAT.p20_p80} (20–80. pct)`,
+    cat_hot: `${CAT.p80_p95} (80–95. pct)`,
+    cat_extreme: `${CAT.above_p95} (>95. pct)`,
     mode_all: "Vse letne čase",
     mode_extremes: "Samo ekstremi",
     anim_stop: "⏹ Ustavi",

--- a/tests/fixtures/snapshot.json
+++ b/tests/fixtures/snapshot.json
@@ -35407,11 +35407,11 @@
               "min": 0,
               "max": 4,
               "categories": [
-                "Zmrzujoče",
                 "Hladno",
+                "Sveže",
                 "Normalno",
                 "Vroče",
-                "Peklensko"
+                "Ekstremno"
               ],
               "plot_lines": [],
               "plot_bands": [
@@ -35503,7 +35503,7 @@
                     "y": 3
                   },
                   {
-                    "catName": "Peklensko",
+                    "catName": "Ekstremno",
                     "color": "#962c1a",
                     "label": "15.07",
                     "pct": 97.5,
@@ -38896,11 +38896,11 @@
               "min": 0,
               "max": 4,
               "categories": [
-                "Zmrzujoče",
                 "Hladno",
+                "Sveže",
                 "Normalno",
                 "Vroče",
-                "Peklensko"
+                "Ekstremno"
               ],
               "plot_lines": [],
               "plot_bands": [
@@ -42347,7 +42347,7 @@
               "Kredarica"
             ]
           },
-          "category_label": "Peklensko",
+          "category_label": "Ekstremno",
           "category_color": "rgb(150, 44, 26)",
           "description": "Izjemna vročina — med najtoplejšimi 5 % vseh 29. jul. od 1950.",
           "percentile": "97",
@@ -45705,7 +45705,7 @@
               "Kredarica"
             ]
           },
-          "category_label": "Peklensko",
+          "category_label": "Ekstremno",
           "category_color": "rgb(150, 44, 26)",
           "description": "Izjemna vročina — med najtoplejšimi 5 % vseh 29. jul. od 1950.",
           "percentile": "99",
@@ -45803,11 +45803,11 @@
               "min": 0,
               "max": 4,
               "categories": [
-                "Zmrzujoče",
                 "Hladno",
+                "Sveže",
                 "Normalno",
                 "Vroče",
-                "Peklensko"
+                "Ekstremno"
               ],
               "plot_lines": [],
               "plot_bands": [
@@ -49254,7 +49254,7 @@
               "Kredarica"
             ]
           },
-          "category_label": "Peklensko",
+          "category_label": "Ekstremno",
           "category_color": "rgb(150, 44, 26)",
           "description": "Izjemna vročina — med najtoplejšimi 5 % vseh 29. jul. od 1950.",
           "percentile": "95",
@@ -49352,11 +49352,11 @@
               "min": 0,
               "max": 4,
               "categories": [
-                "Zmrzujoče",
                 "Hladno",
+                "Sveže",
                 "Normalno",
                 "Vroče",
-                "Peklensko"
+                "Ekstremno"
               ],
               "plot_lines": [],
               "plot_bands": [
@@ -56259,11 +56259,11 @@
               "min": 0,
               "max": 4,
               "categories": [
-                "Zmrzujoče",
                 "Hladno",
+                "Sveže",
                 "Normalno",
                 "Vroče",
-                "Peklensko"
+                "Ekstremno"
               ],
               "plot_lines": [],
               "plot_bands": [
@@ -59808,11 +59808,11 @@
               "min": 0,
               "max": 4,
               "categories": [
-                "Zmrzujoče",
                 "Hladno",
+                "Sveže",
                 "Normalno",
                 "Vroče",
-                "Peklensko"
+                "Ekstremno"
               ],
               "plot_lines": [],
               "plot_bands": [
@@ -59877,7 +59877,7 @@
                     "y": 2
                   },
                   {
-                    "catName": "Hladno",
+                    "catName": "Sveže",
                     "color": "#6c8fb6",
                     "label": "12.07",
                     "pct": 15,
@@ -59904,7 +59904,7 @@
                     "y": 2
                   },
                   {
-                    "catName": "Hladno",
+                    "catName": "Sveže",
                     "color": "#6c8fb6",
                     "label": "09.07",
                     "pct": 15,
@@ -65903,11 +65903,11 @@
               "min": 0,
               "max": 4,
               "categories": [
-                "Zmrzujoče",
                 "Hladno",
+                "Sveže",
                 "Normalno",
                 "Vroče",
-                "Peklensko"
+                "Ekstremno"
               ],
               "plot_lines": [],
               "plot_bands": [
@@ -69443,11 +69443,11 @@
               "min": 0,
               "max": 4,
               "categories": [
-                "Zmrzujoče",
                 "Hladno",
+                "Sveže",
                 "Normalno",
                 "Vroče",
-                "Peklensko"
+                "Ekstremno"
               ],
               "plot_lines": [],
               "plot_bands": [
@@ -72992,11 +72992,11 @@
               "min": 0,
               "max": 4,
               "categories": [
-                "Zmrzujoče",
                 "Hladno",
+                "Sveže",
                 "Normalno",
                 "Vroče",
-                "Peklensko"
+                "Ekstremno"
               ],
               "plot_lines": [],
               "plot_bands": [
@@ -76541,11 +76541,11 @@
               "min": 0,
               "max": 4,
               "categories": [
-                "Zmrzujoče",
                 "Hladno",
+                "Sveže",
                 "Normalno",
                 "Vroče",
-                "Peklensko"
+                "Ekstremno"
               ],
               "plot_lines": [],
               "plot_bands": [
@@ -80090,11 +80090,11 @@
               "min": 0,
               "max": 4,
               "categories": [
-                "Zmrzujoče",
                 "Hladno",
+                "Sveže",
                 "Normalno",
                 "Vroče",
-                "Peklensko"
+                "Ekstremno"
               ],
               "plot_lines": [],
               "plot_bands": [
@@ -83533,7 +83533,7 @@
               "Kredarica"
             ]
           },
-          "category_label": "Peklensko",
+          "category_label": "Ekstremno",
           "category_color": "rgb(150, 44, 26)",
           "description": "Izjemna vročina — med najtoplejšimi 5 % vseh 3. avg. od 1950.",
           "percentile": "99",
@@ -83631,11 +83631,11 @@
               "min": 0,
               "max": 4,
               "categories": [
-                "Zmrzujoče",
                 "Hladno",
+                "Sveže",
                 "Normalno",
                 "Vroče",
-                "Peklensko"
+                "Ekstremno"
               ],
               "plot_lines": [],
               "plot_bands": [
@@ -83673,7 +83673,7 @@
                 "type": "line",
                 "data": [
                   {
-                    "catName": "Peklensko",
+                    "catName": "Ekstremno",
                     "color": "#962c1a",
                     "label": "03.08",
                     "pct": 97.5,
@@ -83682,7 +83682,7 @@
                     "y": 4
                   },
                   {
-                    "catName": "Peklensko",
+                    "catName": "Ekstremno",
                     "color": "#962c1a",
                     "label": "02.08",
                     "pct": 97.5,
@@ -83718,7 +83718,7 @@
                     "y": 2
                   },
                   {
-                    "catName": "Peklensko",
+                    "catName": "Ekstremno",
                     "color": "#962c1a",
                     "label": "29.07",
                     "pct": 97.5,
@@ -83727,7 +83727,7 @@
                     "y": 4
                   },
                   {
-                    "catName": "Peklensko",
+                    "catName": "Ekstremno",
                     "color": "#962c1a",
                     "label": "28.07",
                     "pct": 97.5,
@@ -87074,7 +87074,7 @@
               "Kredarica"
             ]
           },
-          "category_label": "Peklensko",
+          "category_label": "Ekstremno",
           "category_color": "rgb(150, 44, 26)",
           "description": "Izjemna vročina — med najtoplejšimi 5 % vseh 3. avg. od 1950.",
           "percentile": "100",
@@ -87172,11 +87172,11 @@
               "min": 0,
               "max": 4,
               "categories": [
-                "Zmrzujoče",
                 "Hladno",
+                "Sveže",
                 "Normalno",
                 "Vroče",
-                "Peklensko"
+                "Ekstremno"
               ],
               "plot_lines": [],
               "plot_bands": [
@@ -87214,7 +87214,7 @@
                 "type": "line",
                 "data": [
                   {
-                    "catName": "Peklensko",
+                    "catName": "Ekstremno",
                     "color": "#962c1a",
                     "label": "03.08",
                     "pct": 97.5,
@@ -87223,7 +87223,7 @@
                     "y": 4
                   },
                   {
-                    "catName": "Peklensko",
+                    "catName": "Ekstremno",
                     "color": "#962c1a",
                     "label": "02.08",
                     "pct": 97.5,
@@ -87259,7 +87259,7 @@
                     "y": 2
                   },
                   {
-                    "catName": "Peklensko",
+                    "catName": "Ekstremno",
                     "color": "#962c1a",
                     "label": "29.07",
                     "pct": 97.5,
@@ -87268,7 +87268,7 @@
                     "y": 4
                   },
                   {
-                    "catName": "Peklensko",
+                    "catName": "Ekstremno",
                     "color": "#962c1a",
                     "label": "28.07",
                     "pct": 97.5,
@@ -90615,7 +90615,7 @@
               "Kredarica"
             ]
           },
-          "category_label": "Zmrzujoče",
+          "category_label": "Hladno",
           "category_color": "rgb(58, 90, 138)",
           "description": "Med najhladnejšimi 7. feb. v naših 77 letih zapisov.",
           "percentile": "3",
@@ -90713,11 +90713,11 @@
               "min": 0,
               "max": 4,
               "categories": [
-                "Zmrzujoče",
                 "Hladno",
+                "Sveže",
                 "Normalno",
                 "Vroče",
-                "Peklensko"
+                "Ekstremno"
               ],
               "plot_lines": [],
               "plot_bands": [
@@ -90755,7 +90755,7 @@
                 "type": "line",
                 "data": [
                   {
-                    "catName": "Zmrzujoče",
+                    "catName": "Hladno",
                     "color": "#3a5a8a",
                     "label": "07.02",
                     "pct": 5,
@@ -90764,7 +90764,7 @@
                     "y": 0
                   },
                   {
-                    "catName": "Zmrzujoče",
+                    "catName": "Hladno",
                     "color": "#3a5a8a",
                     "label": "06.02",
                     "pct": 5,
@@ -90773,7 +90773,7 @@
                     "y": 0
                   },
                   {
-                    "catName": "Zmrzujoče",
+                    "catName": "Hladno",
                     "color": "#3a5a8a",
                     "label": "05.02",
                     "pct": 5,
@@ -90782,7 +90782,7 @@
                     "y": 0
                   },
                   {
-                    "catName": "Zmrzujoče",
+                    "catName": "Hladno",
                     "color": "#3a5a8a",
                     "label": "04.02",
                     "pct": 5,
@@ -90791,7 +90791,7 @@
                     "y": 0
                   },
                   {
-                    "catName": "Zmrzujoče",
+                    "catName": "Hladno",
                     "color": "#3a5a8a",
                     "label": "03.02",
                     "pct": 5,
@@ -90800,7 +90800,7 @@
                     "y": 0
                   },
                   {
-                    "catName": "Zmrzujoče",
+                    "catName": "Hladno",
                     "color": "#3a5a8a",
                     "label": "02.02",
                     "pct": 5,
@@ -90809,7 +90809,7 @@
                     "y": 0
                   },
                   {
-                    "catName": "Zmrzujoče",
+                    "catName": "Hladno",
                     "color": "#3a5a8a",
                     "label": "01.02",
                     "pct": 5,
@@ -94177,7 +94177,7 @@
               "Kredarica"
             ]
           },
-          "category_label": "Zmrzujoče",
+          "category_label": "Hladno",
           "category_color": "rgb(58, 90, 138)",
           "description": "Med najhladnejšimi 7. jan. v naših 77 letih zapisov.",
           "percentile": "0",
@@ -94275,11 +94275,11 @@
               "min": 0,
               "max": 4,
               "categories": [
-                "Zmrzujoče",
                 "Hladno",
+                "Sveže",
                 "Normalno",
                 "Vroče",
-                "Peklensko"
+                "Ekstremno"
               ],
               "plot_lines": [],
               "plot_bands": [
@@ -94317,7 +94317,7 @@
                 "type": "line",
                 "data": [
                   {
-                    "catName": "Zmrzujoče",
+                    "catName": "Hladno",
                     "color": "#3a5a8a",
                     "label": "07.01",
                     "pct": 5,
@@ -94326,7 +94326,7 @@
                     "y": 0
                   },
                   {
-                    "catName": "Zmrzujoče",
+                    "catName": "Hladno",
                     "color": "#3a5a8a",
                     "label": "06.01",
                     "pct": 5,
@@ -94335,7 +94335,7 @@
                     "y": 0
                   },
                   {
-                    "catName": "Zmrzujoče",
+                    "catName": "Hladno",
                     "color": "#3a5a8a",
                     "label": "05.01",
                     "pct": 5,
@@ -94344,7 +94344,7 @@
                     "y": 0
                   },
                   {
-                    "catName": "Zmrzujoče",
+                    "catName": "Hladno",
                     "color": "#3a5a8a",
                     "label": "04.01",
                     "pct": 5,
@@ -94353,7 +94353,7 @@
                     "y": 0
                   },
                   {
-                    "catName": "Zmrzujoče",
+                    "catName": "Hladno",
                     "color": "#3a5a8a",
                     "label": "03.01",
                     "pct": 5,
@@ -94362,7 +94362,7 @@
                     "y": 0
                   },
                   {
-                    "catName": "Hladno",
+                    "catName": "Sveže",
                     "color": "#6c8fb6",
                     "label": "02.01",
                     "pct": 15,
@@ -94371,7 +94371,7 @@
                     "y": 1
                   },
                   {
-                    "catName": "Zmrzujoče",
+                    "catName": "Hladno",
                     "color": "#3a5a8a",
                     "label": "01.01",
                     "pct": 5,


### PR DESCRIPTION
One category vocabulary across the page: Hladno / Sveže / Normalno / Vroče / Ekstremno.
Zmrzujoče and Peklensko are retired.

The defect: the same five percentile bands, split identically at p10/p20/p80/p95, were named
two ways — and "Hladno" meant the band below p10 in the chart but the band from p10 to p20 in
the today card. One word for two states, two words for one state.

The deciding argument was register rather than consistency. Peklensko editorialises on a page
whose credibility rests on not editorialising. A reader sceptical of climate change who meets
that word may reasonably read the page as arguing rather than reporting — and then the
disclosed Kredarica correction, the forecast labelling and the withheld trends stop reading
as honesty and start reading as decoration. Ekstremno says the same thing without the value
judgement. Recorded as D-25.

Step 1 found four consumers, not the two the ticket named: the today card, the distribution
chart, the last-7 strip (y-axis, tooltip and accessibility prose) and the season heatmap.
Plus a prose line reading "od zmrzujoče do peklensko" — the kind of sentence that survives a
rename and is left describing words that no longer exist.

The four lists were independent literals agreeing by coincidence. Rather than editing four
lists to match, there is now one authoritative source keyed by percentile band that all four
read, so they cannot diverge again.

Colours were the risk and are safe: the colour map is keyed by the band enum, never by label
string, so renaming moved no colour.

Snapshot: 60 leaves moved, all category strings, zero numeric. Re-recorded in the same commit.

Gates: typecheck 0, typecheck:gate 0 allowlisted, yarn test 69, snapshot clean, pytest 72.
