### PR TITLE
T-5.46 — hide the station map card (code retained, commented)

### DIFF
--- a/code/ali-je-vroce-era5/AliJeVroceERA5.tsx
+++ b/code/ali-je-vroce-era5/AliJeVroceERA5.tsx
@@ -6,14 +6,22 @@ import { EmptyState } from "./components/EmptyState.tsx";
 import { TodayCard } from "./components/TodayCard.tsx";
 import { DistributionChart } from "./charts/DistributionChart.tsx";
 import { TodayTrendChart } from "./components/TodayTrendChart.tsx";
-import { RegressionPanel, RegToolbar, RegScatterCard, RegYearRoundCard, FloatingStationChooser, useReg,
-         panelHStyle, panelTitleStyle, panelSubStyle } from "./components/RegressionPanel.tsx";
+// T-5.46: station map hidden for v1 (D-31). Code retained deliberately — revive by
+// uncommenting; StationMap.tsx is untouched.
+// (panelHStyle/panelTitleStyle/panelSubStyle are read only by the hidden map card's
+// panel header; the reduced import below drops them to hold typecheck at zero. Revive
+// by deleting the reduced line and uncommenting the original.)
+// import { RegressionPanel, RegToolbar, RegScatterCard, RegYearRoundCard, FloatingStationChooser, useReg,
+//          panelHStyle, panelTitleStyle, panelSubStyle } from "./components/RegressionPanel.tsx";
+import { RegressionPanel, RegToolbar, RegScatterCard, RegYearRoundCard, FloatingStationChooser, useReg } from "./components/RegressionPanel.tsx";
 import { MethodologyPanel } from "./components/MethodologyPanel.tsx";
 import type { SiteMeta } from "./types.ts";
 import { t, fmtNum, fmtInt, fmtMonthDay } from "./i18n/format.ts";
 
 const Era5SeasonHeatmapChart = lazy(() => import("./charts/Era5SeasonHeatmap.tsx").then(m => ({ default: m.Era5SeasonHeatmap })));
-const StationMap             = lazy(() => import("./components/StationMap.tsx").then(m => ({ default: m.StationMap })));
+// T-5.46: station map hidden for v1 (D-31). Code retained deliberately — revive by
+// uncommenting; StationMap.tsx is untouched.
+// const StationMap             = lazy(() => import("./components/StationMap.tsx").then(m => ({ default: m.StationMap })));
 const HeroCardsPanel         = lazy(() => import("./components/HeroCards.tsx").then(m => ({ default: m.HeroCards })));
 const Era5TropicalChart      = lazy(() => import("./charts/Era5TropicalChart.tsx").then(m => ({ default: m.Era5TropicalChart })));
 const SpeiHeatmapChart       = lazy(() => import("./charts/SpeiHeatmap.tsx").then(m => ({ default: m.SpeiHeatmap })));
