### PR TITLE
T-5.36: the floating chooser drives the SPEI trend; retire its own station picker

### DIFF
--- a/code/ali-je-vroce-era5/AliJeVroceERA5.tsx
+++ b/code/ali-je-vroce-era5/AliJeVroceERA5.tsx
@@ -316,7 +316,7 @@ function Era5Charts() {
         <ErrorBoundary fallback={sectionErrorFallback(refetchSpeiStation, "400px")}>
           <Suspense fallback={<div class="animate-pulse rounded-xl bg-[var(--color-paper-2)]" style={{ height: "400px" }} />}>
             <Show when={speiStationData()?.available} fallback={<EmptyState minHeight="400px" />}>
-              <SpeiTrendChartLazy data={speiStationData()!} />
+              <SpeiTrendChartLazy data={speiStationData()!} loc={loc()} label={st()?.label} />
             </Show>
           </Suspense>
         </ErrorBoundary>

--- a/code/ali-je-vroce-era5/charts/SpeiTrendChart.tsx
+++ b/code/ali-je-vroce-era5/charts/SpeiTrendChart.tsx
@@ -147,16 +147,27 @@ function SpeiScatterChart(props: ChartProps) {
 
 // ── Main component ────────────────────────────────────────────────────────────
 
-export interface SpeiTrendChartProps { data: SpeiStationData; }
+export interface SpeiTrendChartProps {
+  data:   SpeiStationData;
+  // T-5.36 / D-26 — the location is set by the page-wide floating chooser, not an
+  // own picker (retired here; the sibling "Sezonski sušni indeks" is national and
+  // untouched). `loc` is the era5_name key that indexes `data.stations`; `label` is
+  // the diacritic display name (i18n/station-names via meta.stations). The period
+  // control below is NOT a location control and stays.
+  loc:    string | null;
+  label?: string | undefined;
+}
 
 export function SpeiTrendChart(props: SpeiTrendChartProps) {
-  const stations = createMemo(() => Object.keys(props.data.stations).sort());
+  const [period, setPeriod] = createSignal<Period>("Summer");
 
-  const [station, setStation] = createSignal<string>(stations()[0] ?? "");
-  const [period,  setPeriod]  = createSignal<Period>("Summer");
+  // T-5.36 part (3) — the section still NAMES its station in the panel header, since
+  // its location is now set by a possibly-off-screen control. Show the diacritic
+  // display name; ASCII era5_name is the last-resort fallback.
+  const stationName = () => props.label ?? (props.loc ?? "").replace(/_/g, " ");
 
   const series = createMemo((): SpeiSeries | null =>
-    props.data.stations[station()]?.[period()] ?? null
+    (props.loc ? props.data.stations[props.loc] : undefined)?.[period()] ?? null
   );
 
   const isMonth = createMemo(() => (MONTHS as readonly string[]).includes(period()));
@@ -210,16 +221,6 @@ export function SpeiTrendChart(props: SpeiTrendChartProps) {
 
   // ── Button styles ──────────────────────────────────────────────────────────
 
-  function stationBtnStyle(s: string) {
-    const active = station() === s;
-    return {
-      "font-family": "var(--font-sans)", "font-size": "11px", padding: "4px 10px",
-      "border-radius": "20px", border: "1px solid var(--color-rule-2)", cursor: "pointer",
-      background: active ? "var(--color-ink)" : "var(--color-card)",
-      color: active ? "#fff" : "var(--color-ink-soft)",
-    };
-  }
-
   function periodBtnStyle(p: Period) {
     const active = period() === p;
     return {
@@ -236,18 +237,7 @@ export function SpeiTrendChart(props: SpeiTrendChartProps) {
   return (
     <div>
 
-      {/* Station row */}
-      <div style={{ display: "flex", "flex-wrap": "wrap", gap: "6px", margin: "0 40px 10px" }}>
-        <For each={stations()}>
-          {(s) => (
-            <button style={stationBtnStyle(s)} onClick={() => setStation(s)}>
-              {s.replace(/_/g, " ")}
-            </button>
-          )}
-        </For>
-      </div>
-
-      {/* Season + month row */}
+      {/* Season + month row (the station is set by the page-wide floating chooser) */}
       <div style={{ display: "flex", "flex-wrap": "wrap", gap: "5px", "align-items": "center", margin: "0 40px 14px" }}>
         <For each={SEASONS}>
           {(s) => <button style={periodBtnStyle(s)} onClick={() => setPeriod(s)}>{periodLabel(s)}</button>}
@@ -266,7 +256,7 @@ export function SpeiTrendChart(props: SpeiTrendChartProps) {
           <div style={{ padding: "12px 16px 10px", "border-bottom": "1px solid var(--color-rule)", display: "flex", "justify-content": "space-between", "align-items": "flex-start", gap: "12px" }}>
             <div>
               <div style={{ "font-family": "var(--font-sans)", "font-weight": "500", "font-size": "14px", color: "var(--color-ink)" }}>
-                {station().replace(/_/g, " ")} — {periodLabel(period())} {scaleLabel()}
+                {stationName()} — {periodLabel(period())} {scaleLabel()}
               </div>
               <Show when={series()}>
                 {(s) => (

--- a/tests/fixtures/snapshot.json
+++ b/tests/fixtures/snapshot.json
@@ -3290,11 +3290,11 @@
       "baseline": "1950–1980",
       "station_count": 18,
       "default_view": {
-        "_note": "What SpeiTrendChart.tsx:139-140 selects with no interaction.",
-        "station": "Celje",
+        "_note": "T-5.36 — station is set by the page-wide floating chooser (props.loc), not an own picker; the default here is meta.default_location, what the reader sees before touching the chooser. Period defaults to Summer.",
+        "station": "Ljubljana",
         "period": "Summer",
         "rendered": [
-          "Theil-Sen naklon: −0,026 SPEI/desetletje · Mann-Kendall: no trend · ni statistično značilen (p = 0,198). Negativen trend pomeni, da razmere postajajo sušnejše glede na osnovno obdobje 1950–1980."
+          "Theil-Sen naklon: −0,055 SPEI/desetletje · Mann-Kendall: decreasing · statistično značilen (p < 0,05). Negativen trend pomeni, da razmere postajajo sušnejše glede na osnovno obdobje 1950–1980."
         ]
       },
       "trends": {
@@ -12379,15 +12379,15 @@
                     "radius": 4
                   },
                   "x": 1951,
-                  "y": -0.69
+                  "y": -0.97
                 },
                 {
-                  "color": "#8b3a0f",
+                  "color": "#c2713a",
                   "marker": {
                     "radius": 4
                   },
                   "x": 1952,
-                  "y": -1.85
+                  "y": -1.17
                 },
                 {
                   "color": "#aaa49a",
@@ -12395,7 +12395,7 @@
                     "radius": 4
                   },
                   "x": 1953,
-                  "y": 0.02
+                  "y": 0
                 },
                 {
                   "color": "#aaa49a",
@@ -12403,7 +12403,7 @@
                     "radius": 4
                   },
                   "x": 1954,
-                  "y": 0.09
+                  "y": 0.05
                 },
                 {
                   "color": "#aaa49a",
@@ -12411,7 +12411,7 @@
                     "radius": 4
                   },
                   "x": 1955,
-                  "y": 0.3
+                  "y": 0.08
                 },
                 {
                   "color": "#aaa49a",
@@ -12427,7 +12427,7 @@
                     "radius": 4
                   },
                   "x": 1957,
-                  "y": -0.05
+                  "y": 0.11
                 },
                 {
                   "color": "#aaa49a",
@@ -12435,7 +12435,7 @@
                     "radius": 4
                   },
                   "x": 1958,
-                  "y": -0.81
+                  "y": -0.22
                 },
                 {
                   "color": "#aaa49a",
@@ -12443,7 +12443,7 @@
                     "radius": 4
                   },
                   "x": 1959,
-                  "y": 0.42
+                  "y": 0.13
                 },
                 {
                   "color": "#aaa49a",
@@ -12451,7 +12451,7 @@
                     "radius": 4
                   },
                   "x": 1960,
-                  "y": -0.15
+                  "y": 0.05
                 },
                 {
                   "color": "#aaa49a",
@@ -12459,7 +12459,7 @@
                     "radius": 4
                   },
                   "x": 1961,
-                  "y": -0.09
+                  "y": 0
                 },
                 {
                   "color": "#aaa49a",
@@ -12467,7 +12467,7 @@
                     "radius": 4
                   },
                   "x": 1962,
-                  "y": -0.02
+                  "y": -0.42
                 },
                 {
                   "color": "#aaa49a",
@@ -12475,7 +12475,7 @@
                     "radius": 4
                   },
                   "x": 1963,
-                  "y": -0.06
+                  "y": 0.18
                 },
                 {
                   "color": "#aaa49a",
@@ -12483,7 +12483,7 @@
                     "radius": 4
                   },
                   "x": 1964,
