### PR TITLE
T-5.27: one location control below the hero — floating chooser, single-select, station labels

### DIFF
--- a/code/ali-je-vroce-era5/AliJeVroceERA5.tsx
+++ b/code/ali-je-vroce-era5/AliJeVroceERA5.tsx
@@ -6,7 +6,7 @@ import { EmptyState } from "./components/EmptyState.tsx";
 import { TodayCard } from "./components/TodayCard.tsx";
 import { DistributionChart } from "./charts/DistributionChart.tsx";
 import { TodayTrendChart } from "./components/TodayTrendChart.tsx";
-import { RegressionPanel, RegToolbar, RegScatterCard, RegYearRoundCard, useReg,
+import { RegressionPanel, RegToolbar, RegScatterCard, RegYearRoundCard, FloatingStationChooser, useReg,
          panelHStyle, panelTitleStyle, panelSubStyle } from "./components/RegressionPanel.tsx";
 import { MethodologyPanel } from "./components/MethodologyPanel.tsx";
 import type { SiteMeta } from "./types.ts";
@@ -73,6 +73,10 @@ function Dashboard(props: { meta: SiteMeta }) {
   const last7Data = () => pageDataResolved()?.last7;
 
   const [mapLoc, setMapLoc] = createSignal<string | null>(null);
+
+  // T-5.27 — the floating station chooser reveals once the reader scrolls into the
+  // trends region; this anchors on the "Analiza trendov" heading.
+  let trendsAnchor: HTMLDivElement | undefined;
 
   return (
     <div>
@@ -147,7 +151,7 @@ function Dashboard(props: { meta: SiteMeta }) {
         syncLoc={mapLoc}
         onLocChange={setMapLoc}
       >
-        <div class="sec-hs">{t("sections.trends_analysis")}</div>
+        <div class="sec-hs" ref={trendsAnchor}>{t("sections.trends_analysis")}</div>
 
         <RegToolbar />
 
@@ -192,6 +196,10 @@ function Dashboard(props: { meta: SiteMeta }) {
         </div>
 
         <Era5Charts />
+
+        {/* T-5.27 / D-26 — single location control for everything above, in the
+            bottom-right corner. Inside the panel so it drives the regression store. */}
+        <FloatingStationChooser anchor={() => trendsAnchor} />
 
       </RegressionPanel>
 
@@ -249,7 +257,7 @@ function Era5Charts() {
           {t("sections.location_details")}
         </div>
         <Suspense fallback={<div style={{ height: "180px" }} class="animate-pulse rounded-xl bg-[var(--color-paper-2)]" />}>
-          <HeroCardsPanel loc={loc()} doy={s.doy()} />
+          <HeroCardsPanel loc={loc()} label={st()?.label} doy={s.doy()} />
         </Suspense>
       </section>
 

--- a/code/ali-je-vroce-era5/api.ts
+++ b/code/ali-je-vroce-era5/api.ts
@@ -27,6 +27,8 @@ import { CAT_COLORS, cdfPercentile } from "./percentile.ts";
 import { calendarDateIn, LJUBLJANA_TZ } from "./clock.ts";
 // T-5.5 (D-8) — Slovenian catalogue + Slovenian number/date formatting.
 import { t, fmtNum, fmtMonthDay } from "./i18n/format.ts";
+// T-5.27 — nominative diacritic station display names (no datasette column has them).
+import { displayNameFor } from "./i18n/station-names.ts";
 
 // podnebnik.org datasette serves each DB at the root (no /datasette prefix),
 // e.g. https://stage-data.podnebnik.org/climate-si — override with VITE_DATASETTE_URL for dev.
@@ -409,9 +411,16 @@ export async function fetchMeta(): Promise<SiteMeta> {
     era5Stations.map(s => [s.era5_name, { lat: s.lat, lon: s.lon, elevation: s.elevation }])
   );
 
+  // T-5.27 — `label` is the nominative DIACRITIC display name, authored in
+  // i18n/station-names.ts. The datasette `name` column is ASCII (era5_name with
+  // underscores→spaces), `official_name` is the ARSO station identity (a different
+  // place for six towns), and `name_locative` is the locative case — none is the
+  // display name (see that file). `s.name` is now unused for display but stays in
+  // STATIONS_COLS: the fixture layer keys on the exact request URL, so dropping the
+  // column would turn every offline run into a miss (same reason `station_id` stays).
   const stations = era5Stations.map(s => ({
     name:      s.era5_name,
-    label:     s.name,
+    label:     displayNameFor(s.era5_name),
     source:    "era5" as const,
     lat:       s.lat,
     lon:       s.lon,

--- a/code/ali-je-vroce-era5/charts/Era5SeasonHeatmap.tsx
+++ b/code/ali-je-vroce-era5/charts/Era5SeasonHeatmap.tsx
@@ -26,6 +26,12 @@ export function Era5SeasonHeatmap(props: Props) {
     <ErrorBoundary fallback={sectionErrorFallback(refetch, "160px")}>
       <Suspense fallback={<div class="h-40 animate-pulse bg-[var(--color-paper-2)] rounded-xl" />}>
         <Show when={(display()?.length ?? 0) > 0}>
+          {/* T-5.27 part (3) — the chart's station is set by the off-screen floating
+              chooser, so it must name it here (previously the `label` prop was unused
+              and the season chart showed no location at all). */}
+          <Show when={props.label}>
+            <div class="era5-chart-loc">{props.label}</div>
+          </Show>
           <SeasonHeatmap data={display()!} />
         </Show>
         <Show when={data.loading && !display()}>

--- a/code/ali-je-vroce-era5/components/HeroCards.tsx
+++ b/code/ali-je-vroce-era5/components/HeroCards.tsx
@@ -62,6 +62,9 @@ function verdictHtml(st: RegressionResult["stats"], unit: string): string {
 
 interface Props {
   loc:        string | null;
+  // T-5.27 part (3) — the DIACRITIC display name (station.label). loc is the ASCII
+  // era5_name key used for fetching; the card must show the label, not the key.
+  label?:     string | undefined;
   doy:        number;
   dateLabel?: string;
 }
@@ -81,14 +84,17 @@ export function HeroCards(props: Props) {
   return (
     <ErrorBoundary fallback={sectionErrorFallback(refetch, "180px")}>
       <Show when={resp()?.results?.length} fallback={<EmptyState minHeight="180px" />}>
-        <HeroCard res={resp()!.results[0]!} unit={resp()!.unit} dateLabel={resp()!.date_label} />
+        <HeroCard res={resp()!.results[0]!} unit={resp()!.unit} dateLabel={resp()!.date_label} label={props.label} />
       </Show>
     </ErrorBoundary>
   );
 }
 
-function HeroCard(props: { res: RegressionResult; unit: string; dateLabel: string }) {
+function HeroCard(props: { res: RegressionResult; unit: string; dateLabel: string; label?: string | undefined }) {
   const res = () => props.res;
+  // Display name (label) for what the reader sees; res().loc stays the ASCII key for
+  // the heroContext / climateRisks lookups below.
+  const displayName = () => props.label ?? res().loc.replace(/_/g, " ");
   const st  = () => res().stats;
   const cat = () => trendCategory(st().trend10);
   const isPos = () => st().trend10 >= 0;
@@ -102,7 +108,7 @@ function HeroCard(props: { res: RegressionResult; unit: string; dateLabel: strin
   return (
     <div
       role="group"
-      aria-label={t("hero.group_a11y", { station: res().loc.replace(/_/g, " ") })}
+      aria-label={t("hero.group_a11y", { station: displayName() })}
       style={{
       background:    "var(--color-card)",
       border:        "1px solid var(--color-rule)",
@@ -118,7 +124,7 @@ function HeroCard(props: { res: RegressionResult; unit: string; dateLabel: strin
           {/* Eyebrow */}
           <div style={{ display: "flex", "align-items": "center", gap: "6px", "margin-bottom": "12px", "flex-wrap": "wrap" }}>
             <span style={{ ...SANS, "font-size": "15px", "font-weight": "600", color: "var(--color-ink)" }}>
-              {res().loc.replace(/_/g, " ")}
+              {displayName()}
             </span>
             <span style={{ width: "4px", height: "4px", "border-radius": "50%", background: "var(--color-ink-soft)", display: "inline-block", "flex-shrink": "0" }} />
             <span style={{ ...MONO, "font-size": "10px", color: "var(--color-ink-soft)", "letter-spacing": "0.06em", "text-transform": "uppercase" }}>

--- a/code/ali-je-vroce-era5/components/RegressionPanel.tsx
+++ b/code/ali-je-vroce-era5/components/RegressionPanel.tsx
@@ -1,5 +1,5 @@
 import { createSignal, createResource, createEffect, createMemo, createContext, useContext,
-         Show, Suspense, ErrorBoundary, For, lazy } from "solid-js";
+         onMount, onCleanup, Show, Suspense, ErrorBoundary, For, lazy } from "solid-js";
 import type { JSXElement } from "solid-js";
 import type { SiteMeta } from "../types.ts";
 import type { RegressionParams } from "../api.ts";
@@ -39,10 +39,25 @@ function doyToLabel(doy: number): string {
 function createStore(props: ProviderProps) {
   const defaultLoc = () => props.meta.default_location ?? "Ljubljana";
 
+  // T-5.27 / D-26 — the location below the hero is now a SINGLE station. `selLocs`
+  // is kept as an always-length-1 array only so the fetch layer (RegressionParams.locs
+  // → fetchRegression maps over it, RegressionChart plots one series per result) is
+  // untouched; the multi-station selector and its ≥1 toggle are gone. National is not
+  // offered below the hero — annual_trend / season_heatmap / tropical / calendar have
+  // no national row and fetchEra5Tropical returns null for it (api.ts), so the floating
+  // chooser lists the 18 stations only.
   const [selLocs,  setSelLocs]  = createSignal<string[]>([defaultLoc()]);
   const [selVar,   setSelVar]   = createSignal("temperature_max");
   const [doy,      setDoy]      = createSignal(props.defaultDoy);
-  const [locOpen,  setLocOpen]  = createSignal(false);
+
+  const selLoc = () => selLocs()[0] ?? defaultLoc();
+  // The single writer for the below-hero location. It also notifies the page via
+  // onLocChange (→ setMapLoc), so the station map's highlight and panel title follow
+  // the floating chooser, and vice-versa (a map click flows back through syncLoc).
+  const setLoc = (name: string) => {
+    setSelLocs([name]);
+    props.onLocChange?.(name);
+  };
 
   createEffect(() => {
     const ext = props.syncLoc?.();
@@ -78,34 +93,28 @@ function createStore(props: ProviderProps) {
     if (!s) return null;
     return trend10() * s.n_years / 10;
   };
+  // T-5.31 family (recorded in 1a): station.name is the ASCII era5_name key,
+  // station.label is the diacritic display name. Always show the label.
   const stationLabel = (name: string) => {
     const st = props.meta.stations.find(s => s.name === name);
     return (st?.label ?? name).replace(/_/g, " ");
   };
-  const locLabel   = () => {
-    const locs = selLocs();
-    return locs.length === 1 ? stationLabel(locs[0]!) : t("reg.locations_multi", { count: locs.length });
-  };
+  const locLabel   = () => stationLabel(selLoc());
   const varLabel   = () => VARIABLES.find(([k]) => k === selVar())?.[1] ?? selVar();
-  const chartTitle = () => `${varLabel().split("(")[0]!.trim()} · ${doyToLabel(doy())}`;
-  const chartSub   = () => selLocs().map(stationLabel).join(", ");
-
-  function toggleLoc(name: string) {
-    setSelLocs(prev => {
-      if (prev.includes(name)) return prev.length > 1 ? prev.filter(l => l !== name) : prev;
-      return [...prev, name].slice(0, 6);
-    });
-  }
+  // T-5.27 part (3): the scatter card now names its station in the TITLE (it was only
+  // in the subtitle), so a reader whose station is set by the off-screen floating
+  // chooser can read the chart on its own. The day moves to the subtitle.
+  const chartTitle = () => `${stationLabel(selLoc())} · ${varLabel().split("(")[0]!.trim()}`;
+  const chartSub   = () => doyToLabel(doy());
 
   return {
     meta: props.meta,
-    selLocs, setSelLocs, selVar, setSelVar,
+    selLocs, setSelLocs, selLoc, setLoc, selVar, setSelVar,
     doy, setDoy,
-    locOpen, setLocOpen,
     regData, calData, refetchReg, refetchCal,
     isPrecip, stats0, trend10, trendColor, totalChange,
-    locLabel, varLabel, chartTitle, chartSub,
-    toggleLoc, doyToLabel, VARIABLES,
+    stationLabel, locLabel, varLabel, chartTitle, chartSub,
+    doyToLabel, VARIABLES,
   };
 }
 
@@ -189,36 +198,11 @@ export function RegToolbar() {
   return (
     <div class="reg-toolbar">
 
-      {/* Location */}
-      <div style={{ position: "relative" }}>
-        <div style={pillGroupStyle}>
-          <span style={pgkStyle}>{t("reg.location")}</span>
-          <button style={locBtnStyle} onClick={() => s.setLocOpen(v => !v)}>
-            <span>{s.locLabel()}</span>
-            <svg width="9" height="9" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M6 9l6 6 6-6"/></svg>
-          </button>
-        </div>
-        <Show when={s.locOpen()}>
-          <div style={locMenuStyle} onClick={(e) => e.stopPropagation()}>
-            <div style={locMenuHeaderStyle}>
-              <span style={{ "font-size": "11px", "font-weight": "600", "font-family": "var(--font-sans)" }}>{t("reg.select_locations")}</span>
-              <button style={{ background: "none", border: "none", cursor: "pointer", color: "var(--color-ink-soft)", "font-size": "14px" }} onClick={() => s.setLocOpen(false)}>✕</button>
-            </div>
-            <For each={s.meta.stations}>
-              {(st) => {
-                const active = () => s.selLocs().includes(st.name);
-                return (
-                  <label style={{ display: "flex", "align-items": "center", gap: "8px", padding: "5px 12px", cursor: "pointer", "font-size": "12px", "font-family": "var(--font-sans)", color: "var(--color-ink)", background: active() ? "var(--color-paper-2)" : "transparent" }}>
-                    <input type="checkbox" checked={active()} onChange={() => s.toggleLoc(st.name)} />
-                    {st.label ?? st.name}
-                  </label>
-                );
-              }}
-            </For>
-          </div>
-          <div style={{ position: "fixed", inset: "0", "z-index": "9" }} onClick={() => s.setLocOpen(false)} />
-        </Show>
-      </div>
+      {/* T-5.27 / D-26 — the inline LOKACIJA multi-select was RETIRED here. The single
+          location for every section below "Analiza trendov" is now the floating
+          FloatingStationChooser (bottom-right corner); multi-station comparison was
+          dropped deliberately. The store keeps `selLocs` as a length-1 array so the
+          fetch layer is unchanged. */}
 
       {/* Variable */}
       <div style={pillGroupStyle}>
@@ -403,7 +387,7 @@ export function RegYearRoundCard() {
 
       <div style={panelHStyle}>
         <div style={{ "min-width": "0" }}>
-          <div style={panelTitleStyle}>{t("reg.year_round_title", { station: s.selLocs()[0]?.replace(/_/g, " ") ?? "" })}</div>
+          <div style={panelTitleStyle}>{t("reg.year_round_title", { station: s.stationLabel(s.selLoc()) })}</div>
           <div style={{ ...panelSubStyle, "margin-top": "3px" }}>
             {(s.VARIABLES.find(([k]) => k === s.selVar())?.[1] ?? s.selVar()).split("(")[0]!.trim()}
             {" · Theil-Sen + MK"}
@@ -432,6 +416,176 @@ export function RegYearRoundCard() {
         <p style={panelExplainStyle}>{s.meta.strings.explain_cal}</p>
       </Show>
 
+    </div>
+  );
+}
+
+// ── Floating station chooser (T-5.27 / D-26) ──────────────────────────────────
+//
+// The single location control for every section below "Analiza trendov". Fixed to
+// the bott-right corner, revealed once the reader has scrolled into the trends
+// region (the `anchor` element passes the viewport top), and SHOWN WHEN SCROLLING
+// STOPS — it fades out on scroll-start and back in on scroll-stop, so it never
+// flickers on a gesture. It stays visible while open or while it holds focus, so a
+// keyboard user is never chasing a moving target. The list EXPANDS UPWARD (it opens
+// over content already read, not down into charts not yet reached), which is exactly
+// why it cannot be a native <select> — the browser owns that dropdown's direction.
+// Everything a native control gives for free is therefore built here: roving-tabindex
+// keyboard, focus return, outside-click dismissal, listbox/option semantics.
+export function FloatingStationChooser(props: { anchor: () => HTMLElement | undefined }) {
+  const s = useReg();
+
+  // Alphabetical by the DIACRITIC display name, locale-aware (Slovene collation:
+  // Č/Š/Ž sort right after C/S/Z, not by code point).
+  const stations = createMemo(() =>
+    [...s.meta.stations].sort((a, b) =>
+      (a.label ?? a.name).localeCompare(b.label ?? b.name, "sl")),
+  );
+
+  const [open,        setOpen]        = createSignal(false);
+  const [inRegion,    setInRegion]    = createSignal(false);
+  const [scrolling,   setScrolling]   = createSignal(false);
+  const [focusWithin, setFocusWithin] = createSignal(false);
+  const [focusIdx,    setFocusIdx]    = createSignal(0);
+
+  const shown = () => inRegion() && (open() || focusWithin() || !scrolling());
+
+  let triggerRef: HTMLButtonElement | undefined;
+  let listRef:    HTMLUListElement  | undefined;
+  const optRefs: (HTMLLIElement | undefined)[] = [];
+  let alignFoot = false;
+
+  const REVEAL_AT      = 72;   // px from viewport top the trends heading must pass
+  const SCROLL_STOP_MS = 160;
+  let stopTimer: number | undefined;
+
+  const recompute = () => {
+    const el = props.anchor();
+    setInRegion(!!el && el.getBoundingClientRect().top < REVEAL_AT);
+  };
+  const onScroll = () => {
+    recompute();
+    setScrolling(true);
+    if (stopTimer) clearTimeout(stopTimer);
+    stopTimer = window.setTimeout(() => setScrolling(false), SCROLL_STOP_MS);
+  };
+
+  onMount(() => {
+    recompute();  // the page may load already scrolled into the region
+    window.addEventListener("scroll", onScroll, { passive: true });
+    window.addEventListener("resize", recompute, { passive: true });
+  });
+  onCleanup(() => {
+    window.removeEventListener("scroll", onScroll);
+    window.removeEventListener("resize", recompute);
+    if (stopTimer) clearTimeout(stopTimer);
+  });
+
+  const openMenu = () => {
+    const idx = stations().findIndex(st => st.name === s.selLoc());
+    setFocusIdx(idx < 0 ? 0 : idx);
+    alignFoot = true;   // pin the current selection to the foot of the list on open
+    setOpen(true);
+  };
+  const closeMenu = (returnFocus: boolean) => {
+    setOpen(false);
+    if (returnFocus) triggerRef?.focus();
+  };
+  const choose = (name: string) => {
+    s.setLoc(name);
+    closeMenu(true);
+  };
+
+  // Move DOM focus to the roving option on open / navigation. On open, scroll the
+  // selected option to the FOOT of the list (nearest the trigger); during arrow
+  // navigation, only nudge it into view.
+  createEffect(() => {
+    if (!open()) return;
+    const el = optRefs[focusIdx()];
+    if (!el) return;
+    el.focus({ preventScroll: true });
+    if (alignFoot && listRef) {
+      listRef.scrollTop = Math.max(0, el.offsetTop + el.offsetHeight - listRef.clientHeight);
+      alignFoot = false;
+    } else {
+      el.scrollIntoView({ block: "nearest" });
+    }
+  });
+
+  const onTriggerKey = (e: KeyboardEvent) => {
+    if (e.key === "Enter" || e.key === " " || e.key === "ArrowUp" || e.key === "ArrowDown") {
+      e.preventDefault();
+      openMenu();
+    }
+  };
+  const onListKey = (e: KeyboardEvent) => {
+    const n = stations().length;
+    const i = focusIdx();
+    switch (e.key) {
+      case "ArrowDown": e.preventDefault(); setFocusIdx(Math.min(n - 1, i + 1)); break;
+      case "ArrowUp":   e.preventDefault(); setFocusIdx(Math.max(0, i - 1));     break;
+      case "Home":      e.preventDefault(); setFocusIdx(0);     break;
+      case "End":       e.preventDefault(); setFocusIdx(n - 1); break;
+      case "Enter":
+      case " ":         e.preventDefault(); choose(stations()[i]!.name); break;
+      case "Escape":    e.preventDefault(); closeMenu(true);   break;
+      case "Tab":       closeMenu(false);  break;   // let focus leave naturally
+    }
+  };
+
+  return (
+    <div
+      class="fsc"
+      classList={{ "fsc--region": inRegion(), "fsc--shown": shown() }}
+      aria-hidden={!inRegion()}
+      onFocusIn={() => setFocusWithin(true)}
+      onFocusOut={(e) => {
+        if (!(e.currentTarget as HTMLElement).contains(e.relatedTarget as Node | null)) setFocusWithin(false);
+      }}
+    >
+      <Show when={open()}>
+        <div class="fsc-overlay" onClick={() => closeMenu(false)} />
+        <ul ref={listRef} class="fsc-list" role="listbox" aria-label={t("floc.listbox")} onKeyDown={onListKey}>
+          <For each={stations()}>
+            {(st, i) => {
+              const selected = () => st.name === s.selLoc();
+              return (
+                <li
+                  ref={(el) => (optRefs[i()] = el)}
+                  class="fsc-opt"
+                  classList={{ "fsc-opt--sel": selected() }}
+                  role="option"
+                  aria-selected={selected()}
+                  tabindex={focusIdx() === i() ? 0 : -1}
+                  onClick={() => choose(st.name)}
+                >
+                  {st.label ?? st.name}
+                </li>
+              );
+            }}
+          </For>
+        </ul>
+      </Show>
+      {/* Resting state is a compact location-pin icon, not a labelled pill — a wide
+          "Lokacija · <station>" bar overlapped the content to its left. The current
+          station is not hidden: every chart below names it (part 3), and it is the
+          trigger's accessible name + hover title here. */}
+      <button
+        ref={triggerRef}
+        type="button"
+        class="fsc-trigger"
+        aria-haspopup="listbox"
+        aria-expanded={open()}
+        aria-label={t("floc.pick", { station: s.locLabel() })}
+        title={s.locLabel()}
+        onClick={() => (open() ? closeMenu(false) : openMenu())}
+        onKeyDown={onTriggerKey}
+      >
+        <svg class="fsc-pin" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <path d="M12 21s-7-6.2-7-11a7 7 0 0 1 14 0c0 4.8-7 11-7 11z" />
+          <circle cx="12" cy="10" r="2.5" />
+        </svg>
+      </button>
     </div>
   );
 }
@@ -473,38 +627,6 @@ const pillStyle: Record<string, string> = {
   color:          "var(--color-ink)",
   cursor:         "pointer",
   "font-family":  "var(--font-sans)",
-};
-
-const locBtnStyle: Record<string, string> = {
-  ...pillStyle,
-  display:       "flex",
-  "align-items": "center",
-  gap:           "5px",
-  background:    "var(--color-card)",
-};
-
-const locMenuStyle: Record<string, string> = {
-  position:        "absolute",
-  top:             "calc(100% + 6px)",
-  left:            "0",
-  "z-index":       "10",
-  background:      "var(--color-card)",
-  border:          "1px solid var(--color-rule-2)",
-  "border-radius": "var(--radius, 10px)",
-  "box-shadow":    "0 8px 24px rgba(14,14,12,0.12)",
-  "min-width":     "180px",
-  "max-height":    "280px",
-  overflow:        "auto",
-};
-
-const locMenuHeaderStyle: Record<string, string> = {
-  display:           "flex",
-  "align-items":     "center",
-  "justify-content": "space-between",
-  padding:           "8px 12px",
-  "border-bottom":   "1px solid var(--color-rule)",
-  "font-size":       "11px",
-  color:             "var(--color-ink-soft)",
 };
 
 const playBtnStyle: Record<string, string> = {

--- a/code/ali-je-vroce-era5/i18n/sl.ts
+++ b/code/ali-je-vroce-era5/i18n/sl.ts
@@ -230,7 +230,6 @@ export const sl = {
     var_et0: "ET₀ (mm)",
 
     location: "Lokacija",
-    select_locations: "Izberite lokacije (največ 6)",
     variable: "Spremenljivka",
     day: "Dan",
     // T-5.28 — accessible names for the day-of-year calendar picker. The month and
@@ -239,7 +238,6 @@ export const sl = {
     calendar: "Koledar — izbira dneva v letu",
     prev_month: "Prejšnji mesec",
     next_month: "Naslednji mesec",
-    locations_multi: "{count, plural, one{# lokacija} two{# lokaciji} few{# lokacije} other{# lokacij}}",
 
     years_sig: "{count, plural, one{# leto} two{# leti} few{# leta} other{# let}} · {sig}",
     change_over_record: "sprememba v celotnem obdobju",
@@ -256,6 +254,13 @@ export const sl = {
 
     explain_reg: "Theil-Sen regresija + Yue-Wang TFPW Mann-Kendall test · ERA5-Land · nadmorska korekcija",
     explain_cal: "Trend na desetletje za vsak dan v letu · rdeča = ogrevanje · modra = ohlajanje · prosojnost = statistična značilnost",
+  },
+
+  // T-5.27 — floating station chooser (the single location control below the hero).
+  // Accessible names only; the station names themselves are the display labels.
+  floc: {
+    pick: "Izberi lokacijo (trenutno {station})",
+    listbox: "Seznam lokacij",
   },
 
   // RegressionChart (Highcharts)

--- a/code/ali-je-vroce-era5/i18n/station-names.ts
+++ b/code/ali-je-vroce-era5/i18n/station-names.ts
@@ -1,0 +1,67 @@
+// T-5.27 — station DISPLAY names (nominative, with Slovene diacritics), keyed on era5_name.
+//
+// WHY THIS MAP EXISTS — no column in the `stations` datasette table carries the
+// nominative diacritic town name, so it has to be authored:
+//   • `name`          is `era5_name` with underscores→spaces: ASCII, no diacritics
+//                     ("Kocevje", "Ratece", "Domzale").
+//   • `official_name` is the ARSO OBSERVING-STATION identity — a *different place* for
+//                     several towns: "Nova Gorica"→"Bilje", "Murska Sobota"→"Rakičan",
+//                     "Ljubljana"→"Ljubljana Bežigrad". Wrong for a location picker.
+//   • `name_locative` is the locative case ("v Kočevju", "v Novi Gorici"): right town,
+//                     wrong grammar, and cannot be mechanically de-inflected to nominative.
+// Do NOT delete this map believing a column would do. Three sources — the T-5.27 ticket,
+// D-26, and the step-1a audit — each stated `name` held the display name; the correction
+// to `official_name` was wrong too. All of it survived scrutiny only because no consumer
+// displayed a diacritic station until now: the chart titles read correctly solely because
+// "Nova Gorica" happens to have no diacritics. Three wrong answers resting on a sample-data
+// coincidence. The eventual proper home is a real `display_name` in build_stations'
+// metadata dict (A3, PROGRESS 2026-08-01) — that needs a datasette rebuild + redeploy and
+// a fixtures re-record, which is why it is not this ticket.
+//
+// COMPLETE ON PURPOSE — every one of the 18 stations is listed, including the 14 whose
+// display name equals `name`, so a station added upstream without an entry here fails
+// LOUDLY via displayNameFor() rather than silently rendering ASCII for one station nobody
+// notices (same reasoning as the ensure-label fix, T-6.6b).
+//
+// "Novo mesto" — the lowercase "mesto" is CORRECT Slovene, not a typo. A multi-word
+// settlement name capitalises only its first word unless a later word is itself a proper
+// noun: "Murska Sobota" keeps its capital S because Sobota is a proper noun, while "mesto"
+// (= town) is a common noun and stays lowercase. Do not "fix" it to "Novo Mesto".
+//
+// This file lives under i18n/ so the T-5.12 text-integrity guard (tests/unit/
+// text-integrity.test.ts globs i18n/) scans these hand-authored diacritics for
+// Cyrillic/Greek homoglyphs and invisible characters automatically — exactly the vector
+// four pasted Slovenian proper nouns present.
+export const STATION_DISPLAY_NAME: Readonly<Record<string, string>> = {
+  Celje:            "Celje",
+  Domzale:          "Domžale",
+  Ilirska_Bistrica: "Ilirska Bistrica",
+  Kocevje:          "Kočevje",
+  Koper:            "Koper",
+  Kranj:            "Kranj",
+  Kredarica:        "Kredarica",
+  Ljubljana:        "Ljubljana",
+  Maribor:          "Maribor",
+  Murska_Sobota:    "Murska Sobota",
+  Nova_Gorica:      "Nova Gorica",
+  Novo_Mesto:       "Novo mesto",
+  Postojna:         "Postojna",
+  Ptuj:             "Ptuj",
+  Ratece:           "Rateče",
+  Tolmin:           "Tolmin",
+  Trbovlje:         "Trbovlje",
+  Velenje:          "Velenje",
+};
+
+// Loud failure on an unknown station — never a silent ASCII fallback (condition 3).
+export function displayNameFor(era5Name: string): string {
+  const name = STATION_DISPLAY_NAME[era5Name];
+  if (name === undefined) {
+    throw new Error(
+      `[T-5.27] no display name for station "${era5Name}". STATION_DISPLAY_NAME ` +
+        `(i18n/station-names.ts) must list every era5_name — add it there (see the file ` +
+        `comment on why no datasette column can supply it).`,
+    );
+  }
+  return name;
+}

--- a/styles/era5.css
+++ b/styles/era5.css
@@ -244,6 +244,34 @@
 .reg-cal-day:disabled { opacity: 0.28; cursor: not-allowed; background: transparent; }
 .reg-cal-day:disabled:hover { background: transparent; }
 
+/* ── T-5.27: floating station chooser — the single location control below the hero ──
+   Fixed bottom-right; the option list EXPANDS UPWARD, which is why this cannot be a
+   native <select> (the browser owns that dropdown's direction). Hidden until the
+   reader scrolls into the trends region (.fsc--region), then shown only when scrolling
+   STOPS (.fsc--shown); an open menu, or focus inside it, keeps it shown so a keyboard
+   user is never chasing it. The fade is the page's FIRST motion, so it is gated on
+   prefers-reduced-motion (T-5.15) — reduced-motion users get an instant show/hide. */
+.fsc { display: none; position: fixed; right: 20px; bottom: 20px; z-index: 40; }
+.fsc.fsc--region { display: block; opacity: 0; pointer-events: none; }
+.fsc.fsc--region.fsc--shown { opacity: 1; pointer-events: auto; }
+@media (prefers-reduced-motion: no-preference) {
+  .fsc.fsc--region { transition: opacity 0.18s ease; }
+}
+.fsc-overlay { position: fixed; inset: 0; z-index: 1; }
+.fsc-trigger { position: relative; z-index: 2; display: grid; place-items: center; width: 48px; height: 48px; border-radius: 50%; border: 1px solid var(--color-rule-2); background: var(--color-card); box-shadow: 0 6px 20px rgba(14, 14, 12, 0.18); cursor: pointer; color: var(--color-ink); }
+.fsc-trigger:hover { background: var(--color-paper-2); }
+.fsc-trigger:focus-visible { outline: 2px solid var(--color-accent); outline-offset: 2px; }
+.fsc-pin { display: block; }
+.fsc-list { position: absolute; right: 0; bottom: calc(100% + 8px); z-index: 2; margin: 0; padding: 4px; list-style: none; background: var(--color-card); border: 1px solid var(--color-rule-2); border-radius: var(--radius, 10px); box-shadow: 0 8px 24px rgba(14, 14, 12, 0.18); min-width: 200px; max-width: calc(100vw - 40px); max-height: 60vh; overflow-y: auto; }
+.fsc-opt { padding: 7px 12px; border-radius: 7px; font-family: var(--font-sans); font-size: 13px; color: var(--color-ink); cursor: pointer; white-space: nowrap; }
+.fsc-opt:hover { background: var(--color-paper-2); }
+.fsc-opt:focus-visible { outline: 2px solid var(--color-accent); outline-offset: -2px; }
+.fsc-opt--sel { background: var(--color-ink); color: #fff; font-weight: 600; }
+.fsc-opt--sel:hover { background: var(--color-ink); }
+
+/* T-5.27 part (3): the season heatmap names the station the off-screen chooser set. */
+.era5-chart-loc { font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.08em; text-transform: uppercase; color: var(--color-ink-soft); margin-bottom: 8px; }
+
 @media (max-width: 700px) {
   .main-row { grid-template-columns: 1fr; padding: 10px 14px 0; }
   .reg-card--cal { margin: 10px 14px 0; }
@@ -266,6 +294,8 @@
   .shm-controls   { gap: 5px; }
   .shm-btn        { padding: 3px 10px; font-size: 10px; }
   .shm-btn--anim  { margin-left: 0; }
+  .fsc            { right: 12px; bottom: 12px; }
+  .fsc-list       { min-width: 180px; }
 }
 
 /* ── Season & SPEI heatmap ───────────────────────────────────────────────── */

--- a/tests/fixtures/snapshot.json
+++ b/tests/fixtures/snapshot.json
@@ -64,6 +64,7 @@
       "EmptyState",
       "Era5Charts",
       "ErrorBoundary",
+      "FloatingStationChooser",
       "RegressionPanel",
       "Show",
       "SiteMeta",
@@ -132,7 +133,7 @@
         },
         {
           "name": "Novo_Mesto",
-          "label": "Novo Mesto",
+          "label": "Novo mesto",
           "lat": 45.8011,
           "lon": 15.17,
           "elevation": 220
@@ -188,7 +189,7 @@
         },
         {
           "name": "Kocevje",
-          "label": "Kocevje",
+          "label": "Kočevje",
           "lat": 45.6433,
           "lon": 14.8619,
           "elevation": 467
@@ -202,14 +203,14 @@
         },
         {
           "name": "Domzale",
-          "label": "Domzale",
+          "label": "Domžale",
           "lat": 46.1375,
           "lon": 14.5942,
           "elevation": 301
         },
         {
           "name": "Ratece",
-          "label": "Ratece",
+          "label": "Rateče",
           "lat": 46.4967,
           "lon": 13.7131,
           "elevation": 864
@@ -325,7 +326,7 @@
                 },
                 {
                   "color": "#c25a2c",
-                  "label": "Novo Mesto",
+                  "label": "Novo mesto",
                   "lat": 45.8011,
                   "lon": 15.17,
                   "marker": {
@@ -429,7 +430,7 @@
                 },
                 {
                   "color": "#c8b97a",
-                  "label": "Kocevje",
+                  "label": "Kočevje",
                   "lat": 45.6433,
                   "lon": 14.8619,
                   "marker": {
@@ -455,7 +456,7 @@
                 },
                 {
                   "color": "#c25a2c",
-                  "label": "Domzale",
+                  "label": "Domžale",
                   "lat": 46.1375,
                   "lon": 14.5942,
                   "marker": {
@@ -468,7 +469,7 @@
                 },
                 {
                   "color": "#a3c4a0",
-                  "label": "Ratece",
+                  "label": "Rateče",
                   "lat": 46.4967,
                   "lon": 13.7131,
                   "marker": {
@@ -31876,7 +31877,7 @@
               "Celje",
               "Kranj",
               "Koper",
-              "Novo Mesto",
+              "Novo mesto",
               "Murska Sobota",
               "Nova Gorica",
               "Postojna",
@@ -31884,10 +31885,10 @@
               "Velenje",
               "Trbovlje",
               "Tolmin",
-              "Kocevje",
+              "Kočevje",
               "Ilirska Bistrica",
-              "Domzale",
-              "Ratece",
+              "Domžale",
+              "Rateče",
               "Kredarica"
             ]
           },
@@ -33654,7 +33655,6 @@
       "analysis": {
         "rendered": {
           "toolbar": [
-            "LokacijaLjubljana",
             "SpremenljivkaNajvišja temperatura (°C)Najnižja temperatura (°C)Povprečna temperatura (°C)Padavine (mm)ET₀ (mm)",
             "Dan21. jul.◀▶"
           ],
@@ -33669,8 +33669,8 @@
             ]
           },
           "day_label": "21. jul.",
-          "title": "Najvišja temperatura · 21. jul.",
-          "subtitle": "Ljubljana",
+          "title": "Ljubljana · Najvišja temperatura",
+          "subtitle": "21. jul.",
           "stats_badge": "Theil-Sen + TFPW MK · τ = 0,34",
           "total_change": "+4,35°C",
           "total_change_color": "rgb(204, 34, 34)",
@@ -35234,7 +35234,7 @@
               "Celje",
               "Kranj",
               "Koper",
-              "Novo Mesto",
+              "Novo mesto",
               "Murska Sobota",
               "Nova Gorica",
               "Postojna",
@@ -35242,10 +35242,10 @@
               "Velenje",
               "Trbovlje",
               "Tolmin",
-              "Kocevje",
+              "Kočevje",
               "Ilirska Bistrica",
-              "Domzale",
-              "Ratece",
+              "Domžale",
+              "Rateče",
               "Kredarica"
             ]
           },
@@ -37203,7 +37203,6 @@
       "analysis": {
         "rendered": {
           "toolbar": [
-            "LokacijaLjubljana",
             "SpremenljivkaNajvišja temperatura (°C)Najnižja temperatura (°C)Povprečna temperatura (°C)Padavine (mm)ET₀ (mm)",
             "Dan21. jul.◀▶"
           ],
@@ -37218,8 +37217,8 @@
             ]
           },
           "day_label": "21. jul.",
-          "title": "Najvišja temperatura · 21. jul.",
-          "subtitle": "Ljubljana",
+          "title": "Ljubljana · Najvišja temperatura",
+          "subtitle": "21. jul.",
           "stats_badge": "Theil-Sen + TFPW MK · τ = 0,34",
           "total_change": "+4,35°C",
           "total_change_color": "rgb(204, 34, 34)",
@@ -38783,7 +38782,7 @@
               "Celje",
               "Kranj",
               "Koper",
-              "Novo Mesto",
+              "Novo mesto",
               "Murska Sobota",
               "Nova Gorica",
               "Postojna",
@@ -38791,10 +38790,10 @@
               "Velenje",
               "Trbovlje",
               "Tolmin",
-              "Kocevje",
+              "Kočevje",
               "Ilirska Bistrica",
-              "Domzale",
-              "Ratece",
+              "Domžale",
+              "Rateče",
               "Kredarica"
             ]
           },
@@ -40752,7 +40751,6 @@
       "analysis": {
         "rendered": {
           "toolbar": [
-            "LokacijaKredarica",
             "SpremenljivkaNajvišja temperatura (°C)Najnižja temperatura (°C)Povprečna temperatura (°C)Padavine (mm)ET₀ (mm)",
             "Dan21. jul.◀▶"
           ],
@@ -40767,8 +40765,8 @@
             ]
           },
           "day_label": "21. jul.",
-          "title": "Najvišja temperatura · 21. jul.",
-          "subtitle": "Kredarica",
+          "title": "Kredarica · Najvišja temperatura",
+          "subtitle": "21. jul.",
           "stats_badge": "Theil-Sen + TFPW MK · τ = 0,25",
           "total_change": "+2,74°C",
           "total_change_color": "rgb(204, 34, 34)",
@@ -42332,7 +42330,7 @@
               "Celje",
               "Kranj",
               "Koper",
-              "Novo Mesto",
+              "Novo mesto",
               "Murska Sobota",
               "Nova Gorica",
               "Postojna",
@@ -42340,10 +42338,10 @@
               "Velenje",
               "Trbovlje",
               "Tolmin",
-              "Kocevje",
+              "Kočevje",
               "Ilirska Bistrica",
-              "Domzale",
-              "Ratece",
+              "Domžale",
+              "Rateče",
               "Kredarica"
             ]
           },
@@ -44110,7 +44108,6 @@
       "analysis": {
         "rendered": {
           "toolbar": [
-            "LokacijaLjubljana",
             "SpremenljivkaNajvišja temperatura (°C)Najnižja temperatura (°C)Povprečna temperatura (°C)Padavine (mm)ET₀ (mm)",
             "Dan29. jul.◀▶"
           ],
@@ -44125,8 +44122,8 @@
             ]
           },
           "day_label": "29. jul.",
-          "title": "Najvišja temperatura · 29. jul.",
-          "subtitle": "Ljubljana",
+          "title": "Ljubljana · Najvišja temperatura",
+          "subtitle": "29. jul.",
           "stats_badge": "Theil-Sen + TFPW MK · τ = 0,33",
           "total_change": "+3,76°C",
           "total_change_color": "rgb(204, 34, 34)",
@@ -45690,7 +45687,7 @@
               "Celje",
               "Kranj",
               "Koper",
-              "Novo Mesto",
+              "Novo mesto",
               "Murska Sobota",
               "Nova Gorica",
               "Postojna",
@@ -45698,10 +45695,10 @@
               "Velenje",
               "Trbovlje",
               "Tolmin",
-              "Kocevje",
+              "Kočevje",
               "Ilirska Bistrica",
-              "Domzale",
-              "Ratece",
+              "Domžale",
+              "Rateče",
               "Kredarica"
             ]
           },
@@ -47659,7 +47656,6 @@
       "analysis": {
         "rendered": {
           "toolbar": [
-            "LokacijaLjubljana",
             "SpremenljivkaNajvišja temperatura (°C)Najnižja temperatura (°C)Povprečna temperatura (°C)Padavine (mm)ET₀ (mm)",
             "Dan29. jul.◀▶"
           ],
@@ -47674,8 +47670,8 @@
             ]
           },
           "day_label": "29. jul.",
-          "title": "Najvišja temperatura · 29. jul.",
-          "subtitle": "Ljubljana",
+          "title": "Ljubljana · Najvišja temperatura",
+          "subtitle": "29. jul.",
           "stats_badge": "Theil-Sen + TFPW MK · τ = 0,33",
           "total_change": "+3,76°C",
           "total_change_color": "rgb(204, 34, 34)",
@@ -49239,7 +49235,7 @@
               "Celje",
               "Kranj",
               "Koper",
-              "Novo Mesto",
+              "Novo mesto",
               "Murska Sobota",
               "Nova Gorica",
               "Postojna",
@@ -49247,10 +49243,10 @@
               "Velenje",
               "Trbovlje",
               "Tolmin",
-              "Kocevje",
+              "Kočevje",
               "Ilirska Bistrica",
-              "Domzale",
-              "Ratece",
+              "Domžale",
+              "Rateče",
               "Kredarica"
             ]
           },
@@ -51208,7 +51204,6 @@
       "analysis": {
         "rendered": {
           "toolbar": [
-            "LokacijaKredarica",
             "SpremenljivkaNajvišja temperatura (°C)Najnižja temperatura (°C)Povprečna temperatura (°C)Padavine (mm)ET₀ (mm)",
             "Dan29. jul.◀▶"
           ],
@@ -51223,8 +51218,8 @@
             ]
           },
           "day_label": "29. jul.",
-          "title": "Najvišja temperatura · 29. jul.",
-          "subtitle": "Kredarica",
+          "title": "Kredarica · Najvišja temperatura",
+          "subtitle": "29. jul.",
           "stats_badge": "Theil-Sen + TFPW MK · τ = 0,26",
           "total_change": "+2,40°C",
           "total_change_color": "rgb(204, 34, 34)",
@@ -52788,7 +52783,7 @@
               "Celje",
               "Kranj",
               "Koper",
-              "Novo Mesto",
+              "Novo mesto",
               "Murska Sobota",
               "Nova Gorica",
               "Postojna",
@@ -52796,10 +52791,10 @@
               "Velenje",
               "Trbovlje",
               "Tolmin",
-              "Kocevje",
+              "Kočevje",
               "Ilirska Bistrica",
-              "Domzale",
-              "Ratece",
+              "Domžale",
+              "Rateče",
               "Kredarica"
             ]
           },
@@ -54566,7 +54561,6 @@
       "analysis": {
         "rendered": {
           "toolbar": [
-            "LokacijaLjubljana",
             "SpremenljivkaNajvišja temperatura (°C)Najnižja temperatura (°C)Povprečna temperatura (°C)Padavine (mm)ET₀ (mm)",
             "Dan15. jul.◀▶"
           ],
@@ -54581,8 +54575,8 @@
             ]
           },
           "day_label": "15. jul.",
-          "title": "Najvišja temperatura · 15. jul.",
-          "subtitle": "Ljubljana",
+          "title": "Ljubljana · Najvišja temperatura",
+          "subtitle": "15. jul.",
           "stats_badge": "Theil-Sen + TFPW MK · τ = 0,30",
           "total_change": "+3,54°C",
           "total_change_color": "rgb(204, 34, 34)",
@@ -56146,7 +56140,7 @@
               "Celje",
               "Kranj",
               "Koper",
-              "Novo Mesto",
+              "Novo mesto",
               "Murska Sobota",
               "Nova Gorica",
               "Postojna",
@@ -56154,10 +56148,10 @@
               "Velenje",
               "Trbovlje",
               "Tolmin",
-              "Kocevje",
+              "Kočevje",
               "Ilirska Bistrica",
-              "Domzale",
-              "Ratece",
+              "Domžale",
+              "Rateče",
               "Kredarica"
             ]
           },
@@ -58115,7 +58109,6 @@
       "analysis": {
         "rendered": {
           "toolbar": [
-            "LokacijaLjubljana",
             "SpremenljivkaNajvišja temperatura (°C)Najnižja temperatura (°C)Povprečna temperatura (°C)Padavine (mm)ET₀ (mm)",
             "Dan15. jul.◀▶"
           ],
@@ -58130,8 +58123,8 @@
             ]
           },
           "day_label": "15. jul.",
-          "title": "Najvišja temperatura · 15. jul.",
-          "subtitle": "Ljubljana",
+          "title": "Ljubljana · Najvišja temperatura",
+          "subtitle": "15. jul.",
           "stats_badge": "Theil-Sen + TFPW MK · τ = 0,30",
           "total_change": "+3,54°C",
           "total_change_color": "rgb(204, 34, 34)",
@@ -59695,7 +59688,7 @@
               "Celje",
               "Kranj",
               "Koper",
-              "Novo Mesto",
+              "Novo mesto",
               "Murska Sobota",
               "Nova Gorica",
               "Postojna",
@@ -59703,10 +59696,10 @@
               "Velenje",
               "Trbovlje",
               "Tolmin",
-              "Kocevje",
+              "Kočevje",
               "Ilirska Bistrica",
-              "Domzale",
-              "Ratece",
+              "Domžale",
+              "Rateče",
               "Kredarica"
             ]
           },
@@ -61664,7 +61657,6 @@
       "analysis": {
         "rendered": {
           "toolbar": [
-            "LokacijaKredarica",
             "SpremenljivkaNajvišja temperatura (°C)Najnižja temperatura (°C)Povprečna temperatura (°C)Padavine (mm)ET₀ (mm)",
             "Dan15. jul.◀▶"
           ],
@@ -61679,8 +61671,8 @@
             ]
           },
           "day_label": "15. jul.",
-          "title": "Najvišja temperatura · 15. jul.",
-          "subtitle": "Kredarica",
+          "title": "Kredarica · Najvišja temperatura",
+          "subtitle": "15. jul.",
           "stats_badge": "Theil-Sen + TFPW MK · τ = 0,19",
           "total_change": "+1,72°C",
           "total_change_color": "rgb(204, 34, 34)",
@@ -62436,7 +62428,7 @@
               "Celje",
               "Kranj",
               "Koper",
-              "Novo Mesto",
+              "Novo mesto",
               "Murska Sobota",
               "Nova Gorica",
               "Postojna",
@@ -62444,10 +62436,10 @@
               "Velenje",
               "Trbovlje",
               "Tolmin",
-              "Kocevje",
+              "Kočevje",
               "Ilirska Bistrica",
-              "Domzale",
-              "Ratece",
+              "Domžale",
+              "Rateče",
               "Kredarica"
             ]
           },
@@ -62532,7 +62524,6 @@
       "analysis": {
         "rendered": {
           "toolbar": [
-            "LokacijaLjubljana",
             "SpremenljivkaNajvišja temperatura (°C)Najnižja temperatura (°C)Povprečna temperatura (°C)Padavine (mm)ET₀ (mm)",
             "Dan28. feb.◀▶"
           ],
@@ -62547,8 +62538,8 @@
             ]
           },
           "day_label": "28. feb.",
-          "title": "Najvišja temperatura · 28. feb.",
-          "subtitle": "Ljubljana",
+          "title": "Ljubljana · Najvišja temperatura",
+          "subtitle": "28. feb.",
           "stats_badge": "Theil-Sen + TFPW MK · τ = 0,21",
           "total_change": "+4,40°C",
           "total_change_color": "rgb(204, 34, 34)",
@@ -63304,7 +63295,7 @@
               "Celje",
               "Kranj",
               "Koper",
-              "Novo Mesto",
+              "Novo mesto",
               "Murska Sobota",
               "Nova Gorica",
               "Postojna",
@@ -63312,10 +63303,10 @@
               "Velenje",
               "Trbovlje",
               "Tolmin",
-              "Kocevje",
+              "Kočevje",
               "Ilirska Bistrica",
-              "Domzale",
-              "Ratece",
+              "Domžale",
+              "Rateče",
               "Kredarica"
             ]
           },
@@ -63400,7 +63391,6 @@
       "analysis": {
         "rendered": {
           "toolbar": [
-            "LokacijaKredarica",
             "SpremenljivkaNajvišja temperatura (°C)Najnižja temperatura (°C)Povprečna temperatura (°C)Padavine (mm)ET₀ (mm)",
             "Dan28. feb.◀▶"
           ],
@@ -63415,8 +63405,8 @@
             ]
           },
           "day_label": "28. feb.",
-          "title": "Najvišja temperatura · 28. feb.",
-          "subtitle": "Kredarica",
+          "title": "Kredarica · Najvišja temperatura",
+          "subtitle": "28. feb.",
           "stats_badge": "Theil-Sen + TFPW MK · τ = 0,16",
           "total_change": "+2,90°C",
           "total_change_color": "rgb(204, 34, 34)",
@@ -64172,7 +64162,7 @@
               "Celje",
               "Kranj",
               "Koper",
-              "Novo Mesto",
+              "Novo mesto",
               "Murska Sobota",
               "Nova Gorica",
               "Postojna",
@@ -64180,10 +64170,10 @@
               "Velenje",
               "Trbovlje",
               "Tolmin",
-              "Kocevje",
+              "Kočevje",
               "Ilirska Bistrica",
-              "Domzale",
-              "Ratece",
+              "Domžale",
+              "Rateče",
               "Kredarica"
             ]
           },
@@ -64219,7 +64209,6 @@
       "analysis": {
         "rendered": {
           "toolbar": [
-            "LokacijaLjubljana",
             "SpremenljivkaNajvišja temperatura (°C)Najnižja temperatura (°C)Povprečna temperatura (°C)Padavine (mm)ET₀ (mm)",
             "Dan28. feb.◀▶"
           ],
@@ -64234,8 +64223,8 @@
             ]
           },
           "day_label": "28. feb.",
-          "title": "Najvišja temperatura · 28. feb.",
-          "subtitle": "Ljubljana",
+          "title": "Ljubljana · Najvišja temperatura",
+          "subtitle": "28. feb.",
           "stats_badge": "Theil-Sen + TFPW MK · τ = 0,21",
           "total_change": "+4,40°C",
           "total_change_color": "rgb(204, 34, 34)",
@@ -65799,7 +65788,7 @@
               "Celje",
               "Kranj",
               "Koper",
-              "Novo Mesto",
+              "Novo mesto",
               "Murska Sobota",
               "Nova Gorica",
               "Postojna",
@@ -65807,10 +65796,10 @@
               "Velenje",
               "Trbovlje",
               "Tolmin",
-              "Kocevje",
+              "Kočevje",
               "Ilirska Bistrica",
-              "Domzale",
-              "Ratece",
+              "Domžale",
+              "Rateče",
               "Kredarica"
             ]
           },
@@ -67750,7 +67739,6 @@
       "analysis": {
         "rendered": {
           "toolbar": [
-            "LokacijaLjubljana",
             "SpremenljivkaNajvišja temperatura (°C)Najnižja temperatura (°C)Povprečna temperatura (°C)Padavine (mm)ET₀ (mm)",
             "Dan1. mar.◀▶"
           ],
@@ -67765,8 +67753,8 @@
             ]
           },
           "day_label": "1. mar.",
-          "title": "Najvišja temperatura · 1. mar.",
-          "subtitle": "Ljubljana",
+          "title": "Ljubljana · Najvišja temperatura",
+          "subtitle": "1. mar.",
           "stats_badge": "Theil-Sen + TFPW MK · τ = 0,21",
           "total_change": "+4,29°C",
           "total_change_color": "rgb(204, 34, 34)",
@@ -69330,7 +69318,7 @@
               "Celje",
               "Kranj",
               "Koper",
-              "Novo Mesto",
+              "Novo mesto",
               "Murska Sobota",
               "Nova Gorica",
               "Postojna",
@@ -69338,10 +69326,10 @@
               "Velenje",
               "Trbovlje",
               "Tolmin",
-              "Kocevje",
+              "Kočevje",
               "Ilirska Bistrica",
-              "Domzale",
-              "Ratece",
+              "Domžale",
+              "Rateče",
               "Kredarica"
             ]
           },
@@ -71299,7 +71287,6 @@
       "analysis": {
         "rendered": {
           "toolbar": [
-            "LokacijaLjubljana",
             "SpremenljivkaNajvišja temperatura (°C)Najnižja temperatura (°C)Povprečna temperatura (°C)Padavine (mm)ET₀ (mm)",
             "Dan28. feb.◀▶"
           ],
@@ -71314,8 +71301,8 @@
             ]
           },
           "day_label": "28. feb.",
-          "title": "Najvišja temperatura · 28. feb.",
-          "subtitle": "Ljubljana",
+          "title": "Ljubljana · Najvišja temperatura",
+          "subtitle": "28. feb.",
           "stats_badge": "Theil-Sen + TFPW MK · τ = 0,21",
           "total_change": "+4,40°C",
           "total_change_color": "rgb(204, 34, 34)",
@@ -72879,7 +72866,7 @@
               "Celje",
               "Kranj",
               "Koper",
-              "Novo Mesto",
+              "Novo mesto",
               "Murska Sobota",
               "Nova Gorica",
               "Postojna",
@@ -72887,10 +72874,10 @@
               "Velenje",
               "Trbovlje",
               "Tolmin",
-              "Kocevje",
+              "Kočevje",
               "Ilirska Bistrica",
-              "Domzale",
-              "Ratece",
+              "Domžale",
+              "Rateče",
               "Kredarica"
             ]
           },
@@ -74848,7 +74835,6 @@
       "analysis": {
         "rendered": {
           "toolbar": [
-            "LokacijaLjubljana",
             "SpremenljivkaNajvišja temperatura (°C)Najnižja temperatura (°C)Povprečna temperatura (°C)Padavine (mm)ET₀ (mm)",
             "Dan1. mar.◀▶"
           ],
@@ -74863,8 +74849,8 @@
             ]
           },
           "day_label": "1. mar.",
-          "title": "Najvišja temperatura · 1. mar.",
-          "subtitle": "Ljubljana",
+          "title": "Ljubljana · Najvišja temperatura",
+          "subtitle": "1. mar.",
           "stats_badge": "Theil-Sen + TFPW MK · τ = 0,21",
           "total_change": "+4,29°C",
           "total_change_color": "rgb(204, 34, 34)",
@@ -76428,7 +76414,7 @@
               "Celje",
               "Kranj",
               "Koper",
-              "Novo Mesto",
+              "Novo mesto",
               "Murska Sobota",
               "Nova Gorica",
               "Postojna",
@@ -76436,10 +76422,10 @@
               "Velenje",
               "Trbovlje",
               "Tolmin",
-              "Kocevje",
+              "Kočevje",
               "Ilirska Bistrica",
-              "Domzale",
-              "Ratece",
+              "Domžale",
+              "Rateče",
               "Kredarica"
             ]
           },
