### PR TITLE
T-5.33: show the selected year on the hero badge when it is not the current year

### DIFF
--- a/code/ali-je-vroce-era5/components/TodayCard.tsx
+++ b/code/ali-je-vroce-era5/components/TodayCard.tsx
@@ -4,7 +4,7 @@ import { isArsoLoc, daysInMonth } from "../api.ts";
 import { todayYear } from "../clock.ts";
 import { TodayFlag } from "./TodayFlag.tsx";
 import { TodayGauge } from "../charts/TodayGauge.tsx";
-import { t, fmtNum, fmtInt, fmtMonthDay, fmtMonthLong } from "../i18n/format.ts";
+import { t, fmtNum, fmtInt, fmtMonthDay, fmtMonthDayYear, fmtMonthLong } from "../i18n/format.ts";
 
 const TodayLast7Chart = lazy(() => import("./TodayLast7Chart.tsx").then(m => ({ default: m.TodayLast7Chart })));
 
@@ -63,9 +63,18 @@ function fmtDayLabel(dl: string): string {
   const m = EN_MONTHS[mon ?? ""] ?? 0;
   return m ? fmtMonthDay(m, Number(day)) : "??";
 }
-function fmtDate(dateStr: string): string {
-  const [, mm, dd] = dateStr.split("-");
-  return fmtMonthDay(Number(mm), Number(dd));
+// The hero badge (T-5.33). Show the year ONLY when the selected date is not in the
+// device-current year — then "1. avg." would silently read as today's year while the
+// reader is looking at, say, 1994 data. `currentYear` is the device year (clock.ts,
+// Europe/Ljubljana), threaded in as props.today's year — NOT the record end or the
+// served-data end, which lag it. The year comes from Intl (fmtMonthDayYear), same
+// boundary as every other date on the page (format.ts:68).
+function fmtDate(dateStr: string, currentYear: number): string {
+  const [yy, mm, dd] = dateStr.split("-");
+  const y = Number(yy);
+  return y === currentYear
+    ? fmtMonthDay(Number(mm), Number(dd))
+    : fmtMonthDayYear(Number(mm), Number(dd), y);
 }
 
 function addDays(dateStr: string, n: number): string {
@@ -299,8 +308,9 @@ function RankBadge(props: { info: RankInfo; dayLabel: string }) {
 // an error to hide. Split from the DOY picker on purpose (state type, bounds, month-wrap
 // and leap handling all differ); it reuses the .reg-cal-* CSS and the fmtMonthLong month
 // names, so no content has a second source of truth (D-18 / T-5.26). Popover is closed by
-// default → adds no rendered text; the badge text (fmtDate) is unchanged, so the snapshot
-// (r.txt(".today-date-badge")) stays byte-identical.
+// default → adds no rendered text. The badge text (fmtDate) now appends the year for a
+// non-current-year date (T-5.33), so the snapshot leaf (r.txt(".today-date-badge")) moves
+// for any case pinned outside the device-current year — text only, no number.
 function pad2(n: number): string { return String(n).padStart(2, "0"); }
 function isoOf(y: number, m: number, d: number): string { return `${y}-${pad2(m)}-${pad2(d)}`; }
 
@@ -411,7 +421,7 @@ function HeroDatePicker(props: { date: string; today: string; onDateChange: (d: 
         onClick={() => (calOpen() ? closeCal(false) : openCal())}
         onKeyDown={onTriggerKey}
       >
-        {fmtDate(props.date)}
+        {fmtDate(props.date, maxYear())}
       </div>
       <Show when={calOpen()}>
         <div

--- a/code/ali-je-vroce-era5/i18n/format.ts
+++ b/code/ali-je-vroce-era5/i18n/format.ts
@@ -100,6 +100,16 @@ export function fmtMonthDay(month: number, day: number): string {
   return dtShort.format(new Date(2001, month - 1, day));
 }
 
+const dtShortYear = new Intl.DateTimeFormat(LOCALE, { day: "numeric", month: "short", year: "numeric" });
+
+/** Slovenian short date WITH the year, e.g. (8, 1, 1994) → "1. avg. 1994". The
+ * real year is passed (not the 2001 stand-in of fmtMonthDay) so a leap day like
+ * (2, 29, 2024) renders — the year is genuine and Intl formats it as a bare "1994"
+ * (no thousands grouping for a year). */
+export function fmtMonthDayYear(month: number, day: number, year: number): string {
+  return dtShortYear.format(new Date(year, month - 1, day));
+}
+
 /** Slovenian short date for a day-of-year (1..365 on the 2001 non-leap calendar). */
 export function fmtDoy(doy: number): string {
   const d = new Date(Date.UTC(2001, 0, 1));

--- a/tests/fixtures/snapshot.json
+++ b/tests/fixtures/snapshot.json
@@ -52629,7 +52629,7 @@
           }
         },
         "rendered": {
-          "date_badge": "15. jul.",
+          "date_badge": "15. jul. 2025",
           "category_label": "Vroče",
           "category_color": "rgb(194, 90, 44)",
           "description": "Med najtoplejšimi 15. jul. v naših zapisih.",
@@ -55962,7 +55962,7 @@
           }
         },
         "rendered": {
-          "date_badge": "15. jul.",
+          "date_badge": "15. jul. 2025",
           "category_label": "Vroče",
           "category_color": "rgb(194, 90, 44)",
           "description": "Med najtoplejšimi 15. jul. v naših zapisih.",
@@ -59486,7 +59486,7 @@
           }
         },
         "rendered": {
-          "date_badge": "15. jul.",
+          "date_badge": "15. jul. 2025",
           "category_label": "Vroče",
           "category_color": "rgb(194, 90, 44)",
           "description": "Med najtoplejšimi 15. jul. v naših zapisih.",
@@ -62202,7 +62202,7 @@
           }
         },
         "rendered": {
-          "date_badge": "1. mar.",
+          "date_badge": "29. feb. 2024",
           "category_label": null,
           "category_color": null,
           "description": null,
@@ -63045,7 +63045,7 @@
           }
         },
         "rendered": {
-          "date_badge": "1. mar.",
+          "date_badge": "29. feb. 2024",
           "category_label": null,
           "category_color": null,
           "description": null,
@@ -63888,7 +63888,7 @@
           }
         },
         "rendered": {
-          "date_badge": "1. mar.",
+          "date_badge": "29. feb. 2024",
           "category_label": null,
           "category_color": null,
           "description": null,
@@ -65490,7 +65490,7 @@
           }
         },
         "rendered": {
-          "date_badge": "1. mar.",
+          "date_badge": "1. mar. 2024",
           "category_label": "Normalno",
           "category_color": "rgb(231, 217, 184)",
           "description": "Točno takšno, kot 1. mar. v Sloveniji ponavadi je.",
@@ -68996,7 +68996,7 @@
           }
         },
         "rendered": {
-          "date_badge": "28. feb.",
+          "date_badge": "28. feb. 2025",
           "category_label": "Normalno",
           "category_color": "rgb(231, 217, 184)",
           "description": "Točno takšno, kot 28. feb. v Sloveniji ponavadi je.",
@@ -72520,7 +72520,7 @@
           }
         },
         "rendered": {
-          "date_badge": "1. mar.",
+          "date_badge": "1. mar. 2025",
           "category_label": "Normalno",
           "category_color": "rgb(231, 217, 184)",
           "description": "Točno takšno, kot 1. mar. v Sloveniji ponavadi je.",
@@ -76044,7 +76044,7 @@
           }
         },
         "rendered": {
-          "date_badge": "1. jan.",
+          "date_badge": "1. jan. 2025",
           "category_label": "Vroče",
           "category_color": "rgb(194, 90, 44)",
           "description": "Med najtoplejšimi 1. jan. v naših zapisih.",
@@ -79568,7 +79568,7 @@
           }
         },
         "rendered": {
-          "date_badge": "31. dec.",
+          "date_badge": "31. dec. 2025",
           "category_label": "Normalno",
           "category_color": "rgb(231, 217, 184)",
           "description": "Točno takšno, kot 31. dec. v Sloveniji ponavadi je.",
@@ -83084,7 +83084,7 @@
           }
         },
         "rendered": {
-          "date_badge": "3. avg.",
+          "date_badge": "3. avg. 2013",
           "category_label": "Ekstremno",
           "category_color": "rgb(150, 44, 26)",
           "description": "Izjemna vročina — med najtoplejšimi 5 % vseh 3. avg. od 1950.",
@@ -86600,7 +86600,7 @@
           }
         },
         "rendered": {
-          "date_badge": "3. avg.",
+          "date_badge": "3. avg. 2013",
           "category_label": "Ekstremno",
           "category_color": "rgb(150, 44, 26)",
           "description": "Izjemna vročina — med najtoplejšimi 5 % vseh 3. avg. od 1950.",
@@ -90116,7 +90116,7 @@
           }
         },
         "rendered": {
-          "date_badge": "7. feb.",
+          "date_badge": "7. feb. 2012",
           "category_label": "Hladno",
           "category_color": "rgb(58, 90, 138)",
           "description": "Med najhladnejšimi 7. feb. v naših 77 letih zapisov.",
@@ -93653,7 +93653,7 @@
           }
         },
         "rendered": {
-          "date_badge": "7. jan.",
+          "date_badge": "7. jan. 1985",
           "category_label": "Hladno",
           "category_color": "rgb(58, 90, 138)",
           "description": "Med najhladnejšimi 7. jan. v naših 77 letih zapisov.",


### PR DESCRIPTION
The hero date badge now shows the selected year when it is not the current year: "1. avg." in
2026, "1. avg. 1994" otherwise.

The badge rendered month and day only, and the selected year appeared nowhere on the closed
card — every other year shown there is the record range. So a reader viewing 1 August 1994
saw "1. avg." while the percentile, category and gauge all correctly described a day they
could not identify. The calendar picker did not cause this; it made it reachable, taking 1994
from hundreds of arrow clicks to two.

The conditional was chosen over always showing the year, which adds noise on the default view,
and over putting it in the explanatory sentence, which was rejected: the badge is where a
reader looks and what the picker sets, so leaving it incomplete while the correction hides in
prose is a disclosure that is technically present and practically invisible. That sentence
also already contains a year, so it would have carried two years meaning different things.

This uncovered an older display bug: the badge rendered a selected 29 February as "1. mar.",
because the shared formatter formats through a non-leap stand-in year. The label silently
moved the reader's date while the underlying data was correct. Fixed by the real-year path,
which now reads "29. feb. 2024".

Implemented as a new sibling formatter rather than by changing the shared one, which has five
other consumers — editing it would have moved text on surfaces this ticket never intended to
touch. The year comes from Intl, consistent with the existing formatting boundary, and
"current year" is the device year rather than the record end or the served-data end, which
lag by about six days.

Badge width was measured rather than assumed, since mid-word clipping is a recorded defect
class on this page: 114px in a 360px control row, no clipping at 390px.

Snapshot moved exactly 15 leaves, all the date badge, in every case pinning a year other than
2026 — including both leap-year witnesses. Zero numeric leaves moved. Cases sitting in the
current year did not move, as expected.

Gates: typecheck 0, typecheck:gate 0 allowlisted, yarn test 79, snapshot identical after a
deliberate re-record, pytest 72.