-                  "y": 0.03
+                  "y": 0.04
                 },
                 {
                   "color": "#aaa49a",
@@ -12491,14 +12491,6 @@
                     "radius": 4
                   },
                   "x": 1965,
-                  "y": 0.41
-                },
-                {
-                  "color": "#aaa49a",
-                  "marker": {
-                    "radius": 4
-                  },
-                  "x": 1966,
                   "y": 0.55
                 },
                 {
@@ -12506,8 +12498,16 @@
                   "marker": {
                     "radius": 4
                   },
+                  "x": 1966,
+                  "y": 0.51
+                },
+                {
+                  "color": "#aaa49a",
+                  "marker": {
+                    "radius": 4
+                  },
                   "x": 1967,
-                  "y": -0.38
+                  "y": -0.32
                 },
                 {
                   "color": "#aaa49a",
@@ -12515,14 +12515,6 @@
                     "radius": 4
                   },
                   "x": 1968,
-                  "y": 0.29
-                },
-                {
-                  "color": "#aaa49a",
-                  "marker": {
-                    "radius": 4
-                  },
-                  "x": 1969,
                   "y": 0.45
                 },
                 {
@@ -12530,8 +12522,16 @@
                   "marker": {
                     "radius": 4
                   },
+                  "x": 1969,
+                  "y": 0.31
+                },
+                {
+                  "color": "#aaa49a",
+                  "marker": {
+                    "radius": 4
+                  },
                   "x": 1970,
-                  "y": 0.23
+                  "y": 0.3
                 },
                 {
                   "color": "#aaa49a",
@@ -12547,7 +12547,7 @@
                     "radius": 4
                   },
                   "x": 1972,