@@ -78397,7 +78383,6 @@
       "analysis": {
         "rendered": {
           "toolbar": [
-            "LokacijaLjubljana",
             "SpremenljivkaNajvišja temperatura (°C)Najnižja temperatura (°C)Povprečna temperatura (°C)Padavine (mm)ET₀ (mm)",
             "Dan1. jan.◀▶"
           ],
@@ -78412,8 +78397,8 @@
             ]
           },
           "day_label": "1. jan.",
-          "title": "Najvišja temperatura · 1. jan.",
-          "subtitle": "Ljubljana",
+          "title": "Ljubljana · Najvišja temperatura",
+          "subtitle": "1. jan.",
           "stats_badge": "Theil-Sen + TFPW MK · τ = 0,24",
           "total_change": "+3,73°C",
           "total_change_color": "rgb(204, 34, 34)",
@@ -79977,7 +79962,7 @@
               "Celje",
               "Kranj",
               "Koper",
-              "Novo Mesto",
+              "Novo mesto",
               "Murska Sobota",
               "Nova Gorica",
               "Postojna",
@@ -79985,10 +79970,10 @@
               "Velenje",
               "Trbovlje",
               "Tolmin",
-              "Kocevje",
+              "Kočevje",
               "Ilirska Bistrica",
-              "Domzale",
-              "Ratece",
+              "Domžale",
+              "Rateče",
               "Kredarica"
             ]
           },
