### PR TITLE
T-5.32: year-aware calendar picker on the hero date control

### DIFF
--- a/code/ali-je-vroce-era5/api.ts
+++ b/code/ali-je-vroce-era5/api.ts
@@ -192,6 +192,16 @@ function assertNationalStationRows(rows: readonly unknown[], table: string): voi
 // without mounting the Solid island (tests/unit/doy.test.ts).
 export const MONTH_LEN = [31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31] as const;
 
+// T-5.32: YEAR-AWARE day count for the HERO date picker, which — unlike the yearless
+// DOY control — selects a real dated day and must offer 29 February only in leap
+// years. `new Date(year, month, 0)` rolls to the last day of `month` (1..12), so its
+// `getDate()` is that month's length for THAT year: Feb → 29 in 2024, 28 in 2023.
+// Pure arithmetic on explicit arguments, no clock read (see the clock.ts audit note),
+// so it is unit-tested without mounting the Solid island (tests/unit/hero-date.test.ts).
+export function daysInMonth(year: number, month: number): number {
+  return new Date(year, month, 0).getDate();
+}
+
 export function doyToMonthDay(doy: number): { month: number; day: number } {
   const d = new Date(Date.UTC(2001, 0, 1));
   d.setUTCDate(d.getUTCDate() + doy - 1);

--- a/code/ali-je-vroce-era5/components/TodayCard.tsx
+++ b/code/ali-je-vroce-era5/components/TodayCard.tsx
@@ -1,10 +1,10 @@
-import { Show, For, createSignal, lazy, Suspense } from "solid-js";
+import { Show, For, createSignal, createEffect, lazy, Suspense } from "solid-js";
 import type { TodayStatus, Last7, SiteMeta, RankInfo } from "../types.ts";
-import { isArsoLoc } from "../api.ts";
+import { isArsoLoc, daysInMonth } from "../api.ts";
 import { todayYear } from "../clock.ts";
 import { TodayFlag } from "./TodayFlag.tsx";
 import { TodayGauge } from "../charts/TodayGauge.tsx";
-import { t, fmtNum, fmtInt, fmtMonthDay } from "../i18n/format.ts";
+import { t, fmtNum, fmtInt, fmtMonthDay, fmtMonthLong } from "../i18n/format.ts";
 
 const TodayLast7Chart = lazy(() => import("./TodayLast7Chart.tsx").then(m => ({ default: m.TodayLast7Chart })));
 
@@ -105,7 +105,7 @@ export function TodayCard(props: Props) {
             <polyline points="15 18 9 12 15 6"/>
           </svg>
         </button>
-        <div class="today-date-badge">{fmtDate(props.date)}</div>
+        <HeroDatePicker date={props.date} today={props.today} onDateChange={props.onDateChange} />
         <button
           class="today-nav-btn"
           aria-label={t("today.next_day")}
@@ -303,6 +303,183 @@ function RankBadge(props: { info: RankInfo; dayLabel: string }) {
             </For>
           </div>
         </div>
+      </Show>
+    </div>
+  );
+}
+
+// ── Hero date picker (T-5.32) ───────────────────────────────────────────────────
+// A calendar popover on the hero date badge. UNLIKE the yearless DOY picker (RegToolbar,
+// T-5.28) this selects a real dated day, so it carries a YEAR row and year-aware month
+// lengths — 29 February appears only in leap years, via daysInMonth (api.ts). Bounds are
+// the record: 1950-01-01 to device-"today" (props.today). The ~6 reanalysis-gap days at
+// the tail are WITHIN bounds and deliberately NOT disabled — selecting one is the default
+// view's normal state (the Open-Meteo forecast path with the "napoved" badge, D-24), not
+// an error to hide. Split from the DOY picker on purpose (state type, bounds, month-wrap
+// and leap handling all differ); it reuses the .reg-cal-* CSS and the fmtMonthLong month
+// names, so no content has a second source of truth (D-18 / T-5.26). Popover is closed by
+// default → adds no rendered text; the badge text (fmtDate) is unchanged, so the snapshot
+// (r.txt(".today-date-badge")) stays byte-identical.
+function pad2(n: number): string { return String(n).padStart(2, "0"); }
+function isoOf(y: number, m: number, d: number): string { return `${y}-${pad2(m)}-${pad2(d)}`; }
+
+function HeroDatePicker(props: { date: string; today: string; onDateChange: (d: string) => void }) {
+  const [calOpen,    setCalOpen]    = createSignal(false);
+  const [calYear,    setCalYear]    = createSignal(1950);
+  const [calMonth,   setCalMonth]   = createSignal(1);   // 1..12 shown in the grid
+  const [focusedDay, setFocusedDay] = createSignal(1);   // roving-tabindex day
+  let triggerRef: HTMLDivElement | undefined;
+  const dayRefs: (HTMLButtonElement | undefined)[] = [];
+
+  const maxYear  = () => Number(props.today.slice(0, 4));
+  const maxMonth = () => Number(props.today.slice(5, 7));
+  const maxDay   = () => Number(props.today.slice(8, 10));
+
+  const monthLen = () => daysInMonth(calYear(), calMonth());
+  // Last selectable day of the viewed month: its length, except the record-end month,
+  // which stops at device-today. (No lower cut: the min is 1950-01-01, and month nav is
+  // bounded to >= 1950-01 below, so no day in a viewable month falls before the min.)
+  const lastDay = () =>
+    calYear() === maxYear() && calMonth() === maxMonth()
+      ? Math.min(maxDay(), monthLen())
+      : monthLen();
+  const dayDisabled = (day: number) => isoOf(calYear(), calMonth(), day) > props.today;
+
+  const clampFocus = () => setFocusedDay(d => Math.min(Math.max(1, d), lastDay()));
+
+  const atFirstMonth = () => calYear() <= 1950 && calMonth() <= 1;
+  const atLastMonth  = () => calYear() >= maxYear() && calMonth() >= maxMonth();
+  const atFirstYear  = () => calYear() <= 1950;
+  const atLastYear   = () => calYear() >= maxYear();
+
+  const openCal = () => {
+    setCalYear(Number(props.date.slice(0, 4)));
+    setCalMonth(Number(props.date.slice(5, 7)));
+    setFocusedDay(Number(props.date.slice(8, 10)));
+    setCalOpen(true);
+  };
+  const closeCal = (returnFocus: boolean) => {
+    setCalOpen(false);
+    if (returnFocus) triggerRef?.focus();
+  };
+  const selectDay = (day: number) => {
+    props.onDateChange(isoOf(calYear(), calMonth(), day));
+    closeCal(true);
+  };
+  const stepMonth = (delta: number) => {
+    let y = calYear();
+    let m = calMonth() + delta;
+    if (m < 1)  { m = 12; y -= 1; }
+    if (m > 12) { m = 1;  y += 1; }
+    if (y < 1950) { y = 1950; m = 1; }                                   // clamp to record start
+    if (y > maxYear() || (y === maxYear() && m > maxMonth())) { y = maxYear(); m = maxMonth(); }  // to record end
+    setCalYear(y); setCalMonth(m); clampFocus();
+  };
+  const stepYear = (delta: number) => {
+    let y = Math.min(maxYear(), Math.max(1950, calYear() + delta));
+    let m = calMonth();
+    if (y === maxYear() && m > maxMonth()) m = maxMonth();
+    setCalYear(y); setCalMonth(m); clampFocus();
+  };
+
+  // Move DOM focus to the roving day button when the target day or open-state changes.
+  // Month/year nav that leaves focusedDay unchanged keeps focus naturally — Solid's <For>
+  // reuses the day button (same primitive key), so the focused element survives the
+  // re-render; only a clamp (shorter month) changes focusedDay and re-runs this. Mirrors
+  // the verified T-5.28 approach.
+  createEffect(() => {
+    if (calOpen()) dayRefs[focusedDay()]?.focus();
+  });
+
+  const onTriggerKey = (e: KeyboardEvent) => {
+    if (e.key === "Enter" || e.key === " " || e.key === "ArrowDown") {
+      e.preventDefault();
+      openCal();
+    }
+  };
+  const onGridKey = (e: KeyboardEvent) => {
+    const last = lastDay();
+    const d = focusedDay();
+    switch (e.key) {
+      case "ArrowRight": e.preventDefault(); setFocusedDay(Math.min(last, d + 1)); break;
+      case "ArrowLeft":  e.preventDefault(); setFocusedDay(Math.max(1, d - 1));    break;
+      case "ArrowDown":  e.preventDefault(); setFocusedDay(Math.min(last, d + 7)); break;
+      case "ArrowUp":    e.preventDefault(); setFocusedDay(Math.max(1, d - 7));    break;
+      case "Home":       e.preventDefault(); setFocusedDay(1);    break;
+      case "End":        e.preventDefault(); setFocusedDay(last); break;
+      // PageUp/Down step the month; with Shift they step the year (big jumps without a
+      // 76-option dropdown).
+      case "PageUp":     e.preventDefault(); e.shiftKey ? stepYear(-1) : stepMonth(-1); break;
+      case "PageDown":   e.preventDefault(); e.shiftKey ? stepYear(1)  : stepMonth(1);  break;
+      case "Enter":
+      case " ":          e.preventDefault(); selectDay(focusedDay()); break;
+      case "Escape":     e.preventDefault(); closeCal(true); break;
+    }
+  };
+
+  return (
+    <div class="today-date-badge-wrap">
+      <div
+        ref={triggerRef}
+        class="today-date-badge"
+        role="button"
+        tabindex="0"
+        aria-haspopup="dialog"
+        aria-expanded={calOpen()}
+        aria-label={t("today.pick_date")}
+        onClick={() => (calOpen() ? closeCal(false) : openCal())}
+        onKeyDown={onTriggerKey}
+      >
+        {fmtDate(props.date)}
+      </div>
+      <Show when={calOpen()}>
+        <div
+          class="reg-cal-pop"
+          role="dialog"
+          aria-label={t("today.cal_dialog")}
+          onKeyDown={(e) => { if (e.key === "Escape") { e.preventDefault(); closeCal(true); } }}
+        >
+          {/* Year row — the substance of this ticket: reaching a distant year without
+              hundreds of ‹ clicks. */}
+          <div class="reg-cal-head">
+            <button type="button" class="reg-cal-nav" aria-label={t("today.cal_prev_year")} disabled={atFirstYear()} onClick={() => stepYear(-1)}>◀</button>
+            <span class="reg-cal-title">{calYear()}</span>
+            <button type="button" class="reg-cal-nav" aria-label={t("today.cal_next_year")} disabled={atLastYear()} onClick={() => stepYear(1)}>▶</button>
+          </div>
+          {/* Month row */}
+          <div class="reg-cal-head">
+            <button type="button" class="reg-cal-nav" aria-label={t("today.cal_prev_month")} disabled={atFirstMonth()} onClick={() => stepMonth(-1)}>◀</button>
+            <span class="reg-cal-title">{fmtMonthLong(calMonth())}</span>
+            <button type="button" class="reg-cal-nav" aria-label={t("today.cal_next_month")} disabled={atLastMonth()} onClick={() => stepMonth(1)}>▶</button>
+          </div>
+          <div class="reg-cal-grid" onKeyDown={onGridKey}>
+            <For each={Array.from({ length: monthLen() }, (_, i) => i + 1)}>
+              {(day) => {
+                const selected = () =>
+                  Number(props.date.slice(0, 4)) === calYear() &&
+                  Number(props.date.slice(5, 7)) === calMonth() &&
+                  Number(props.date.slice(8, 10)) === day;
+                return (
+                  <button
+                    type="button"
+                    ref={(el) => (dayRefs[day] = el)}
+                    class="reg-cal-day"
+                    // Full dated label (day, month name, year) — Intl month name, raw
+                    // year (NO thousands grouping: "1994", never "1.994").
+                    aria-label={`${day}. ${fmtMonthLong(calMonth())} ${calYear()}`}
+                    aria-pressed={selected()}
+                    disabled={dayDisabled(day)}
+                    tabindex={focusedDay() === day ? 0 : -1}
+                    onClick={() => selectDay(day)}
+                  >
+                    {day}
+                  </button>
+                );
+              }}
+            </For>
+          </div>
+        </div>
+        <div style={{ position: "fixed", inset: "0", "z-index": "9" }} onClick={() => closeCal(false)} />
       </Show>
     </div>
   );

--- a/code/ali-je-vroce-era5/i18n/sl.ts
+++ b/code/ali-je-vroce-era5/i18n/sl.ts
@@ -98,6 +98,16 @@ export const sl = {
   today: {
     prev_day: "Prejšnji dan",
     next_day: "Naslednji dan",
+    // T-5.32 — accessible names for the HERO date-picker popover. Month names and the
+    // selected date come from Intl (i18n/format.ts); only this framing prose is here.
+    // Kept separate from the reg.* calendar strings, whose "dan v letu" framing is for
+    // the yearless DOY control, not a real date.
+    pick_date: "Izberi datum",
+    cal_dialog: "Koledar — izbira datuma",
+    cal_prev_month: "Prejšnji mesec",
+    cal_next_month: "Naslednji mesec",
+    cal_prev_year: "Prejšnje leto",
+    cal_next_year: "Naslednje leto",
     loc_national: "Slovenija — povprečje {count, plural, one{# postaja} two{# postaji} few{# postaje} other{# postaj}}",
     arso_group: "ARSO postaje",
     era5_group: "ERA5 postaje",

--- a/styles/era5.css
+++ b/styles/era5.css
@@ -61,7 +61,11 @@
 .today-heading-subtitle { font-family: 'Space Grotesk', sans-serif; font-size: 13px; font-weight: 400; color: var(--color-ink-soft); }
 
 .today-date-control { display: flex; align-items: center; gap: 3px; flex-shrink: 0; justify-content: center; }
+/* T-5.32: the date badge doubles as the hero calendar trigger; the popover (styled by
+   the shared .reg-cal-* rules below) anchors to this relatively-positioned wrapper. */
+.today-date-badge-wrap { position: relative; }
 .today-date-badge { font-family: var(--font-mono,'JetBrains Mono',monospace); font-weight: 600; font-size: 13px; background: var(--color-card); border: 1px solid var(--color-rule-2); border-radius: 7px; padding: 4px 10px; min-width: 60px; text-align: center; white-space: nowrap; cursor: pointer; line-height: 20px; }
+.today-date-badge:focus-visible { outline: 2px solid var(--color-accent); outline-offset: 1px; }
 .today-nav-btn { display: flex; align-items: center; justify-content: center; width: 28px; height: 28px; border-radius: 7px; border: 1px solid var(--color-rule-2); background: var(--color-card); color: var(--color-ink); cursor: pointer; flex-shrink: 0; }
 .today-nav-btn:disabled { opacity: 0.3; cursor: not-allowed; }
 .today-loc-select { font-family: var(--font-mono,'JetBrains Mono',monospace); font-weight: 600; font-size: 12px; background: var(--color-card); border: 1px solid var(--color-rule-2); border-radius: 7px; padding: 4px 8px; margin-left: 6px; color: var(--color-ink); cursor: pointer; max-width: 150px; }
@@ -221,16 +225,24 @@
 .reg-doy-label  { position: relative; }
 .reg-doy-value  { font-family: var(--font-mono); font-weight: 600; font-size: 13px; background: var(--color-card); border: 1px solid var(--color-rule-2); border-radius: 7px; padding: 4px 10px; min-width: 60px; text-align: center; white-space: nowrap; cursor: pointer; }
 .reg-doy-value:focus-visible { outline: 2px solid var(--color-accent); outline-offset: 1px; }
+/* T-5.28 / T-5.32: the .reg-cal-* popover rules are SHARED by BOTH calendar pickers —
+   the yearless DOY control (RegToolbar) and the dated HERO picker (TodayCard) — despite
+   the reg- prefix. One visual source of truth on purpose; do not fork or rename per
+   caller. The :disabled rules serve the hero picker's record bounds (1950-01-01..today);
+   the DOY control never disables a cell. */
 .reg-cal-pop    { position: absolute; top: calc(100% + 6px); left: 50%; transform: translateX(-50%); z-index: 10; background: var(--color-card); border: 1px solid var(--color-rule-2); border-radius: var(--radius, 10px); box-shadow: 0 8px 24px rgba(14, 14, 12, 0.12); padding: 10px; width: 236px; }
 .reg-cal-head   { display: flex; align-items: center; justify-content: space-between; margin-bottom: 8px; }
 .reg-cal-title  { font-family: var(--font-sans); font-size: 13px; font-weight: 600; color: var(--color-ink); text-transform: capitalize; }
 .reg-cal-nav    { display: inline-grid; place-items: center; width: 24px; height: 24px; border-radius: 6px; border: 1px solid var(--color-rule); background: var(--color-card); cursor: pointer; color: var(--color-ink); font-size: 10px; }
 .reg-cal-nav:focus-visible { outline: 2px solid var(--color-accent); outline-offset: 1px; }
+.reg-cal-nav:disabled { opacity: 0.3; cursor: not-allowed; }
 .reg-cal-grid   { display: grid; grid-template-columns: repeat(7, 1fr); gap: 3px; }
 .reg-cal-day    { aspect-ratio: 1; border: 1px solid transparent; border-radius: 6px; background: var(--color-paper); cursor: pointer; font-family: var(--font-mono); font-size: 11px; color: var(--color-ink); display: grid; place-items: center; }
 .reg-cal-day:hover { background: var(--color-paper-2); }
 .reg-cal-day:focus-visible { outline: 2px solid var(--color-accent); outline-offset: 1px; }
 .reg-cal-day[aria-pressed="true"] { background: var(--color-ink); color: #fff; border-color: var(--color-ink); }
+.reg-cal-day:disabled { opacity: 0.28; cursor: not-allowed; background: transparent; }
+.reg-cal-day:disabled:hover { background: transparent; }
 
 @media (max-width: 700px) {
   .main-row { grid-template-columns: 1fr; padding: 10px 14px 0; }

--- a/tests/unit/hero-date.test.ts
+++ b/tests/unit/hero-date.test.ts
@@ -1,0 +1,44 @@
+// T-5.32 — the HERO date picker (TodayCard) selects a real dated day, so its grid must
+// size February by the YEAR: 29 days only in leap years. Unlike the yearless DOY picker
+// (T-5.28, which always offers 29 Feb via MONTH_LEN), this is the year-aware count from
+// daysInMonth. A pure .ts export, so no Solid island is mounted here. Every value is
+// hand-computed from the Gregorian calendar, never read back from the code.
+import { describe, expect, it } from "vitest";
+
+import { daysInMonth } from "../../code/ali-je-vroce-era5/api.ts";
+
+describe("daysInMonth — year-aware month length for the hero picker (T-5.32)", () => {
+  it("gives February 29 days in a leap year and 28 in a common year", () => {
+    expect(daysInMonth(2024, 2)).toBe(29); // divisible by 4, not by 100 → leap
+    expect(daysInMonth(2023, 2)).toBe(28); // common year → NO 29 Feb offered
+  });
+
+  it("handles the century leap-year rule (÷100 not leap, ÷400 leap)", () => {
+    expect(daysInMonth(1900, 2)).toBe(28); // ÷100, not ÷400 → common
+    expect(daysInMonth(2000, 2)).toBe(29); // ÷400 → leap
+  });
+
+  it("gives 30 days to April, June, September, November (no 31st offered)", () => {
+    for (const y of [1950, 1994, 2026]) {
+      for (const m of [4, 6, 9, 11]) expect(daysInMonth(y, m)).toBe(30);
+    }
+  });
+
+  it("gives 31 days to the long months, in any year", () => {
+    for (const y of [1950, 2026]) {
+      for (const m of [1, 3, 5, 7, 8, 10, 12]) expect(daysInMonth(y, m)).toBe(31);
+    }
+  });
+
+  it("sums to 366 in a leap year and 365 in a common year", () => {
+    const sum = (y: number) => Array.from({ length: 12 }, (_, i) => daysInMonth(y, i + 1)).reduce((a, b) => a + b, 0);
+    expect(sum(2024)).toBe(366);
+    expect(sum(2023)).toBe(365);
+  });
+
+  it("matches the record bounds' years (1950 and 2026 both handled)", () => {
+    // The picker's real range is 1950-01-01 .. device-today; February at both ends:
+    expect(daysInMonth(1950, 2)).toBe(28); // common
+    expect(daysInMonth(2026, 2)).toBe(28); // common
+  });
+});


### PR DESCRIPTION
Adds a year-aware calendar picker to the hero date control — the one at the top of the page
driving the today card, gauge, distribution chart and last-7 strip.

A picker already exists on the "Analiza trendov" toolbar, but that control is yearless: it
selects a day-of-year, 1 to 365. This one holds a real date. The two were kept as separate
components rather than one shared grid, because they differ on four behavioural axes — state
type, bounds, month-wrap semantics and leap handling — all created by the year dimension. A
shared grid would need a mode flag on each plus a year row, which is more complex than two
concrete grids and would mean editing already-shipped, snapshot-verified code. Month names
come from the single Intl helper and all prose from the catalogue in both, so no content is
duplicated; only markup and keyboard wiring, which must differ.

Year navigation is a bracketed year row with Shift+PageUp/PageDown for jumps, chosen over a
76-option dropdown that would have been a second popup layer inside a popover.

Bounds run from 1950-01-01 to device-today, and no day inside that range is disabled. The
served daily table ends about six days behind, so recent days have no reanalysis — but that
is the forecast path and the default view's normal state, not an error to hide. Verified that
a July 2026 gap day is selectable and yields the forecast.

29 February appears only in leap years, unlike the yearless grid where it always appears.
Verified against February 2024 and 2023, and pinned by unit tests — the earlier picker's
first attempt had April with 31 days.

Snapshot byte-identical: the badge text is unchanged and the popover is closed by default.

Found while investigating: the selected year is invisible on the card once the popover
closes. The badge shows month and day only, and every other year rendered there is the record
range rather than the selected date. Not fixed here — the badge is snapshot-captured, so it
is a deliberate text change with its own trace. Tracked separately.

Gates: typecheck 0, typecheck:gate 0 allowlisted, yarn test 73 to 79, snapshot identical,
pytest 72.

Note: popover placement and touch behaviour need checking on stage — PR previews do not
currently deploy.