-                  "y": 0.68
+                  "y": 0.51
                 },
                 {
                   "color": "#aaa49a",
@@ -12555,7 +12555,7 @@
                     "radius": 4
                   },
                   "x": 1973,
-                  "y": 0.04
+                  "y": -0.25
                 },
                 {
                   "color": "#aaa49a",
@@ -12563,102 +12563,6 @@
                     "radius": 4
                   },
                   "x": 1974,
-                  "y": 0.24
-                },
-                {
-                  "color": "#aaa49a",
-                  "marker": {
-                    "radius": 4
-                  },
-                  "x": 1975,
-                  "y": 0.45
-                },
-                {
-                  "color": "#aaa49a",
-                  "marker": {
-                    "radius": 4
-                  },
-                  "x": 1976,
-                  "y": 0.03
-                },
-                {
-                  "color": "#aaa49a",
-                  "marker": {
-                    "radius": 4
-                  },
-                  "x": 1977,
-                  "y": -0.03
-                },
-                {
-                  "color": "#aaa49a",
-                  "marker": {
-                    "radius": 4
-                  },
-                  "x": 1978,
-                  "y": 0.11
-                },
-                {
-                  "color": "#aaa49a",
-                  "marker": {
-                    "radius": 4
-                  },
-                  "x": 1979,
-                  "y": 0.3
-                },
-                {
-                  "color": "#aaa49a",
-                  "marker": {
-                    "radius": 4
-                  },
-                  "x": 1980,
-                  "y": 0.24
-                },
-                {
-                  "color": "#aaa49a",
-                  "marker": {
-                    "radius": 4
-                  },
-                  "x": 1981,
-                  "y": 0.23
-                },
-                {
-                  "color": "#aaa49a",
-                  "marker": {
-                    "radius": 4
-                  },
-                  "x": 1982,
-                  "y": 0.29
-                },
-                {
-                  "color": "#aaa49a",
-                  "marker": {
-                    "radius": 4
-                  },
-                  "x": 1983,
-                  "y": -0.51
-                },
-                {
-                  "color": "#aaa49a",
-                  "marker": {
-                    "radius": 4
-                  },
-                  "x": 1984,
-                  "y": -0.13
-                },
-                {
-                  "color": "#aaa49a",
-                  "marker": {
-                    "radius": 4
-                  },
-                  "x": 1985,
-                  "y": 0.23
-                },
-                {
-                  "color": "#aaa49a",
-                  "marker": {
-                    "radius": 4
-                  },
-                  "x": 1986,
                   "y": 0.36
                 },
                 {
@@ -12666,31 +12570,39 @@
                   "marker": {
                     "radius": 4
                   },
-                  "x": 1987,
-                  "y": -0.05
+                  "x": 1975,
+                  "y": 0.28
                 },
                 {
                   "color": "#aaa49a",
                   "marker": {
                     "radius": 4
                   },
-                  "x": 1988,
-                  "y": -0.07
+                  "x": 1976,
+                  "y": -0.12
                 },
                 {
                   "color": "#aaa49a",
                   "marker": {
                     "radius": 4
                   },
-                  "x": 1989,
-                  "y": 0.6
+                  "x": 1977,
+                  "y": 0.22
                 },
                 {
                   "color": "#aaa49a",
                   "marker": {
                     "radius": 4
                   },
-                  "x": 1990,
+                  "x": 1978,
+                  "y": 0.28
+                },
+                {
+                  "color": "#aaa49a",
+                  "marker": {
+                    "radius": 4
+                  },
+                  "x": 1979,
                   "y": -0.03
                 },
                 {
@@ -12698,8 +12610,96 @@
                   "marker": {
                     "radius": 4
                   },
+                  "x": 1980,
+                  "y": 0.27
+                },
+                {
+                  "color": "#aaa49a",
+                  "marker": {
+                    "radius": 4
+                  },
+                  "x": 1981,
+                  "y": 0.14
+                },
+                {
+                  "color": "#aaa49a",
+                  "marker": {
+                    "radius": 4
+                  },
+                  "x": 1982,
+                  "y": 0.21
+                },
+                {
+                  "color": "#c2713a",
+                  "marker": {
+                    "radius": 4
+                  },
+                  "x": 1983,
+                  "y": -1.32
+                },
+                {
+                  "color": "#aaa49a",
+                  "marker": {
+                    "radius": 4
+                  },
+                  "x": 1984,
+                  "y": -0.16
+                },
+                {
+                  "color": "#aaa49a",
+                  "marker": {
+                    "radius": 4
+                  },
+                  "x": 1985,
+                  "y": 0.25
+                },
+                {
+                  "color": "#aaa49a",
+                  "marker": {
+                    "radius": 4
+                  },
+                  "x": 1986,
+                  "y": 0.17
+                },
+                {
+                  "color": "#aaa49a",
+                  "marker": {
+                    "radius": 4
+                  },
+                  "x": 1987,
+                  "y": -0.02
+                },
+                {
+                  "color": "#aaa49a",
+                  "marker": {
+                    "radius": 4
+                  },
+                  "x": 1988,
+                  "y": -0.39
+                },
+                {
+                  "color": "#aaa49a",
+                  "marker": {
+                    "radius": 4
+                  },
+                  "x": 1989,
+                  "y": 0.46
+                },
+                {
+                  "color": "#aaa49a",
+                  "marker": {
+                    "radius": 4
+                  },
+                  "x": 1990,
+                  "y": 0
+                },
+                {
+                  "color": "#aaa49a",
+                  "marker": {
+                    "radius": 4
+                  },
                   "x": 1991,
-                  "y": -0.01
+                  "y": -0.44
                 },
                 {
                   "color": "#c2713a",
@@ -12715,7 +12715,7 @@
                     "radius": 4
                   },
                   "x": 1993,
