### PR TITLE
T-5.39/T-5.40: retire the map as a chooser, keep it as an orientation aid, fix four label defects

### DIFF
--- a/code/ali-je-vroce-era5/AliJeVroceERA5.tsx
+++ b/code/ali-je-vroce-era5/AliJeVroceERA5.tsx
@@ -64,6 +64,12 @@ function Dashboard(props: { meta: SiteMeta }) {
   const defaultDoy = createMemo(() => dateToDoy(date()));
   const era5Meta = (): SiteMeta => ({ ...props.meta, stations: era5Stations, default_location: defaultLoc });
 
+  // T-5.40 (B1) — the map card header must show the DIACRITIC display name, not the
+  // ASCII era5_name. The map's own point labels already resolve via station.label
+  // (StationMap.tsx); this makes the header read the same authored field (T-5.27).
+  const stationLabelOf = (name: string | null): string | null =>
+    name == null ? null : (era5Stations.find(s => s.name === name)?.label ?? name);
+
   const [pageData, { refetch: refetchPageData }] = createResource(
     () => ({ date: date(), loc: loc() }),
     ({ date, loc }) => fetchPageData(date, loc),
@@ -72,7 +78,13 @@ function Dashboard(props: { meta: SiteMeta }) {
   const todayData = () => pageDataResolved()?.status;
   const last7Data = () => pageDataResolved()?.last7;
 
-  const [mapLoc, setMapLoc] = createSignal<string | null>(null);
+  // T-5.39 — `mapLoc` now MIRRORS the below-hero selection; it no longer writes it.
+  // It is set only by the store's `setLoc` (via onLocChange, i.e. the floating
+  // chooser) and read by the map card's header + marker highlight, so the map
+  // reflects the chosen station. It opens on the body's default station (Ljubljana),
+  // matching what the analysis below is actually showing. The retired click-to-select
+  // path (map → store via syncLoc) is gone.
+  const [mapLoc, setMapLoc] = createSignal<string | null>(defaultLoc);
 
   // T-5.35 — the floating chooser is present from page load (it is the only location
   // control now). It anchors on the hero (today-status) section to decide when to
@@ -149,7 +161,6 @@ function Dashboard(props: { meta: SiteMeta }) {
       <RegressionPanel
         meta={era5Meta()}
         defaultDoy={defaultDoy()}
-        syncLoc={mapLoc}
         onLocChange={setMapLoc}
       >
         {/* T-5.35 / D-27 — the single location control, over the hero and every
@@ -178,7 +189,7 @@ function Dashboard(props: { meta: SiteMeta }) {
             <div style={{ ...panelHStyle, background: "var(--color-card)" }}>
               <div>
                 <div style={panelTitleStyle}>
-                  {mapLoc() ? mapLoc()!.replace(/_/g, " ") : t("map.panel_title_all", { count: era5Stations.length })}
+                  {stationLabelOf(mapLoc()) ?? t("map.panel_title_all", { count: era5Stations.length })}
                 </div>
                 <div style={{ ...panelSubStyle, "margin-top": "3px" }}>
                   {t("map.panel_sub_count", { count: era5Stations.length })}
@@ -186,7 +197,7 @@ function Dashboard(props: { meta: SiteMeta }) {
               </div>
             </div>
             <Suspense fallback={<div style={{ height: "280px" }} class="animate-pulse bg-[var(--color-paper-2)]" />}>
-              <StationMap meta={era5Meta()} loc={mapLoc()} onSelect={setMapLoc} />
+              <StationMap meta={era5Meta()} loc={mapLoc()} />
             </Suspense>
             <div style={{ padding: "8px 12px 10px", "border-top": "1px solid var(--color-rule)", display: "flex", gap: "10px", "flex-wrap": "wrap", background: "var(--color-card)" }}>
               {([

--- a/code/ali-je-vroce-era5/components/RegressionPanel.tsx
+++ b/code/ali-je-vroce-era5/components/RegressionPanel.tsx
@@ -53,13 +53,17 @@ function createStore(props: ProviderProps) {
 
   const selLoc = () => selLocs()[0] ?? defaultLoc();
   // The single writer for the below-hero location. It also notifies the page via
-  // onLocChange (→ setMapLoc), so the station map's highlight and panel title follow
-  // the floating chooser, and vice-versa (a map click flows back through syncLoc).
+  // onLocChange (→ setMapLoc), so the station map's header and marker highlight follow
+  // the floating chooser's selection. T-5.39 retired the reverse path: the map is an
+  // orientation aid only now, no longer a chooser, so it no longer writes back.
   const setLoc = (name: string) => {
     setSelLocs([name]);
     props.onLocChange?.(name);
   };
 
+  // syncLoc is a controlled-location input: an external signal that pins the station.
+  // Production no longer wires it (the station map used to, via mapLoc, until T-5.39);
+  // it remains the seam the snapshot harness uses to set a station per case.
   createEffect(() => {
     const ext = props.syncLoc?.();
     if (ext) setSelLocs([ext]);

--- a/code/ali-je-vroce-era5/components/StationMap.tsx
+++ b/code/ali-je-vroce-era5/components/StationMap.tsx
@@ -4,9 +4,8 @@ import type { SiteMeta } from "../types.ts";
 import { t } from "../i18n/format.ts";
 
 interface Props {
-  meta:     SiteMeta;
-  loc:      string | null;
-  onSelect: (loc: string | null) => void;
+  meta: SiteMeta;
+  loc:  string | null;
 }
 
 // Elevation → fill colour (matches the original Flask SPA palette)
@@ -16,6 +15,49 @@ function elevColor(elev: number): string {
   if (elev > 400)  return "#c8b97a";
   return "#c25a2c";
 }
+
+// T-5.40 (B2/B3) — the 18 stations are a fixed, known set, and Highcharts' only
+// built-in collision handling for mappoint labels is to HIDE whichever ones overlap
+// (dataLabels.allowOverlap:false). That is forbidden here: a station whose name
+// silently vanishes defeats the map's whole purpose (showing where the 18 stations
+// are). So the labels are placed deterministically instead — `allowOverlap:true`
+// keeps every one drawn, and these per-point offsets:
+//   • steer the western-most and eastern-most labels INLAND so they are not clipped
+//     at the card edge (B2 — "ova Gorica"); and
+//   • spread the crowded central cluster apart (B3 — Ljubljana / Domžale / Kranj /
+//     Trbovlje overlapping).
+// A per-point object merges over the series-level dataLabels, so unlisted stations
+// keep the default centred label above the point; listed ones override only the
+// keys named. Keyed on era5_name (station.name).
+const LABEL_PLACEMENT: Record<string,
+  { align?: "left" | "center" | "right"; verticalAlign?: "top" | "middle" | "bottom"; x?: number; y?: number }
+> = {
+  // Western edge — label extends east (inland), so its start sits on the point and
+  // nothing runs off the left of the card.
+  Nova_Gorica: { align: "left",  x: 5 },
+  // Koper is the coastal SW tip; its label extends WEST (open space) so it clears
+  // Ilirska Bistrica, which sits at almost the same latitude just to the east.
+  Koper:       { align: "right", x: -5 },
+  Tolmin:      { align: "left",  x: 5 },
+  Ratece:      { align: "left",  x: 5 },
+  // Postojna extends WEST so it clears Ljubljana's dropped label to its north-east.
+  Postojna:    { align: "right", x: -5 },
+  // Eastern edge — label extends west (inland).
+  Murska_Sobota: { align: "right", x: -5 },
+  Ptuj:          { align: "right", x: -5 },
+  Maribor:       { align: "right", x: -5 },
+  // Central cluster — pull the four crowded labels apart.
+  Kranj:     { align: "right", x: -5, y: -9 }, // west, lifted clear of Tolmin
+  Ljubljana: { verticalAlign: "top", y: 12 },  // below its own point
+  Domzale:   { align: "left",  x: 5 },         // east
+  Trbovlje:  { align: "left",  x: 5, y: 2 },   // east, nudged down
+  // Kredarica keeps the default (centred, above): the alpine outlier sits north of
+  // the cluster with clear space above it.
+};
+// Verified with real Highcharts across card widths 290–600 px (the map card is
+// min(460px, 44%) of the trend row, and drops to full width below the 700 px
+// breakpoint): every one of the 18 labels renders in full with no overlap and no
+// edge clip. See PROGRESS for the measurement.
 
 export function StationMap(props: Props) {
   let container!: HTMLDivElement;
@@ -34,6 +76,7 @@ export function StationMap(props: Props) {
         lineColor: s.name === loc ? "#1a1a18" : "#fff",
         symbol:    "circle",
       },
+      dataLabels: LABEL_PLACEMENT[s.name],
     }));
   }
 
@@ -69,7 +112,9 @@ export function StationMap(props: Props) {
       },
       mapNavigation: {
         enabled: true,
-        buttonOptions: { verticalAlign: "bottom" },
+        // T-5.40 — bottom-RIGHT (the Adriatic/Croatia corner, no station near it) so
+        // the zoom buttons do not sit on top of Koper's label in the south-west.
+        buttonOptions: { verticalAlign: "bottom", align: "right" },
       },
       plotOptions: {
         series: { states: { inactive: { opacity: 1 } } },
@@ -98,11 +143,16 @@ export function StationMap(props: Props) {
           type: "mappoint",
           name: "Postaje",
           data: buildPoints(currentLoc),
-          cursor: "pointer",
           findNearestPointBy: "xy",
           stickyTracking: false,
           dataLabels: {
             enabled: true,
+            // T-5.40 — keep every station's name visible (never drop a label) and let
+            // labels draw past the plot edge; LABEL_PLACEMENT (above) keeps them from
+            // colliding or clipping.
+            allowOverlap: true,
+            crop: false,
+            overflow: "allow",
             formatter(this: any) { return this.point.label ?? this.point.name; },
             style: {
               fontSize: "8px",
@@ -113,14 +163,8 @@ export function StationMap(props: Props) {
             },
             y: -2,
           },
-          point: {
-            events: {
-              click(this: any) {
-                const name: string = this.name;
-                props.onSelect(props.loc === name ? null : name);
-              },
-            },
-          },
+          // T-5.39 — the map is an orientation aid, not a chooser: no click handler,
+          // no pointer cursor. The floating chooser is the single location control.
         },
       ],
     } as any);

--- a/code/ali-je-vroce-era5/i18n/sl.ts
+++ b/code/ali-je-vroce-era5/i18n/sl.ts
@@ -462,7 +462,7 @@ export const sl = {
 
   // StationMap + map legend
   map: {
-    a11y: "Zemljevid Slovenije z merilnimi postajami; barva točke označuje višinski pas postaje. Postajo lahko izberete tudi s spustnim seznamom v analizi trendov.",
+    a11y: "Zemljevid Slovenije z merilnimi postajami; barva točke označuje višinski pas postaje, izbrana postaja pa je poudarjena. Postajo izberete z izbirnikom lokacije.",
     panel_title_all: "Slovenija — vseh {count, plural, one{# postaja} two{# postaji} few{# postaje} other{# postaj}}",
     panel_sub_count: "{count, plural, one{# postaja} two{# postaji} few{# postaje} other{# postaj}} · ERA5",
     legend_alpine: "Alpska (>1500m)",

--- a/scripts/snapshot/main.mjs
+++ b/scripts/snapshot/main.mjs
@@ -204,13 +204,13 @@ const MIRRORED = [
   },
   {
     file: PAGE_SRC,
-    cite: "AliJeVroceERA5.tsx:155",
+    cite: "AliJeVroceERA5.tsx map panel header — title (T-5.40 B1: diacritic display name)",
     mirror: "harness.tsx MapPanelHeader — title",
-    fragment: '{mapLoc() ? mapLoc()!.replace(/_/g, " ") : t("map.panel_title_all", { count: era5Stations.length })}',
+    fragment: 'stationLabelOf(mapLoc()) ?? t("map.panel_title_all", { count: era5Stations.length })',
   },
   {
     file: PAGE_SRC,
-    cite: "AliJeVroceERA5.tsx:158",
+    cite: "AliJeVroceERA5.tsx map panel header — station count",
     mirror: "harness.tsx MapPanelHeader — station count",
     fragment: 't("map.panel_sub_count", { count: era5Stations.length })',
   },

--- a/tests/fixtures/snapshot.json
+++ b/tests/fixtures/snapshot.json
@@ -261,6 +261,10 @@
               "data": [
                 {
                   "color": "#c25a2c",
+                  "dataLabels": {
+                    "verticalAlign": "top",
+                    "y": 12
+                  },
                   "label": "Ljubljana",
                   "lat": 46.0511,
                   "lon": 14.5051,
@@ -274,6 +278,10 @@
                 },
                 {
                   "color": "#c25a2c",
+                  "dataLabels": {
+                    "align": "right",
+                    "x": -5
+                  },
                   "label": "Maribor",
                   "lat": 46.5547,
                   "lon": 15.6459,
@@ -287,6 +295,7 @@
                 },
                 {
                   "color": "#c25a2c",
+                  "dataLabels": null,
                   "label": "Celje",
                   "lat": 46.2313,
                   "lon": 15.2617,
@@ -300,6 +309,11 @@
                 },
                 {
                   "color": "#c25a2c",
+                  "dataLabels": {
+                    "align": "right",
+                    "x": -5,
+                    "y": -9
+                  },
                   "label": "Kranj",
                   "lat": 46.2392,
                   "lon": 14.3556,
@@ -313,6 +327,10 @@
                 },
                 {
                   "color": "#c25a2c",
+                  "dataLabels": {
+                    "align": "right",
+                    "x": -5
+                  },
                   "label": "Koper",
                   "lat": 45.5483,
                   "lon": 13.73,
@@ -326,6 +344,7 @@
                 },
                 {
                   "color": "#c25a2c",
+                  "dataLabels": null,
                   "label": "Novo mesto",
                   "lat": 45.8011,
                   "lon": 15.17,
@@ -339,6 +358,10 @@
                 },
                 {
                   "color": "#c25a2c",
+                  "dataLabels": {
+                    "align": "right",
+                    "x": -5
+                  },
                   "label": "Murska Sobota",
                   "lat": 46.6625,
                   "lon": 16.1667,
@@ -352,6 +375,10 @@
                 },
                 {
                   "color": "#c25a2c",
+                  "dataLabels": {
+                    "align": "left",
+                    "x": 5
+                  },
                   "label": "Nova Gorica",
                   "lat": 45.9564,
                   "lon": 13.6431,
@@ -365,6 +392,10 @@
                 },
                 {
                   "color": "#c8b97a",
+                  "dataLabels": {
+                    "align": "right",
+                    "x": -5
+                  },
                   "label": "Postojna",
                   "lat": 45.7756,
                   "lon": 14.2133,
@@ -378,6 +409,10 @@
                 },
                 {
                   "color": "#c25a2c",
+                  "dataLabels": {
+                    "align": "right",
+                    "x": -5
+                  },
                   "label": "Ptuj",
                   "lat": 46.4197,
                   "lon": 15.8697,
@@ -391,6 +426,7 @@
                 },
                 {
                   "color": "#c8b97a",
+                  "dataLabels": null,
                   "label": "Velenje",
                   "lat": 46.3592,
                   "lon": 15.1119,
@@ -404,6 +440,11 @@
                 },
                 {
                   "color": "#c25a2c",
+                  "dataLabels": {
+                    "align": "left",
+                    "x": 5,
+                    "y": 2
+                  },
                   "label": "Trbovlje",
                   "lat": 46.1511,
                   "lon": 15.0511,
@@ -417,6 +458,10 @@
                 },
                 {
                   "color": "#c25a2c",
+                  "dataLabels": {
+                    "align": "left",
+                    "x": 5
+                  },
                   "label": "Tolmin",
                   "lat": 46.1858,
                   "lon": 13.7317,
@@ -430,6 +475,7 @@
                 },
                 {
                   "color": "#c8b97a",
+                  "dataLabels": null,
                   "label": "Kočevje",
                   "lat": 45.6433,
                   "lon": 14.8619,
@@ -443,6 +489,7 @@
                 },
                 {
                   "color": "#c8b97a",
+                  "dataLabels": null,
                   "label": "Ilirska Bistrica",
                   "lat": 45.5667,
                   "lon": 14.2358,
@@ -456,6 +503,10 @@
                 },
                 {
                   "color": "#c25a2c",
+                  "dataLabels": {
+                    "align": "left",
+                    "x": 5
+                  },
                   "label": "Domžale",
                   "lat": 46.1375,
                   "lon": 14.5942,
@@ -469,6 +520,10 @@
                 },
                 {
                   "color": "#a3c4a0",
+                  "dataLabels": {
+                    "align": "left",
+                    "x": 5
+                  },
                   "label": "Rateče",
                   "lat": 46.4967,
                   "lon": 13.7131,
@@ -482,6 +537,7 @@
                 },
                 {
                   "color": "#7bafd4",
+                  "dataLabels": null,
                   "label": "Kredarica",
                   "lat": 46.3792,
                   "lon": 14.5267,
@@ -500,8 +556,8 @@
         }
       ],
       "panel_header": {
-        "_note": "Raw JSX in AliJeVroceERA5.tsx:137-145, owned by no component and therefore invisible to the section-set assertion. Mirrored by MapPanelHeader in harness.tsx and checked against the source by main.mjs assertMirroredCopy. `station_count` is the same figure the _size=50 cap would truncate (T-5.2).",
-        "title": "Slovenija — vseh 18 postaj",
+        "_note": "Raw JSX in AliJeVroceERA5.tsx, owned by no component and therefore invisible to the section-set assertion. Mirrored by MapPanelHeader in harness.tsx and checked against the source by main.mjs assertMirroredCopy. T-5.40 (B1): `title` now shows the selected station's DIACRITIC display name (the body opens on Ljubljana), not the ASCII era5_name or an all-stations line. `station_count` is the same figure the _size=50 cap would truncate (T-5.2).",
+        "title": "Ljubljana",
         "station_count": "18 postaj · ERA5"
       }
     },

--- a/tests/snapshot/harness.tsx
+++ b/tests/snapshot/harness.tsx
@@ -658,12 +658,14 @@ function TodayChartCopy(props: { data: TodayStatus; isNat: boolean }) {
   );
 }
 
-/** Mirrors AliJeVroceERA5.tsx:155-158 — the map panel header. */
-function MapPanelHeader(props: { mapLoc: string | null; stationCount: number }) {
+/** Mirrors AliJeVroceERA5.tsx — the map panel header. T-5.40 (B1): the title now
+ *  shows the DIACRITIC display name of the selected station (via stationLabelOf),
+ *  not the ASCII era5_name; `label` is that resolved value. */
+function MapPanelHeader(props: { label: string | null; stationCount: number }) {
   return (
     <div>
       <div class="mirror-panel-title">
-        {props.mapLoc ? props.mapLoc.replace(/_/g, " ") : t("map.panel_title_all", { count: props.stationCount })}
+        {props.label ?? t("map.panel_title_all", { count: props.stationCount })}
       </div>
       <div class="mirror-panel-sub">{t("map.panel_sub_count", { count: props.stationCount })}</div>
     </div>
@@ -703,7 +705,7 @@ export async function run(): Promise<RunResult> {
   // ── global ──────────────────────────────────────────────────────────────────
   const mapUnit = await mount(
     "global.station_map",
-    () => <StationMap meta={era5Meta()} loc={null} onSelect={() => {}} />,
+    () => <StationMap meta={era5Meta()} loc={null} />,
     1, // the mapChart (StationMap.tsx:47)
   );
 
@@ -712,7 +714,7 @@ export async function run(): Promise<RunResult> {
   // is a displayed number no component owns.
   const mapHeaderUnit = await mount(
     "global.map_panel_header",
-    () => <MapPanelHeader mapLoc={null} stationCount={era5Stations.length} />,
+    () => <MapPanelHeader label={labelOf(era5Meta().default_location!)} stationCount={era5Stations.length} />,
     0,
   );
 
@@ -817,10 +819,13 @@ export async function run(): Promise<RunResult> {
       charts: mapUnit.charts.map(extractChart),
       panel_header: {
         _note:
-          "Raw JSX in AliJeVroceERA5.tsx:137-145, owned by no component and therefore " +
+          "Raw JSX in AliJeVroceERA5.tsx, owned by no component and therefore " +
           "invisible to the section-set assertion. Mirrored by MapPanelHeader in " +
           "harness.tsx and checked against the source by main.mjs assertMirroredCopy. " +
-          "`station_count` is the same figure the _size=50 cap would truncate (T-5.2).",
+          "T-5.40 (B1): `title` now shows the selected station's DIACRITIC display name " +
+          "(the body opens on Ljubljana), not the ASCII era5_name or an all-stations " +
+          "line. `station_count` is the same figure the _size=50 cap would truncate " +
+          "(T-5.2).",
         title: read(mapHeaderUnit).txt(".mirror-panel-title"),
         station_count: read(mapHeaderUnit).txt(".mirror-panel-sub"),
       },


### PR DESCRIPTION
Retires the map's click-to-select role and fixes four rendering defects. The map itself is
kept.

Selection now has a single home in the floating chooser, so the map picking a station was
redundant. But the map does a job nothing else does: its elevation-banded markers and legend
are how a reader sees that the network spans 10 to 2514 metres, which the methodology
describes in prose and which the trust-furniture work counted as station visibility. A
dropdown of eighteen names conveys none of that.

The syncLoc prop could not simply be deleted — the snapshot harness reuses it as its
per-case station-injection seam, so removing it would have broken the snapshot for a reason
unrelated to the map. Only the app-to-map wiring went; mapLoc now one-way mirrors the
selection, so the map highlights and names the body's station at load rather than starting
out of sync.

Four defects fixed. The card header showed ASCII "Domzale" while the map label beside it
correctly read "Domžale" — the same inconsistency the authored display-name map exists to
remove, inside a single card. Nova Gorica's label was clipped at the left edge. Domžale and
Trbovlje overlapped in the central cluster. And a fourth, found during verification and
reported by nobody: Koper colliding with Ilirska Bistrica, plus the zoom buttons overlapping.

Highcharts' only built-in collision handling hides overlapping labels, which is worse than
overlap here — a station whose name silently disappears defeats the map's purpose. Instead:
overlap allowed, cropping off, and a deterministic per-point placement map.

Verification is the part worth noting. The snapshot stubs Highcharts and proves nothing about
a map render, so the config was rendered with real Highcharts, the fixture topojson and all
eighteen stations, then every label's bounding box was scanned programmatically for overlap
and edge-clipping across card widths from 290 to 600 pixels. Zero overlaps and zero clips at
every width, with screenshots at 360 pixels and 2x confirming. A single-width check would have
missed the fourth defect.

Snapshot: zero numeric leaves moved. The panel header title changed to reflect the default
selection, and per-point label placement changed — layout, not data. Station and marker counts
hold at eighteen, so the truncation tripwire is intact.

Gates: typecheck 0, typecheck:gate 0 allowlisted, yarn test 79, snapshot identical after a
deliberate re-record, pytest 75.

Note: that the chooser highlights and names the station on the map can only be confirmed on
stage — the harness never mounts the map card.