@@ -81938,7 +81923,6 @@
       "analysis": {
         "rendered": {
           "toolbar": [
-            "LokacijaLjubljana",
             "SpremenljivkaNajvišja temperatura (°C)Najnižja temperatura (°C)Povprečna temperatura (°C)Padavine (mm)ET₀ (mm)",
             "Dan31. dec.◀▶"
           ],
@@ -81953,8 +81937,8 @@
             ]
           },
           "day_label": "31. dec.",
-          "title": "Najvišja temperatura · 31. dec.",
-          "subtitle": "Ljubljana",
+          "title": "Ljubljana · Najvišja temperatura",
+          "subtitle": "31. dec.",
           "stats_badge": "Theil-Sen + TFPW MK · τ = 0,27",
           "total_change": "+3,90°C",
           "total_change_color": "rgb(204, 34, 34)",
@@ -83518,7 +83502,7 @@
               "Celje",
               "Kranj",
               "Koper",
-              "Novo Mesto",
+              "Novo mesto",
               "Murska Sobota",
               "Nova Gorica",
               "Postojna",
@@ -83526,10 +83510,10 @@
               "Velenje",
               "Trbovlje",
               "Tolmin",
-              "Kocevje",
+              "Kočevje",
               "Ilirska Bistrica",
-              "Domzale",
-              "Ratece",
+              "Domžale",
+              "Rateče",
               "Kredarica"
             ]
           },