-                  "y": -0.39
+                  "y": -0.22
                 },
                 {
                   "color": "#aaa49a",
@@ -12723,7 +12723,7 @@
                     "radius": 4
                   },
                   "x": 1994,
-                  "y": 0.02
+                  "y": -0.34
                 },
                 {
                   "color": "#aaa49a",
@@ -12731,7 +12731,7 @@
                     "radius": 4
                   },
                   "x": 1995,
-                  "y": 0.2
+                  "y": 0.09
                 },
                 {
                   "color": "#aaa49a",
@@ -12739,7 +12739,7 @@
                     "radius": 4
                   },
                   "x": 1996,
-                  "y": 0
+                  "y": -0.06
                 },
                 {
                   "color": "#aaa49a",
@@ -12747,7 +12747,7 @@
                     "radius": 4
                   },
                   "x": 1997,
-                  "y": 0.26
+                  "y": 0.17
                 },
                 {
                   "color": "#aaa49a",
@@ -12755,182 +12755,6 @@
                     "radius": 4
                   },
                   "x": 1998,
-                  "y": 0.24
-                },
-                {
-                  "color": "#aaa49a",
-                  "marker": {
-                    "radius": 4
-                  },
-                  "x": 1999,
-                  "y": 0.32
-                },
-                {
-                  "color": "#aaa49a",
-                  "marker": {
-                    "radius": 4
-                  },
-                  "x": 2000,
-                  "y": -0.5
-                },
-                {
-                  "color": "#aaa49a",
-                  "marker": {
-                    "radius": 4
-                  },
-                  "x": 2001,
-                  "y": -0.21
-                },
-                {
-                  "color": "#aaa49a",
-                  "marker": {
-                    "radius": 4
-                  },
-                  "x": 2002,
-                  "y": 0.32
-                },
-                {
-                  "color": "#aaa49a",
-                  "marker": {
-                    "radius": 4
-                  },
-                  "x": 2003,
-                  "y": -0.27
-                },
-                {
-                  "color": "#aaa49a",
-                  "marker": {
-                    "radius": 4
-                  },
-                  "x": 2004,
-                  "y": 0.39
-                },
-                {
-                  "color": "#aaa49a",
-                  "marker": {
-                    "radius": 4
-                  },
-                  "x": 2005,
-                  "y": 0.44
-                },
-                {
-                  "color": "#aaa49a",
-                  "marker": {
-                    "radius": 4
-                  },
-                  "x": 2006,
-                  "y": 0.02
-                },
-                {
-                  "color": "#aaa49a",
-                  "marker": {
-                    "radius": 4
-                  },
-                  "x": 2007,
-                  "y": -0.02
-                },
-                {
-                  "color": "#aaa49a",
-                  "marker": {
-                    "radius": 4
-                  },
-                  "x": 2008,
-                  "y": 0.21
-                },
-                {
-                  "color": "#aaa49a",
-                  "marker": {
-                    "radius": 4
-                  },
-                  "x": 2009,
-                  "y": 0.16
-                },
-                {
-                  "color": "#aaa49a",
-                  "marker": {
-                    "radius": 4
-                  },
-                  "x": 2010,
-                  "y": 0.22
-                },
-                {
-                  "color": "#aaa49a",
-                  "marker": {
-                    "radius": 4
-                  },
-                  "x": 2011,
-                  "y": -0.21
-                },
-                {
-                  "color": "#aaa49a",
-                  "marker": {
-                    "radius": 4
-                  },
-                  "x": 2012,
-                  "y": -0.76
-                },
-                {
-                  "color": "#aaa49a",
-                  "marker": {
-                    "radius": 4
-                  },
-                  "x": 2013,
-                  "y": -0.81
-                },
-                {
-                  "color": "#aaa49a",
-                  "marker": {
-                    "radius": 4
-                  },
-                  "x": 2014,
-                  "y": 0.24
-                },
-                {
-                  "color": "#aaa49a",
-                  "marker": {
-                    "radius": 4
-                  },
-                  "x": 2015,
-                  "y": -0.14
-                },
-                {
-                  "color": "#aaa49a",
-                  "marker": {
-                    "radius": 4
-                  },
-                  "x": 2016,
-                  "y": -0.03
-                },
-                {
-                  "color": "#c2713a",
-                  "marker": {
-                    "radius": 4
-                  },
-                  "x": 2017,
-                  "y": -1.4
-                },
-                {
-                  "color": "#aaa49a",
-                  "marker": {
-                    "radius": 4
-                  },
-                  "x": 2018,
-                  "y": -0.33
-                },
-                {
-                  "color": "#aaa49a",
-                  "marker": {
-                    "radius": 4
-                  },
-                  "x": 2019,
-                  "y": -0.17
-                },
-                {
-                  "color": "#aaa49a",
-                  "marker": {
-                    "radius": 4
-                  },
-                  "x": 2020,
                   "y": 0.11
                 },
                 {
@@ -12938,8 +12762,184 @@
                   "marker": {
                     "radius": 4
                   },
+                  "x": 1999,
+                  "y": 0.15
+                },
+                {
+                  "color": "#aaa49a",
+                  "marker": {
+                    "radius": 4
+                  },
+                  "x": 2000,
+                  "y": -0.57
+                },
+                {
+                  "color": "#aaa49a",
+                  "marker": {
+                    "radius": 4
+                  },
+                  "x": 2001,
+                  "y": -0.75
+                },
+                {
+                  "color": "#aaa49a",
+                  "marker": {
+                    "radius": 4
+                  },
+                  "x": 2002,
+                  "y": 0.37
+                },
+                {
+                  "color": "#aaa49a",
+                  "marker": {
+                    "radius": 4
+                  },
+                  "x": 2003,
+                  "y": -0.6
+                },
+                {
+                  "color": "#aaa49a",
+                  "marker": {
+                    "radius": 4
+                  },
+                  "x": 2004,
+                  "y": 0.32
+                },
+                {
+                  "color": "#aaa49a",
+                  "marker": {
+                    "radius": 4
+                  },
+                  "x": 2005,
+                  "y": 0.19
+                },
+                {
+                  "color": "#aaa49a",
+                  "marker": {
+                    "radius": 4
+                  },
+                  "x": 2006,
+                  "y": -0.21
+                },
+                {
+                  "color": "#aaa49a",
+                  "marker": {
+                    "radius": 4
+                  },
+                  "x": 2007,
+                  "y": 0.03
+                },
+                {
+                  "color": "#aaa49a",
+                  "marker": {
+                    "radius": 4
+                  },
+                  "x": 2008,
+                  "y": 0.44
+                },
+                {
+                  "color": "#aaa49a",
+                  "marker": {
+                    "radius": 4
+                  },
+                  "x": 2009,
+                  "y": 0.06
+                },
+                {
+                  "color": "#aaa49a",
+                  "marker": {
+                    "radius": 4
+                  },
+                  "x": 2010,
+                  "y": -0.1
+                },
+                {
+                  "color": "#aaa49a",
+                  "marker": {
+                    "radius": 4
+                  },
+                  "x": 2011,
+                  "y": -0.32
+                },
+                {
+                  "color": "#aaa49a",
+                  "marker": {
+                    "radius": 4
+                  },
+                  "x": 2012,
+                  "y": -0.24
+                },
+                {
+                  "color": "#8b3a0f",
+                  "marker": {
+                    "radius": 4
+                  },
+                  "x": 2013,
+                  "y": -2.97
+                },
+                {
+                  "color": "#aaa49a",
+                  "marker": {
+                    "radius": 4
+                  },
+                  "x": 2014,
+                  "y": 0.26
+                },
+                {
+                  "color": "#aaa49a",
+                  "marker": {
+                    "radius": 4
+                  },
+                  "x": 2015,
+                  "y": -0.43
+                },
+                {
+                  "color": "#aaa49a",
+                  "marker": {
+                    "radius": 4
+                  },
+                  "x": 2016,
+                  "y": 0.05
+                },
+                {
+                  "color": "#8b3a0f",
+                  "marker": {
+                    "radius": 4
+                  },
+                  "x": 2017,
+                  "y": -2.5
+                },
+                {
+                  "color": "#aaa49a",
+                  "marker": {
+                    "radius": 4
+                  },
+                  "x": 2018,
+                  "y": -0.55
+                },
+                {
+                  "color": "#aaa49a",
+                  "marker": {
+                    "radius": 4
+                  },
+                  "x": 2019,
+                  "y": -0.59
+                },
+                {
+                  "color": "#aaa49a",
+                  "marker": {
+                    "radius": 4
+                  },
+                  "x": 2020,
+                  "y": 0.12
+                },
+                {
+                  "color": "#8b3a0f",
+                  "marker": {
+                    "radius": 4
+                  },
                   "x": 2021,
-                  "y": -0.99
+                  "y": -3
                 },
                 {
                   "color": "#8b3a0f",
@@ -12947,7 +12947,7 @@
                     "radius": 4
                   },
                   "x": 2022,