@@ -64,11 +72,13 @@ function Dashboard(props: { meta: SiteMeta }) {
   const defaultDoy = createMemo(() => dateToDoy(date()));
   const era5Meta = (): SiteMeta => ({ ...props.meta, stations: era5Stations, default_location: defaultLoc });
 
+  // T-5.46: station map hidden for v1 (D-31). Code retained deliberately — revive by
+  // uncommenting; StationMap.tsx is untouched.
   // T-5.40 (B1) — the map card header must show the DIACRITIC display name, not the
   // ASCII era5_name. The map's own point labels already resolve via station.label
   // (StationMap.tsx); this makes the header read the same authored field (T-5.27).
-  const stationLabelOf = (name: string | null): string | null =>
-    name == null ? null : (era5Stations.find(s => s.name === name)?.label ?? name);
+  // const stationLabelOf = (name: string | null): string | null =>
+  //   name == null ? null : (era5Stations.find(s => s.name === name)?.label ?? name);
 
   const [pageData, { refetch: refetchPageData }] = createResource(
     () => ({ date: date(), loc: loc() }),
@@ -78,13 +88,15 @@ function Dashboard(props: { meta: SiteMeta }) {
   const todayData = () => pageDataResolved()?.status;
   const last7Data = () => pageDataResolved()?.last7;
 
+  // T-5.46: station map hidden for v1 (D-31). Code retained deliberately — revive by
+  // uncommenting; StationMap.tsx is untouched.
   // T-5.39 — `mapLoc` now MIRRORS the below-hero selection; it no longer writes it.
   // It is set only by the store's `setLoc` (via onLocChange, i.e. the floating
   // chooser) and read by the map card's header + marker highlight, so the map
   // reflects the chosen station. It opens on the body's default station (Ljubljana),
   // matching what the analysis below is actually showing. The retired click-to-select
   // path (map → store via syncLoc) is gone.
-  const [mapLoc, setMapLoc] = createSignal<string | null>(defaultLoc);
+  // const [mapLoc, setMapLoc] = createSignal<string | null>(defaultLoc);
 
   // T-5.35 — the floating chooser is present from page load (it is the only location
   // control now). It anchors on the hero (today-status) section to decide when to
@@ -161,7 +173,12 @@ function Dashboard(props: { meta: SiteMeta }) {
       <RegressionPanel
         meta={era5Meta()}
         defaultDoy={defaultDoy()}
+        /* T-5.46: station map hidden for v1 (D-31). Code retained deliberately — revive
+           by uncommenting; StationMap.tsx is untouched. onLocChange fed the hidden map's
+           mapLoc mirror only; it is optional (RegressionPanel.tsx:26) and called as
+           props.onLocChange?.(name) (:61), so its absence is a no-op for the store.
         onLocChange={setMapLoc}
+        */
       >
         {/* T-5.35 / D-27 — the single location control, over the hero and every
             section below. Placed FIRST inside the panel (right after the hero's date
@@ -185,6 +202,8 @@ function Dashboard(props: { meta: SiteMeta }) {
         <div class="main-row">
 
           {/* Map panel */}
+          {/* T-5.46: station map hidden for v1 (D-31). Code retained deliberately — revive by
+              uncommenting; StationMap.tsx is untouched.
           <div class="reg-card" style={{ background: "var(--color-paper)" }}>
             <div style={{ ...panelHStyle, background: "var(--color-card)" }}>
               <div>
@@ -213,6 +232,7 @@ function Dashboard(props: { meta: SiteMeta }) {
               ))}
             </div>
           </div>
+          */}
 
           <RegScatterCard />
 

--- a/styles/era5.css
+++ b/styles/era5.css
@@ -133,7 +133,13 @@
 /* ── Responsive: Main row grid (map left | scatter right) ─────────────────── */
 .main-row {
   display: grid;
-  grid-template-columns: min(460px, 44%) 1fr;
+  /* T-5.46: station map hidden for v1 (D-31). Code retained deliberately — revive by
+     uncommenting; StationMap.tsx is untouched. With the map card commented out of
+     AliJeVroceERA5.tsx, RegScatterCard is the sole child; the two-track original left
+     an empty second column at desktop widths, so collapse to one full-width track.
+     Revive by deleting the single-column line and uncommenting the original. */
+  /* grid-template-columns: min(460px, 44%) 1fr; */
+  grid-template-columns: 1fr;
   gap: 20px;
   padding: 20px 40px 0;
 }


### PR DESCRIPTION
Hides the station map card from the ERA5 page for v1. **No map code is deleted** — the card's render, its lazy import, `stationLabelOf`, the `mapLoc` signal and the `onLocChange` mirror are all commented out behind a greppable `T-5.46` marker, and `StationMap.tsx` is untouched. Revival is a pure uncomment plus removing one reduced-import line and one CSS line.

This reverses T-5.39's decision to keep the map as an elevation-band orientation aid. That argument was heard and overridden — the card is not wanted on the page for launch, and the code is retained so the call is cheap to revisit.

**Paired, not trimmed.** The `RegressionPanel` import and the `.main-row` grid rule both keep their original line commented directly above the replacement, so nothing has to be reconstructed from memory later.

**Layout.** `.main-row` declared two tracks (`min(460px, 44%) 1fr`) and would have left the scatter card at ~44% with an empty track beside it. Collapsed to a single column; the <700px rule was already single-column and is untouched. `RegressionChart` needs no reflow call — it renders into a `width:100%` container and is created in `onMount` after CSS applies, so it initialises at the final width.

**Snapshot is byte-identical, and that proves less than usual.** The harness mounts `StationMap` and `MapPanelHeader` independently of the page render, so `marker_count: 18` — T-5.2's truncation tripwire — is untouched and still captured. But it also means every guard here is green regardless of what the page does: `assertSections` and `assertMirroredCopy` are satisfied by the commented-out text, and the topojson fixture is still fetched by the harness's own mount. `assertSections` cannot tell a rendered section from a commented one.

**Needs eyes on stage** (no previews, T-6.9): that the card is gone, that the scatter card fills the row with no gap at desktop widths, that nothing shifted at 390px.

**Open editorial question, not addressed here.** D-7 requires the station list and the 10-2514 m elevation range to be visible. Both are stated in the methodology panel, but that panel is a `<details>` with no `open` attribute, so the disclosure moves from always-visible in the map legend to behind a click. Flagged for a decision, deliberately not acted on in this PR.

Gates: typecheck 0 · typecheck:gate 0 allowlisted · yarn test 79 · snapshot:check identical · pytest 75.