@@ -85479,7 +85463,6 @@
       "analysis": {
         "rendered": {
           "toolbar": [
-            "LokacijaLjubljana",
             "SpremenljivkaNajvišja temperatura (°C)Najnižja temperatura (°C)Povprečna temperatura (°C)Padavine (mm)ET₀ (mm)",
             "Dan3. avg.◀▶"
           ],
@@ -85494,8 +85477,8 @@
             ]
           },
           "day_label": "3. avg.",
-          "title": "Najvišja temperatura · 3. avg.",
-          "subtitle": "Ljubljana",
+          "title": "Ljubljana · Najvišja temperatura",
+          "subtitle": "3. avg.",
           "stats_badge": "Theil-Sen + TFPW MK · τ = 0,28",
           "total_change": "+3,13°C",
           "total_change_color": "rgb(204, 34, 34)",
@@ -87059,7 +87042,7 @@
               "Celje",
               "Kranj",
               "Koper",
-              "Novo Mesto",
+              "Novo mesto",
               "Murska Sobota",
               "Nova Gorica",
               "Postojna",
@@ -87067,10 +87050,10 @@
               "Velenje",
               "Trbovlje",
               "Tolmin",
-              "Kocevje",
+              "Kočevje",
               "Ilirska Bistrica",
-              "Domzale",
-              "Ratece",
+              "Domžale",
+              "Rateče",
               "Kredarica"
             ]
           },