-                  "y": -1.56
+                  "y": -3
                 },
                 {
                   "color": "#aaa49a",
@@ -12955,23 +12955,23 @@
                     "radius": 4
                   },
                   "x": 2023,
-                  "y": 0.49
+                  "y": 0.35
                 },
                 {
-                  "color": "#aaa49a",
+                  "color": "#8b3a0f",
                   "marker": {
                     "radius": 4
                   },
                   "x": 2024,
-                  "y": -0.64
+                  "y": -1.53
                 },
                 {
-                  "color": "#aaa49a",
+                  "color": "#c2713a",
                   "marker": {
                     "radius": 4
                   },
                   "x": 2025,
-                  "y": -0.9
+                  "y": -1.12
                 }
               ]
             },
@@ -12981,11 +12981,11 @@
               "data": [
                 [
                   1950,
-                  0.06
+                  0.145
                 ],
                 [
                   2025,
-                  -0.135
+                  -0.268
                 ]
               ]
             }

--- a/tests/snapshot/harness.tsx
+++ b/tests/snapshot/harness.tsx
@@ -737,9 +737,15 @@ export async function run(): Promise<RunResult> {
 
   const speiStation = await fetchSpeiStationSeasonal();
   assertNoMisses("global.spei_station (fetch)");
+  // T-5.36 — SpeiTrendChart no longer has its own station picker; the page-wide
+  // floating chooser sets it. Mount with the page default (meta.default_location),
+  // the station the reader sees before touching the chooser — replacing the retired
+  // picker's alphabetical-first default.
+  const speiDefaultLoc   = meta.default_location ?? "Ljubljana";
+  const speiDefaultLabel = era5Stations.find((s) => s.name === speiDefaultLoc)?.label;
   const speiStationUnit = await mount(
     "global.spei_station",
-    () => <SpeiTrendChart data={speiStation} />,
+    () => <SpeiTrendChart data={speiStation} loc={speiDefaultLoc} label={speiDefaultLabel} />,
     1,
   );
 
@@ -845,8 +851,10 @@ export async function run(): Promise<RunResult> {
       baseline: speiStation.baseline,
       station_count: Object.keys(speiStation.stations ?? {}).length,
       default_view: {
-        _note: "What SpeiTrendChart.tsx:139-140 selects with no interaction.",
-        station: Object.keys(speiStation.stations ?? {}).sort()[0] ?? null,
+        _note: "T-5.36 — station is set by the page-wide floating chooser (props.loc), " +
+          "not an own picker; the default here is meta.default_location, what the reader " +
+          "sees before touching the chooser. Period defaults to Summer.",
+        station: speiDefaultLoc,
         period: "Summer",
         rendered: read(speiStationUnit).all("p"),
       },


### PR DESCRIPTION
Retires the SPEI trend's own eighteen-button station row; the floating chooser now drives it
like every other section below the hero.

Until now, changing the chooser updated six sections and left the SPEI trend on whatever
station it happened to hold — the same undisclosed divergent state the single-control decision
set out to remove, and one that became more noticeable once everything else followed a single
control.

The wiring deliberately differs from how the regression sections were connected. Those use
context; this chart takes props, because the snapshot harness mounts it standalone with no
provider, so a context call inside it would crash the harness. Props also match how its
sibling ERA5 charts already receive location.

The retired picker was single-select over exactly the eighteen stations — no multi-select, no
empty state, no national option — so nothing the chooser cannot express was lost. The period
selector is not a location control and is untouched.

The panel header previously showed the underscore-stripped ASCII key; it now shows the proper
diacritic display name.

The genuinely national sibling section, which reads a different table and was recently
labelled as national for that reason, is out of scope and untouched.

Snapshot moved only the SPEI-station capture, 84 lines either way: the standalone-mounted
chart now plots Ljubljana's summer series instead of Celje's, and those values are
byte-identical to the already-captured Ljubljana summer series. No station's trend parameters
or full series changed — a default-view station switch, not a recomputation.

Gates: typecheck 0, typecheck:gate 0 allowlisted, yarn test 79, snapshot identical after a
deliberate re-record, pytest 75.

Note: that the chooser now drives this section can only be confirmed on stage — the harness
mounts the chart standalone and cannot drive the chooser.
