### PR TITLE
T-5.37 — remove the date slider and ‹ › arrows from the trend toolbar; group the controls left

### DIFF
--- a/code/ali-je-vroce-era5/components/RegressionPanel.tsx
+++ b/code/ali-je-vroce-era5/components/RegressionPanel.tsx
@@ -180,6 +180,16 @@ export function RegToolbar() {
     if (e.key === "Enter" || e.key === " " || e.key === "ArrowDown") {
       e.preventDefault();
       openCal();
+    } else if (!calOpen() && e.key === "ArrowLeft") {
+      // T-5.37: ±1-day stepping for keyboard users, moved here when the slider
+      // (a native range input, itself an arrow-stepper) and the ◀ ▶ buttons were
+      // removed. Same clamping the arrows used. Undiscoverable for mouse users by
+      // design — this compensates keyboard users, it does not replace the arrows.
+      e.preventDefault();
+      s.setDoy(d => Math.max(1, d - 1));
+    } else if (!calOpen() && e.key === "ArrowRight") {
+      e.preventDefault();
+      s.setDoy(d => Math.min(365, d + 1));
     }
   };
   const onGridKey = (e: KeyboardEvent) => {
@@ -235,8 +245,6 @@ export function RegToolbar() {
           readouts (stats.method footer, precip-vs-temp trend colour) are sourced
           elsewhere and are untouched. */}
 
-      <div class="reg-doy-spacer" />
-
       {/* DOY control */}
       <div class="reg-doy-ctrl">
         <span style={{ "font-family": "var(--font-mono)", "font-size": "9px", "letter-spacing": "0.12em", "text-transform": "uppercase", color: "var(--color-ink-soft)", "white-space": "nowrap" }}>{t("reg.day")}</span>
@@ -253,6 +261,7 @@ export function RegToolbar() {
             aria-haspopup="dialog"
             aria-expanded={calOpen()}
             aria-label={t("reg.pick_day")}
+            aria-keyshortcuts="ArrowLeft ArrowRight"
             onClick={() => (calOpen() ? closeCal(false) : openCal())}
             onKeyDown={onTriggerKey}
           >
@@ -296,17 +305,6 @@ export function RegToolbar() {
             </div>
             <div style={{ position: "fixed", inset: "0", "z-index": "9" }} onClick={() => closeCal(false)} />
           </Show>
-        </div>
-        <div class="reg-doy-slider">
-          <input
-            type="range" min="1" max="365" value={s.doy()}
-            style={{ flex: "1", appearance: "none", "-webkit-appearance": "none", background: "linear-gradient(to right,#3a5a8a,#6ca0c0,#e0d8c8,#c25a2c,#962c1a)", height: "3px", "border-radius": "2px", cursor: "pointer" }}
-            onInput={(e) => s.setDoy(Number(e.currentTarget.value))}
-          />
-        </div>
-        <div style={{ display: "flex", gap: "2px" }}>
-          <button style={playBtnStyle} onClick={() => s.setDoy(d => Math.max(1, d - 1))}>◀</button>
-          <button style={{ ...playBtnStyle, width: "36px", background: "var(--color-ink)", color: "#fff", "border-color": "var(--color-ink)" }} onClick={() => s.setDoy(d => Math.min(365, d + 1))}>▶</button>
         </div>
       </div>
 
@@ -704,19 +702,6 @@ const pillStyle: Record<string, string> = {
   color:          "var(--color-ink)",
   cursor:         "pointer",
   "font-family":  "var(--font-sans)",
-};
-
-const playBtnStyle: Record<string, string> = {
-  display:        "inline-grid",
-  "place-items":  "center",
-  width:          "28px",
-  height:         "28px",
-  "border-radius":"7px",
-  border:         "1px solid var(--color-rule)",
-  background:     "var(--color-card)",
-  cursor:         "pointer",
-  "font-size":    "9px",
-  color:          "var(--color-ink)",
 };
 
 export const panelHStyle: Record<string, string> = {

--- a/styles/era5.css
+++ b/styles/era5.css
@@ -219,9 +219,7 @@
 .reg-card--cal  { margin: 20px 40px 0; }
 
 /* ── Responsive: DOY control ─────────────────────────────────────────────── */
-.reg-doy-spacer { flex: 1; min-width: 8px; }
 .reg-doy-ctrl   { display: flex; align-items: center; gap: 8px; padding: 4px 4px 4px 10px; border-radius: 10px; background: var(--color-paper); height: 36px; }
-.reg-doy-slider { height: 28px; background: var(--color-card); border: 1px solid var(--color-rule-2); border-radius: 7px; display: flex; align-items: center; padding: 0 8px; width: 180px; }
 
 /* ── T-5.28: day-of-year calendar picker ─────────────────────────────────────
    Opens from the "1. avg." label; a yearless month + day-number grid (no weekday
@@ -310,9 +308,7 @@
   .sec-hs2{ padding-inline: 14px; }
   .sec-p  { padding-inline: 14px; }
   .reg-toolbar { margin: 10px 14px 0; padding: 8px 10px; }
-  .reg-doy-spacer { display: none; }
   .reg-doy-ctrl   { order: 10; flex: 1 0 100%; height: auto; padding: 6px 10px; }
-  .reg-doy-slider { flex: 1; width: auto; min-width: 80px; }
   .shm-grid       { grid-template-columns: 20px 1fr; row-gap: 4px; }
   .shm-year-axis  { grid-template-columns: 20px 1fr; }
   .shm-season-lbl { font-size: 0; padding-right: 0; }

--- a/tests/fixtures/snapshot.json
+++ b/tests/fixtures/snapshot.json
@@ -33688,7 +33688,7 @@
         "rendered": {
           "toolbar": [
             "SpremenljivkaNajvišja temperatura (°C)Najnižja temperatura (°C)Povprečna temperatura (°C)Padavine (mm)ET₀ (mm)",
-            "Dan21. jul.◀▶"
+            "Dan21. jul."
           ],
           "variable_select": {
             "selected": "temperature_max",
@@ -37212,7 +37212,7 @@
         "rendered": {
           "toolbar": [
             "SpremenljivkaNajvišja temperatura (°C)Najnižja temperatura (°C)Povprečna temperatura (°C)Padavine (mm)ET₀ (mm)",
-            "Dan21. jul.◀▶"
+            "Dan21. jul."
           ],
           "variable_select": {
             "selected": "temperature_max",
@@ -40736,7 +40736,7 @@
         "rendered": {
           "toolbar": [
             "SpremenljivkaNajvišja temperatura (°C)Najnižja temperatura (°C)Povprečna temperatura (°C)Padavine (mm)ET₀ (mm)",
-            "Dan21. jul.◀▶"
+            "Dan21. jul."
           ],
           "variable_select": {
             "selected": "temperature_max",
@@ -44069,7 +44069,7 @@
         "rendered": {
           "toolbar": [
             "SpremenljivkaNajvišja temperatura (°C)Najnižja temperatura (°C)Povprečna temperatura (°C)Padavine (mm)ET₀ (mm)",
-            "Dan29. jul.◀▶"
+            "Dan29. jul."
           ],
           "variable_select": {
             "selected": "temperature_max",
@@ -47593,7 +47593,7 @@
         "rendered": {
           "toolbar": [
             "SpremenljivkaNajvišja temperatura (°C)Najnižja temperatura (°C)Povprečna temperatura (°C)Padavine (mm)ET₀ (mm)",
-            "Dan29. jul.◀▶"
+            "Dan29. jul."
           ],
           "variable_select": {
             "selected": "temperature_max",
@@ -51117,7 +51117,7 @@
         "rendered": {
           "toolbar": [
             "SpremenljivkaNajvišja temperatura (°C)Najnižja temperatura (°C)Povprečna temperatura (°C)Padavine (mm)ET₀ (mm)",
-            "Dan29. jul.◀▶"
+            "Dan29. jul."
           ],
           "variable_select": {
             "selected": "temperature_max",
@@ -54450,7 +54450,7 @@
         "rendered": {
           "toolbar": [
             "SpremenljivkaNajvišja temperatura (°C)Najnižja temperatura (°C)Povprečna temperatura (°C)Padavine (mm)ET₀ (mm)",
-            "Dan15. jul.◀▶"
+            "Dan15. jul."
           ],
           "variable_select": {
             "selected": "temperature_max",
@@ -57974,7 +57974,7 @@
         "rendered": {
           "toolbar": [
             "SpremenljivkaNajvišja temperatura (°C)Najnižja temperatura (°C)Povprečna temperatura (°C)Padavine (mm)ET₀ (mm)",
-            "Dan15. jul.◀▶"
+            "Dan15. jul."
           ],
           "variable_select": {
             "selected": "temperature_max",
@@ -61498,7 +61498,7 @@
         "rendered": {
           "toolbar": [
             "SpremenljivkaNajvišja temperatura (°C)Najnižja temperatura (°C)Povprečna temperatura (°C)Padavine (mm)ET₀ (mm)",
-            "Dan15. jul.◀▶"
+            "Dan15. jul."
           ],
           "variable_select": {
             "selected": "temperature_max",
@@ -62341,7 +62341,7 @@
         "rendered": {
           "toolbar": [
             "SpremenljivkaNajvišja temperatura (°C)Najnižja temperatura (°C)Povprečna temperatura (°C)Padavine (mm)ET₀ (mm)",
-            "Dan28. feb.◀▶"
+            "Dan28. feb."
           ],
           "variable_select": {
             "selected": "temperature_max",
@@ -63184,7 +63184,7 @@
         "rendered": {
           "toolbar": [
             "SpremenljivkaNajvišja temperatura (°C)Najnižja temperatura (°C)Povprečna temperatura (°C)Padavine (mm)ET₀ (mm)",
-            "Dan28. feb.◀▶"
+            "Dan28. feb."
           ],
           "variable_select": {
             "selected": "temperature_max",
@@ -63978,7 +63978,7 @@
         "rendered": {
           "toolbar": [
             "SpremenljivkaNajvišja temperatura (°C)Najnižja temperatura (°C)Povprečna temperatura (°C)Padavine (mm)ET₀ (mm)",
-            "Dan28. feb.◀▶"
+            "Dan28. feb."
           ],
           "variable_select": {
             "selected": "temperature_max",
@@ -67484,7 +67484,7 @@
         "rendered": {
           "toolbar": [
             "SpremenljivkaNajvišja temperatura (°C)Najnižja temperatura (°C)Povprečna temperatura (°C)Padavine (mm)ET₀ (mm)",
-            "Dan1. mar.◀▶"
+            "Dan1. mar."
           ],
           "variable_select": {
             "selected": "temperature_max",
@@ -71008,7 +71008,7 @@
         "rendered": {
           "toolbar": [
             "SpremenljivkaNajvišja temperatura (°C)Najnižja temperatura (°C)Povprečna temperatura (°C)Padavine (mm)ET₀ (mm)",
-            "Dan28. feb.◀▶"
+            "Dan28. feb."
           ],
           "variable_select": {
             "selected": "temperature_max",
@@ -74532,7 +74532,7 @@
         "rendered": {
           "toolbar": [
             "SpremenljivkaNajvišja temperatura (°C)Najnižja temperatura (°C)Povprečna temperatura (°C)Padavine (mm)ET₀ (mm)",
-            "Dan1. mar.◀▶"
+            "Dan1. mar."
           ],
           "variable_select": {
             "selected": "temperature_max",
@@ -78056,7 +78056,7 @@
         "rendered": {
           "toolbar": [
             "SpremenljivkaNajvišja temperatura (°C)Najnižja temperatura (°C)Povprečna temperatura (°C)Padavine (mm)ET₀ (mm)",
-            "Dan1. jan.◀▶"
+            "Dan1. jan."
           ],
           "variable_select": {
             "selected": "temperature_max",
@@ -81572,7 +81572,7 @@
         "rendered": {
           "toolbar": [
             "SpremenljivkaNajvišja temperatura (°C)Najnižja temperatura (°C)Povprečna temperatura (°C)Padavine (mm)ET₀ (mm)",
-            "Dan31. dec.◀▶"
+            "Dan31. dec."
           ],
           "variable_select": {
             "selected": "temperature_max",
@@ -85088,7 +85088,7 @@
         "rendered": {
           "toolbar": [
             "SpremenljivkaNajvišja temperatura (°C)Najnižja temperatura (°C)Povprečna temperatura (°C)Padavine (mm)ET₀ (mm)",
-            "Dan3. avg.◀▶"
+            "Dan3. avg."
           ],
           "variable_select": {
             "selected": "temperature_max",
@@ -88604,7 +88604,7 @@
         "rendered": {
           "toolbar": [
             "SpremenljivkaNajvišja temperatura (°C)Najnižja temperatura (°C)Povprečna temperatura (°C)Padavine (mm)ET₀ (mm)",
-            "Dan3. avg.◀▶"
+            "Dan3. avg."
           ],
           "variable_select": {
             "selected": "temperature_max",
@@ -92128,7 +92128,7 @@
         "rendered": {
           "toolbar": [
             "SpremenljivkaNajvišja temperatura (°C)Najnižja temperatura (°C)Povprečna temperatura (°C)Padavine (mm)ET₀ (mm)",
-            "Dan7. feb.◀▶"
+            "Dan7. feb."
           ],
           "variable_select": {
             "selected": "temperature_max",
@@ -95665,7 +95665,7 @@
         "rendered": {
           "toolbar": [
             "SpremenljivkaNajvišja temperatura (°C)Najnižja temperatura (°C)Povprečna temperatura (°C)Padavine (mm)ET₀ (mm)",
-            "Dan7. jan.◀▶"
+            "Dan7. jan."
           ],
           "variable_select": {
             "selected": "temperature_max",


### PR DESCRIPTION
Cleans up the "Analiza trendov" toolbar: removes the gradient date slider and the ‹ › stepper arrows, and groups the remaining controls left.

**The gradient encoded nothing.** It was a hard-coded blue→beige→red ramp mapped onto day 1→365 — not temperature, not significance, not anomaly. It implied monotonic warming from January to December when the year is warm in the middle. Removing it loses no information and removes a false signal.

**The alignment defect was `.reg-doy-spacer { flex: 1 }`**, which pinned DAN to the far right. Removing it lets the toolbar's own `gap: 8px` group SPREMENLJIVKA and DAN adjacently at the left. There was no vertical or baseline defect — removing the two controls would not have fixed the alignment on its own.

**Single-keystroke ±1 day stepping is deliberately lost.** Both the arrows and the native range slider stepped by a day. The control selects a day-of-year for a trend aggregated over a ±7-day window (D-23), so adjacent days share 13 of their 15 pooled values — the affordance implied a precision the statistic does not have. Keyboard users are compensated: ArrowLeft/Right on the focused, closed calendar trigger steps ±1 with the same clamping, marked with `aria-keyshortcuts`. That is undiscoverable for mouse users by design, and is a repair rather than a replacement. The calendar remains fully keyboard-operable, so nothing became mouse-only.

**Snapshot moved exactly as predicted**: 21 insertions, 21 deletions, all `cases[N].analysis.rendered.toolbar[1]`, `"Dan<day>◀▶"` → `"Dan<day>"`. Deletions only, no numeric leaf, array length and every sibling key unchanged.

**Stale premise corrected:** the ticket said "LOKACIJA / SPREMENLJIVKA / DAN". There is no LOKACIJA control — T-5.27/D-26 retired it. `reg.location` in `i18n/sl.ts` has had zero readers since then; left in place and flagged.

**Left alignment was checked locally against the fixtures** and reads correctly; the 6px content inset between the first control (54px) and the card title below (60px) was measured, reported and deliberately left alone. Still needs eyes on stage (no previews, T-6.9) for the deployed CSS and fonts at desktop and 390px, and that day selection works by calendar alone.

Gates: typecheck 0 · typecheck:gate 0 allowlisted · yarn test 79 · snapshot:check identical after an authorised re-record · pytest 75.