@@ -89020,7 +89003,6 @@
       "analysis": {
         "rendered": {
           "toolbar": [
-            "LokacijaKredarica",
             "SpremenljivkaNajvišja temperatura (°C)Najnižja temperatura (°C)Povprečna temperatura (°C)Padavine (mm)ET₀ (mm)",
             "Dan3. avg.◀▶"
           ],
@@ -89035,8 +89017,8 @@
             ]
           },
           "day_label": "3. avg.",
-          "title": "Najvišja temperatura · 3. avg.",
-          "subtitle": "Kredarica",
+          "title": "Kredarica · Najvišja temperatura",
+          "subtitle": "3. avg.",
           "stats_badge": "Theil-Sen + TFPW MK · τ = 0,22",
           "total_change": "+2,04°C",
           "total_change_color": "rgb(204, 34, 34)",
@@ -90600,7 +90582,7 @@
               "Celje",
               "Kranj",
               "Koper",
-              "Novo Mesto",
+              "Novo mesto",
               "Murska Sobota",
               "Nova Gorica",
               "Postojna",
@@ -90608,10 +90590,10 @@
               "Velenje",
               "Trbovlje",
               "Tolmin",
-              "Kocevje",
+              "Kočevje",
               "Ilirska Bistrica",
-              "Domzale",
-              "Ratece",
+              "Domžale",
+              "Rateče",
               "Kredarica"
             ]
           },
