### PR TITLE
T-5.28: calendar picker on the day-of-year control

### DIFF
--- a/code/ali-je-vroce-era5/api.ts
+++ b/code/ali-je-vroce-era5/api.ts
@@ -185,6 +185,13 @@ function assertNationalStationRows(rows: readonly unknown[], table: string): voi
 }
 
 
+// T-5.28: day counts per month on the FIXED non-leap 2001 calendar the DOY helpers
+// walk. February keeps 29 so the leap day is SELECTABLE in the calendar picker —
+// monthDayToDoy(2,29) folds it to DOY 59 (28 Feb's slot, D-12). Lives here beside the
+// DOY conversions so "the shape of the year" has one home and can be unit-tested
+// without mounting the Solid island (tests/unit/doy.test.ts).
+export const MONTH_LEN = [31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31] as const;
+
 export function doyToMonthDay(doy: number): { month: number; day: number } {
   const d = new Date(Date.UTC(2001, 0, 1));
   d.setUTCDate(d.getUTCDate() + doy - 1);

--- a/code/ali-je-vroce-era5/components/RegressionPanel.tsx
+++ b/code/ali-je-vroce-era5/components/RegressionPanel.tsx
@@ -3,9 +3,10 @@ import { createSignal, createResource, createEffect, createMemo, createContext, 
 import type { JSXElement } from "solid-js";
 import type { SiteMeta } from "../types.ts";
 import type { RegressionParams } from "../api.ts";
-import { fetchRegression, fetchCalendar, varLabel as varLabelOf } from "../api.ts";
+import { fetchRegression, fetchCalendar, varLabel as varLabelOf,
+         monthDayToDoy, doyToMonthDay, MONTH_LEN } from "../api.ts";
 import { sectionErrorFallback } from "./SectionError.tsx";
-import { t, fmtSigned, fmtDoy } from "../i18n/format.ts";
+import { t, fmtSigned, fmtDoy, fmtMonthLong } from "../i18n/format.ts";
 
 const RegressionChart = lazy(() => import("../charts/RegressionChart.tsx").then(m => ({ default: m.RegressionChart })));
 const YearRoundChart  = lazy(() => import("../charts/YearRoundChart.tsx").then(m => ({ default: m.YearRoundChart })));
@@ -28,6 +29,10 @@ interface ProviderProps {
 function doyToLabel(doy: number): string {
   return fmtDoy(doy);
 }
+
+// T-5.28 — the calendar picker sizes each month's day grid from MONTH_LEN (api.ts).
+// No weekday columns: the control has no year, so weekday alignment would be arbitrary
+// and would misrepresent a day-of-year selection as a dated day.
 
 // ── Store factory ─────────────────────────────────────────────────────────────
 
@@ -123,6 +128,64 @@ export function RegressionPanel(props: ProviderProps) {
 
 export function RegToolbar() {
   const s = useReg();
+
+  // ── Calendar picker state (T-5.28) ─────────────────────────────────────────
+  const [calOpen,    setCalOpen]    = createSignal(false);
+  const [calMonth,   setCalMonth]   = createSignal(1);   // 1..12 shown in the grid
+  const [focusedDay, setFocusedDay] = createSignal(1);   // roving-tabindex day
+  let triggerRef: HTMLDivElement | undefined;
+  const dayRefs: (HTMLButtonElement | undefined)[] = [];
+
+  const openCal = () => {
+    const { month, day } = doyToMonthDay(s.doy());
+    setCalMonth(month);
+    setFocusedDay(day);
+    setCalOpen(true);
+  };
+  const closeCal = (returnFocus: boolean) => {
+    setCalOpen(false);
+    if (returnFocus) triggerRef?.focus();
+  };
+  const selectDay = (day: number) => {
+    s.setDoy(monthDayToDoy(calMonth(), day));
+    closeCal(true);
+  };
+  const stepMonth = (delta: number) => {
+    const m = ((calMonth() - 1 + delta + 12) % 12) + 1;  // wrap 1..12 (yearless)
+    setCalMonth(m);
+    setFocusedDay(d => Math.min(d, MONTH_LEN[m - 1]!));
+  };
+
+  // Move DOM focus to the roving day button whenever the target day, the month, or
+  // open-state changes (the grid re-renders on month change, so refs are rebuilt).
+  createEffect(() => {
+    if (calOpen()) dayRefs[focusedDay()]?.focus();
+  });
+
+  const onTriggerKey = (e: KeyboardEvent) => {
+    if (e.key === "Enter" || e.key === " " || e.key === "ArrowDown") {
+      e.preventDefault();
+      openCal();
+    }
+  };
+  const onGridKey = (e: KeyboardEvent) => {
+    const len = MONTH_LEN[calMonth() - 1]!;
+    const d = focusedDay();
+    switch (e.key) {
+      case "ArrowRight": e.preventDefault(); setFocusedDay(Math.min(len, d + 1)); break;
+      case "ArrowLeft":  e.preventDefault(); setFocusedDay(Math.max(1, d - 1));   break;
+      case "ArrowDown":  e.preventDefault(); setFocusedDay(Math.min(len, d + 7)); break;
+      case "ArrowUp":    e.preventDefault(); setFocusedDay(Math.max(1, d - 7));   break;
+      case "Home":       e.preventDefault(); setFocusedDay(1);   break;
+      case "End":        e.preventDefault(); setFocusedDay(len); break;
+      case "PageUp":     e.preventDefault(); stepMonth(-1); break;
+      case "PageDown":   e.preventDefault(); stepMonth(1);  break;
+      case "Enter":
+      case " ":          e.preventDefault(); selectDay(focusedDay()); break;
+      case "Escape":     e.preventDefault(); closeCal(true); break;
+    }
+  };
+
   return (
     <div class="reg-toolbar">
 
@@ -188,8 +251,62 @@ export function RegToolbar() {
       {/* DOY control */}
       <div class="reg-doy-ctrl">
         <span style={{ "font-family": "var(--font-mono)", "font-size": "9px", "letter-spacing": "0.12em", "text-transform": "uppercase", color: "var(--color-ink-soft)", "white-space": "nowrap" }}>{t("reg.day")}</span>
-        <div style={{ "font-family": "var(--font-mono)", "font-weight": "600", "font-size": "13px", background: "var(--color-card)", border: "1px solid var(--color-rule-2)", "border-radius": "7px", padding: "4px 10px", "min-width": "60px", "text-align": "center", "white-space": "nowrap" }}>
-          {s.doyToLabel(s.doy())}
+        {/* T-5.28: the "1. avg." display doubles as the calendar trigger. Kept a
+            <div role="button"> (not a native <button>) so it stays the first
+            `.reg-doy-ctrl > div` the snapshot reads as `day_label`; the popover is a
+            SIBLING of the trigger, never a descendant (no button-in-button). */}
+        <div class="reg-doy-label">
+          <div
+            ref={triggerRef}
+            class="reg-doy-value"
+            role="button"
+            tabindex="0"
+            aria-haspopup="dialog"
+            aria-expanded={calOpen()}
+            aria-label={t("reg.pick_day")}
+            onClick={() => (calOpen() ? closeCal(false) : openCal())}
+            onKeyDown={onTriggerKey}
+          >
+            {s.doyToLabel(s.doy())}
+          </div>
+          <Show when={calOpen()}>
+            <div
+              class="reg-cal-pop"
+              role="dialog"
+              aria-label={t("reg.calendar")}
+              onKeyDown={(e) => { if (e.key === "Escape") { e.preventDefault(); closeCal(true); } }}
+            >
+              <div class="reg-cal-head">
+                <button type="button" class="reg-cal-nav" aria-label={t("reg.prev_month")} onClick={() => stepMonth(-1)}>◀</button>
+                <span class="reg-cal-title">{fmtMonthLong(calMonth())}</span>
+                <button type="button" class="reg-cal-nav" aria-label={t("reg.next_month")} onClick={() => stepMonth(1)}>▶</button>
+              </div>
+              <div class="reg-cal-grid" onKeyDown={onGridKey}>
+                <For each={Array.from({ length: MONTH_LEN[calMonth() - 1]! }, (_, i) => i + 1)}>
+                  {(day) => {
+                    const selected = () => {
+                      const md = doyToMonthDay(s.doy());
+                      return md.month === calMonth() && md.day === day;
+                    };
+                    return (
+                      <button
+                        type="button"
+                        ref={(el) => (dayRefs[day] = el)}
+                        class="reg-cal-day"
+                        aria-label={`${day}. ${fmtMonthLong(calMonth())}`}
+                        aria-pressed={selected()}
+                        tabindex={focusedDay() === day ? 0 : -1}
+                        onClick={() => selectDay(day)}
+                      >
+                        {day}
+                      </button>
+                    );
+                  }}
+                </For>
+              </div>
+            </div>
+            <div style={{ position: "fixed", inset: "0", "z-index": "9" }} onClick={() => closeCal(false)} />
+          </Show>
         </div>
         <div class="reg-doy-slider">
           <input

--- a/code/ali-je-vroce-era5/i18n/format.ts
+++ b/code/ali-je-vroce-era5/i18n/format.ts
@@ -65,11 +65,31 @@ export function fmtSigned(n: number, digits = 2): string {
   return nf({ minimumFractionDigits: digits, maximumFractionDigits: digits, signDisplay: "always" }).format(preRound(n, digits));
 }
 
+// ── The i18n boundary (D-8, refined T-5.28) ─────────────────────────────────────
+// DATE and NUMBER formatting comes from `Intl` under the `sl-SI` locale (the
+// helpers below and the `Intl.NumberFormat` cache above) — this is the SOLE source
+// of every Slovenian month name, weekday, decimal comma and thousands separator on
+// the page, and it is deliberate (T-5.5 operator decision). ALL OTHER Slovenian
+// prose lives in `i18n/sl.ts`. So a month name generated here is NOT a D-8 bypass to
+// be "fixed" by hand-typing it into the catalogue: doing that would create a second
+// source of truth for the same twelve words, free to diverge with nothing comparing
+// them (the failure D-18 and T-5.26 exist to prevent). Extend the locale surface by
+// adding a helper HERE (one place, several callers), never by calling `Intl` inline
+// in a component.
+
 const dtMonthShort = new Intl.DateTimeFormat(LOCALE, { month: "short" });
 
 /** Slovenian short month name for a 1..12 month, e.g. 7 → "jul.". */
 export function fmtMonthShort(month: number): string {
   return dtMonthShort.format(new Date(2001, month - 1, 1));
+}
+
+const dtMonthLong = new Intl.DateTimeFormat(LOCALE, { month: "long" });
+
+/** Slovenian full month name for a 1..12 month, e.g. 8 → "avgust". Slovenian
+ * months are lowercase; capitalise for a heading with CSS, not string surgery. */
+export function fmtMonthLong(month: number): string {
+  return dtMonthLong.format(new Date(2001, month - 1, 1));
 }
 
 const dtShort = new Intl.DateTimeFormat(LOCALE, { day: "numeric", month: "short" });

--- a/code/ali-je-vroce-era5/i18n/sl.ts
+++ b/code/ali-je-vroce-era5/i18n/sl.ts
@@ -223,6 +223,12 @@ export const sl = {
     select_locations: "Izberite lokacije (največ 6)",
     variable: "Spremenljivka",
     day: "Dan",
+    // T-5.28 — accessible names for the day-of-year calendar picker. The month and
+    // day NAMES come from Intl (i18n/format.ts); only this framing prose is here.
+    pick_day: "Izberi dan v letu",
+    calendar: "Koledar — izbira dneva v letu",
+    prev_month: "Prejšnji mesec",
+    next_month: "Naslednji mesec",
     locations_multi: "{count, plural, one{# lokacija} two{# lokaciji} few{# lokacije} other{# lokacij}}",
 
     years_sig: "{count, plural, one{# leto} two{# leti} few{# leta} other{# let}} · {sig}",

--- a/styles/era5.css
+++ b/styles/era5.css
@@ -214,6 +214,24 @@
 .reg-doy-ctrl   { display: flex; align-items: center; gap: 8px; padding: 4px 4px 4px 10px; border-radius: 10px; background: var(--color-paper); height: 36px; }
 .reg-doy-slider { height: 28px; background: var(--color-card); border: 1px solid var(--color-rule-2); border-radius: 7px; display: flex; align-items: center; padding: 0 8px; width: 180px; }
 
+/* ── T-5.28: day-of-year calendar picker ─────────────────────────────────────
+   Opens from the "1. avg." label; a yearless month + day-number grid (no weekday
+   columns — the control selects a day-of-year, not a dated day). No transition, so
+   there is nothing for prefers-reduced-motion to suppress (T-5.15). */
+.reg-doy-label  { position: relative; }
+.reg-doy-value  { font-family: var(--font-mono); font-weight: 600; font-size: 13px; background: var(--color-card); border: 1px solid var(--color-rule-2); border-radius: 7px; padding: 4px 10px; min-width: 60px; text-align: center; white-space: nowrap; cursor: pointer; }
+.reg-doy-value:focus-visible { outline: 2px solid var(--color-accent); outline-offset: 1px; }
+.reg-cal-pop    { position: absolute; top: calc(100% + 6px); left: 50%; transform: translateX(-50%); z-index: 10; background: var(--color-card); border: 1px solid var(--color-rule-2); border-radius: var(--radius, 10px); box-shadow: 0 8px 24px rgba(14, 14, 12, 0.12); padding: 10px; width: 236px; }
+.reg-cal-head   { display: flex; align-items: center; justify-content: space-between; margin-bottom: 8px; }
+.reg-cal-title  { font-family: var(--font-sans); font-size: 13px; font-weight: 600; color: var(--color-ink); text-transform: capitalize; }
+.reg-cal-nav    { display: inline-grid; place-items: center; width: 24px; height: 24px; border-radius: 6px; border: 1px solid var(--color-rule); background: var(--color-card); cursor: pointer; color: var(--color-ink); font-size: 10px; }
+.reg-cal-nav:focus-visible { outline: 2px solid var(--color-accent); outline-offset: 1px; }
+.reg-cal-grid   { display: grid; grid-template-columns: repeat(7, 1fr); gap: 3px; }
+.reg-cal-day    { aspect-ratio: 1; border: 1px solid transparent; border-radius: 6px; background: var(--color-paper); cursor: pointer; font-family: var(--font-mono); font-size: 11px; color: var(--color-ink); display: grid; place-items: center; }
+.reg-cal-day:hover { background: var(--color-paper-2); }
+.reg-cal-day:focus-visible { outline: 2px solid var(--color-accent); outline-offset: 1px; }
+.reg-cal-day[aria-pressed="true"] { background: var(--color-ink); color: #fff; border-color: var(--color-ink); }
+
 @media (max-width: 700px) {
   .main-row { grid-template-columns: 1fr; padding: 10px 14px 0; }
   .reg-card--cal { margin: 10px 14px 0; }

--- a/tests/unit/doy.test.ts
+++ b/tests/unit/doy.test.ts
@@ -4,7 +4,7 @@
 // calls delegateEvents() at load); moving it here removed that coupling.
 import { describe, expect, it } from "vitest";
 
-import { dateToDoy, monthDayToDoy, doyToMonthDay } from "../../code/ali-je-vroce-era5/api.ts";
+import { dateToDoy, monthDayToDoy, doyToMonthDay, MONTH_LEN } from "../../code/ali-je-vroce-era5/api.ts";
 
 // T-4.5 — day-of-year conversions, AFTER the leap-year fix. The island now uses ONE
 // convention: a FIXED non-leap 365-slot year, with 29 Feb folded into 28 Feb / DOY 59
@@ -108,5 +108,37 @@ describe("FIXED round-trip (T-4.5): non-leap forward + non-leap inverse agree", 
   it("sends 2024-02-29 (leap day) to 28 February (D-12 fold)", () => {
     const doy = dateToDoy("2024-02-29"); // 59
     expect(doyToMonthDay(doy)).toEqual({ month: 2, day: 28 });
+  });
+});
+
+// T-5.28 — the calendar picker sizes each month's day grid from MONTH_LEN and maps a
+// clicked (month, day) straight through monthDayToDoy. These pin the two things the
+// operator flagged: February must offer 29 days (and not error), and no month may
+// offer a day it doesn't have (no "31 April"). Values hand-computed, not read back.
+describe("MONTH_LEN — the picker's per-month day counts (T-5.28)", () => {
+  it("is 12 months, February 29, summing to 366 (leap day selectable)", () => {
+    expect(MONTH_LEN.length).toBe(12);
+    expect(MONTH_LEN[1]).toBe(29);
+    expect(MONTH_LEN.reduce((a, b) => a + b, 0)).toBe(366);
+  });
+
+  it("gives 30 days to April, June, September, November (no 31st offered)", () => {
+    for (const m of [4, 6, 9, 11]) expect(MONTH_LEN[m - 1]).toBe(30);
+  });
+
+  it("every selectable (month, day) maps to a valid 1..365 DOY", () => {
+    for (let m = 1; m <= 12; m++) {
+      for (let day = 1; day <= MONTH_LEN[m - 1]!; day++) {
+        const doy = monthDayToDoy(m, day);
+        expect(doy).toBeGreaterThanOrEqual(1);
+        expect(doy).toBeLessThanOrEqual(365);
+      }
+    }
+  });
+
+  it("selecting 29 February does not error and folds to DOY 59, like 28 February", () => {
+    // The exact path a Feb-29 click walks: monthDayToDoy(calMonth=2, day=29).
+    expect(monthDayToDoy(2, 29)).toBe(59);
+    expect(monthDayToDoy(2, 28)).toBe(59);
   });
 });


### PR DESCRIPTION
Adds a calendar picker to the existing day-of-year control. Hand-built, no new dependency.

The control is yearless — it selects a day-of-year, not a date — so the calendar is a month
plus day-number grid with no weekday columns. Weekday alignment would require inventing a
reference year and would communicate something false: that the reader is picking a specific
dated day, when the page pools a seven-day window across 77 years and weekday bears on
nothing displayed.

Month names reuse the existing Intl helper rather than being hand-typed into the catalogue.
Investigation found that Intl.DateTimeFormat with the sl-SI locale is already the sole source
of every Slovenian month name on the page, so adding twelve strings would have created two
sources of truth for the same words. The i18n boundary is now documented in format.ts: dates
and numbers come from Intl, all other prose from the catalogue.

A unit test caught April having 31 days before this shipped, which shifted March through
June. MONTH_LEN now lives beside the day-of-year conversions so it is testable without
mounting the island.

Verified live rather than asserted: February shows 29 days, selecting the 29th produces no
error and folds to day-of-year 59 as the leap-day decision requires. Keyboard flow checked
end to end — open, navigate with arrows and Home/End/PageUp/PageDown including December to
January wrap, select, dismiss, and focus returns to the trigger.

No URL state added; shareable links are tracked separately. No CSS transition, so nothing to
gate on reduced-motion preference.

Snapshot byte-identical: the label remains the element the harness reads and the popover is
closed by default, so no rendered text moves.

Gates: typecheck 0, typecheck:gate 0 allowlisted, yarn test 69 to 73, snapshot identical,
pytest 72.

Note: popover placement in the real page and touch behaviour still need checking on stage —
PR previews do not currently deploy.