@@ -92569,7 +92551,6 @@
       "analysis": {
         "rendered": {
           "toolbar": [
-            "LokacijaLjubljana",
             "SpremenljivkaNajvišja temperatura (°C)Najnižja temperatura (°C)Povprečna temperatura (°C)Padavine (mm)ET₀ (mm)",
             "Dan7. feb.◀▶"
           ],
@@ -92584,8 +92565,8 @@
             ]
           },
           "day_label": "7. feb.",
-          "title": "Najvišja temperatura · 7. feb.",
-          "subtitle": "Ljubljana",
+          "title": "Ljubljana · Najvišja temperatura",
+          "subtitle": "7. feb.",
           "stats_badge": "Theil-Sen + TFPW MK · τ = 0,25",
           "total_change": "+4,38°C",
           "total_change_color": "rgb(204, 34, 34)",
@@ -94162,7 +94143,7 @@
               "Celje",
               "Kranj",
               "Koper",
-              "Novo Mesto",
+              "Novo mesto",
               "Murska Sobota",
               "Nova Gorica",
               "Postojna",
@@ -94170,10 +94151,10 @@
               "Velenje",
               "Trbovlje",
               "Tolmin",
-              "Kocevje",
+              "Kočevje",
               "Ilirska Bistrica",
-              "Domzale",
-              "Ratece",
+              "Domžale",
+              "Rateče",
               "Kredarica"
             ]
           },
@@ -96131,7 +96112,6 @@
       "analysis": {
         "rendered": {
           "toolbar": [
-            "LokacijaKredarica",
             "SpremenljivkaNajvišja temperatura (°C)Najnižja temperatura (°C)Povprečna temperatura (°C)Padavine (mm)ET₀ (mm)",
             "Dan7. jan.◀▶"
           ],
@@ -96146,8 +96126,8 @@
             ]
           },
           "day_label": "7. jan.",
-          "title": "Najvišja temperatura · 7. jan.",
-          "subtitle": "Kredarica",
+          "title": "Kredarica · Najvišja temperatura",
+          "subtitle": "7. jan.",
           "stats_badge": "Theil-Sen + TFPW MK · τ = 0,28",
           "total_change": "+4,16°C",
           "total_change_color": "rgb(204, 34, 34)",

--- a/tests/snapshot/sections.json
+++ b/tests/snapshot/sections.json
@@ -99,6 +99,7 @@
 
   "structural": {
     "Dashboard": "Local layout wrapper for the whole page (AliJeVroceERA5.tsx:43). The harness mirrors its composition; it renders no numbers itself.",
+    "FloatingStationChooser": "The single below-hero location control (T-5.27 / D-26, RegressionPanel.tsx). Like TropControls, it displays no data of its own — it WRITES the regression store's location (s.setLoc), and that location drives every analysis capture (RegScatterCard title, RegYearRoundCard, tropical, season, hero). Its markup is a station list; the snapshot cannot scroll or interact with it and there is no rendered number to watch. The station it selects is pinned per case by cases.json analysis_loc (via syncLoc), exactly as before.",
     "Era5Charts": "Local layout wrapper for the lower sections (AliJeVroceERA5.tsx:207). Renders no numbers itself.",
     "TropControls": "Threshold and streak inputs (AliJeVroceERA5.tsx:181). Their VALUES are pinned in cases.json analysis_defaults and drive the tropical captures; the control markup itself displays no data.",
     "RegressionPanel": "Context provider only (RegressionPanel.tsx:121). Supplies the analysis store to the cards, renders no DOM of its own.",


### PR DESCRIPTION
One location control below the hero: a floating corner chooser, the regression panel's
multi-select retired, and every below-hero chart now naming its station.

The control is a compact circular location-pin icon in the bottom-right, revealed in the
trends region, shown when scrolling stops and hidden when it resumes, and kept visible while
open or focused so a keyboard user never chases it. The list expands upward over content
already read, holds the 18 stations in Slovene collation order, and is single-select. A
native select could not do this — the browser controls its dropdown direction — so the
keyboard contract, focus management and listbox semantics are hand-built, and the fade is
gated on prefers-reduced-motion, the page's first such guard.

National is deliberately absent below the fold. It has no data there: the tropical fetch
returns null for it and annual_trend, season_heatmap and calendar have no national row, so
offering it would blank five sections at once.

Investigating the station display names found three wrong premises in sequence. The name
column is ASCII, not the display name. official_name is the ARSO observing-station identity,
so projecting it would have rendered Nova Gorica as Bilje and Murska Sobota as Rakičan —
worse than the original bug. name_locative holds the right towns in the locative case. No
column holds the nominative diacritic town name. All of this survived earlier scrutiny
because no consumer displayed a station with diacritics: the chart titles read correctly only
because Nova Gorica has none.

Resolved with a complete 18-entry authored map that fails loudly on an unknown station rather
than falling back to ASCII. Four corrections: Domžale, Kočevje, Rateče, and Novo mesto —
lowercase m is correct Slovene, since only the first word of a multi-word settlement name
capitalises unless a later word is itself a proper noun.

Every below-hero chart now names its station. The season heatmap had none at all; the scatter
title leads with the station and moves the day to the subtitle.

Snapshot moved text only, zero numeric, fixture set unchanged at 2087. Note that the
snapshot's two stations have no diacritics, so it barely moves while the page changes for
four others — this is device-verified, not snapshot-verified.

Residual, scoped out: the SPEI trend keeps its own station picker, so two below-hero location
controls still exist. Tracked separately.

Gates: typecheck 0, typecheck:gate 0 allowlisted, yarn test 79, snapshot identical after a
deliberate re-record, pytest 72.
