### PR TITLE
T-4.26b — Okno: selectable trend window for the panel and calendar; hero stays on published ±7

### DIFF
--- a/code/ali-je-vroce-era5/api.ts
+++ b/code/ali-je-vroce-era5/api.ts
@@ -16,7 +16,7 @@ import type { SpeiStationData } from "./charts/SpeiTrendChart.tsx";
 // identifier→string-literal quirk; verified against datasette 0.65.2 / SQLite DQS=3).
 import type {
   StationsCol, DailyCol, DailyWindowCol, SeasonHeatmapCol, SpeiCol, SpeiStationCol,
-  AnnualTrendCol, DsTropical, TropicalCol, DsDailyWindow,
+  AnnualTrendCol, AnnualTrendWindowsCol, DsTropical, TropicalCol, DsDailyWindow,
 } from "./generated/datasette-schema.ts";
 // The category palette lives with the percentile helpers salvaged from the
 // deleted ARSO path (T-2.2 / D-2); see percentile.ts for why they were kept.
@@ -127,7 +127,30 @@ const dwCol = (c: DailyWindowCol):  DailyWindowCol  => c;
 const dCol  = (c: DailyCol):        DailyCol        => c;
 const shCol = (c: SeasonHeatmapCol): SeasonHeatmapCol => c;
 const atCol = (c: AnnualTrendCol):  AnnualTrendCol  => c;
+// T-4.26b — the `annual_trend_windows` filter columns. Only `window` is unique to
+// that table; era5_name/variable/month/day are shared with annual_trend (identical
+// names) and stay pinned by atCol above, so a windowed URL reuses atCol for those.
+const atwCol = (c: AnnualTrendWindowsCol): AnnualTrendWindowsCol => c;
 const trCol = (c: TropicalCol):     TropicalCol     => c;
+
+// T-4.26b — the ±7 window has ONE home: the `annual_trend` table. T-4.26a
+// deliberately did NOT duplicate ±7 into `annual_trend_windows`; that table holds
+// only ±3/±15/±45, keyed by the half-width `window` column. This is the SINGLE site
+// in the frontend that names `annual_trend_windows`, and it returns the table name
+// and its MANDATORY `window__exact` filter AS ONE OBJECT — a caller cannot select the
+// windows table without also emitting the filter, because both come from this one
+// call. Omitting the filter would silently over-read: annual_trend_windows returns one
+// row PER window (3× the rows), so an unfiltered calendar query (365×3 = 1095 rows)
+// would hit the datasette `_size` cap and blend three windows into one calendar
+// (see fetchCalendar). Inseparability makes that mistake unwriteable.
+// For window===7 the returned filter is "" and the table is `annual_trend`, so a
+// window-7 URL is BYTE-IDENTICAL to the pre-T-4.26b URL — which is what keeps the hero
+// (fetchRegression with no window, D-34) on its recorded fixtures.
+function annualTrendSource(window: number): { table: string; filter: string } {
+  return window === 7
+    ? { table: "annual_trend",         filter: "" }
+    : { table: "annual_trend_windows", filter: `&${atwCol("window")}__exact=${window}` };
+}
 
 // T-5.1: guard for the datasette `*_json` columns (distribution_json, scatter_json,
 // years_json, counts_json, trend_json, spei_json). An unguarded JSON.parse throws a
@@ -602,13 +625,18 @@ export interface RegressionParams {
   locs:   string[];
   var:    string;
   doy:    number;
+  // T-4.26b (D-34) — the trend half-window in days. OPTIONAL and defaults to ±7:
+  // the hero (HeroCards.tsx) omits it and therefore stays on the published `annual_trend`
+  // table with a byte-identical URL, while the analysis panel passes its selected window.
+  window?: number;
 }
 
 export async function fetchRegression(p: RegressionParams): Promise<RegressionResponse> {
   const { month, day } = doyToMonthDay(p.doy);
+  const window = p.window ?? 7;
 
   const era5Results = await Promise.all(
-    p.locs.map(loc => buildRegressionResult(loc, p.var, month, day))
+    p.locs.map(loc => buildRegressionResult(loc, p.var, month, day, window))
   );
 
   return {
@@ -620,10 +648,13 @@ export async function fetchRegression(p: RegressionParams): Promise<RegressionRe
 }
 
 async function buildRegressionResult(
-  era5Name: string, variable: string, month: number, day: number
+  era5Name: string, variable: string, month: number, day: number, window = 7
 ): Promise<RegressionResult | null> {
+  // T-4.26b — window===7 → annual_trend (unchanged URL, keeps the hero on fixtures);
+  // ±3/±15/±45 → annual_trend_windows with its mandatory window filter (annualTrendSource).
+  const src = annualTrendSource(window);
   const rows = await dsGet<AnnualTrendRow[]>(
-    `annual_trend.json?_shape=array&${atCol("era5_name")}__exact=${encodeURIComponent(era5Name)}&${atCol("variable")}__exact=${encodeURIComponent(variable)}&${atCol("month")}__exact=${month}&${atCol("day")}__exact=${day}&_size=1`
+    `${src.table}.json?_shape=array&${atCol("era5_name")}__exact=${encodeURIComponent(era5Name)}&${atCol("variable")}__exact=${encodeURIComponent(variable)}&${atCol("month")}__exact=${month}&${atCol("day")}__exact=${day}${src.filter}&_size=1`
   );
   const r = rows[0];
   if (!r) return null;
@@ -790,10 +821,19 @@ export interface CalendarData {
 }
 
 export async function fetchCalendar(
-  loc: string, variable: string
+  loc: string, variable: string, window = 7
 ): Promise<CalendarData> {
+  // T-4.26b (D-34) — the year-round calendar follows the window control. The window
+  // filter here is NOT optional: annual_trend_windows holds one row per window, so an
+  // unfiltered read would return 365×3 = 1095 rows, silently capped at `_size=400` and
+  // blending three windows into one calendar. `annualTrendSource` makes that unwriteable
+  // — the windows table name and its `window__exact` filter arrive as one pair, so this
+  // call site cannot name the table without the filter. For window===7 the table is
+  // `annual_trend` and the filter is "", preserving the exact recorded URL. 365 rows for
+  // a single window sit safely under 400.
+  const src = annualTrendSource(window);
   const rows = await dsGet<CalendarRow[]>(
-    `annual_trend.json?_shape=array&${atCol("era5_name")}__exact=${encodeURIComponent(loc)}&${atCol("variable")}__exact=${encodeURIComponent(variable)}&${dsCols(CALENDAR_COLS)}&_size=400`
+    `${src.table}.json?_shape=array&${atCol("era5_name")}__exact=${encodeURIComponent(loc)}&${atCol("variable")}__exact=${encodeURIComponent(variable)}&${dsCols(CALENDAR_COLS)}${src.filter}&_size=400`
   );
   return { loc, var: variable, unit: "°C", method_label: "Theil-Sen + TFPW MK", rows };
 }

--- a/code/ali-je-vroce-era5/components/RegressionPanel.tsx
+++ b/code/ali-je-vroce-era5/components/RegressionPanel.tsx
@@ -19,6 +19,12 @@ const VAR_KEYS = [
 ];
 const VARIABLES: [string, string][] = VAR_KEYS.map(k => [k, varLabelOf(k)]);
 
+// T-4.26b (D-34) — the selectable trend half-windows, ascending. ±7 is the published
+// default and the ONLY one served by the `annual_trend` table (api.annualTrendSource);
+// ±3/±15/±45 come from `annual_trend_windows` (T-4.26a). The control drives the panel
+// and the year-round calendar; the hero above is fixed at ±7.
+const WINDOWS = [3, 7, 15, 45] as const;
+
 interface ProviderProps {
   meta:         SiteMeta;
   defaultDoy:   number;
@@ -50,6 +56,9 @@ function createStore(props: ProviderProps) {
   const [selLocs,  setSelLocs]  = createSignal<string[]>([defaultLoc()]);
   const [selVar,   setSelVar]   = createSignal("temperature_max");
   const [doy,      setDoy]      = createSignal(props.defaultDoy);
+  // T-4.26b (D-34) — the trend half-window, ±7 default (the published value). Only the
+  // surfaces BELOW the control read it (params + calParams below); the hero does not.
+  const [selWindow, setSelWindow] = createSignal<number>(7);
 
   const selLoc = () => selLocs()[0] ?? defaultLoc();
   // The single writer for the below-hero location. It also notifies the page via
@@ -73,16 +82,18 @@ function createStore(props: ProviderProps) {
     locs:   selLocs(),
     var:    selVar(),
     doy:    doy(),
+    window: selWindow(),
   }));
   const [regData, { refetch: refetchReg }] = createResource(params, fetchRegression);
 
   const calParams = createMemo(() => ({
     loc:     selLocs()[0] ?? defaultLoc(),
     var:     selVar(),
+    window:  selWindow(),
   }));
   const [calData, { refetch: refetchCal }] = createResource(
     calParams,
-    p => fetchCalendar(p.loc, p.var),
+    p => fetchCalendar(p.loc, p.var, p.window),
   );
 
   const isPrecip   = () => selVar() === "precipitation_sum" || selVar() === "et0_evapotranspiration";
@@ -116,10 +127,11 @@ function createStore(props: ProviderProps) {
     meta: props.meta,
     selLocs, setSelLocs, selLoc, setLoc, selVar, setSelVar,
     doy, setDoy,
+    selWindow, setSelWindow,
     regData, calData, refetchReg, refetchCal,
     isPrecip, stats0, trend10, trendColor, totalChange,
     stationLabel, locLabel, varLabel, chartTitle, chartSub,
-    doyToLabel, VARIABLES,
+    doyToLabel, VARIABLES, WINDOWS,
   };
 }
 
@@ -235,6 +247,25 @@ export function RegToolbar() {
         </div>
       </div>
 
+      {/* Window (T-4.26b / D-34) — placed AFTER the variable <select> on purpose: the
+          snapshot's variable_select capture reads querySelector("select") (the FIRST
+          select), so a second select ahead of it would hijack that capture. Drives ONLY
+          the panel + calendar below; the hero omits window and stays on annual_trend. */}
+      <div style={pillGroupStyle}>
+        <span style={pgkStyle}>{t("reg.window")}</span>
+        <div style={{ ...pillStyle, "padding-right": "4px" }}>
+          <select
+            value={String(s.selWindow())}
+            style={selectStyle}
+            onChange={(e) => s.setSelWindow(Number(e.currentTarget.value))}
+          >
+            <For each={s.WINDOWS}>
+              {(w) => <option value={String(w)}>{t("reg.window_opt", { n: w })}</option>}
+            </For>
+          </select>
+        </div>
+      </div>
+
       {/* NB: former "Method" (Theil-Sen/OLS) and "Elevation corr." toolbar controls
           were removed in T-4.15 — they were dead. Their signals fed
           RegressionParams.corr/method, but fetchRegression reads the precomputed
@@ -308,6 +339,13 @@ export function RegToolbar() {
         </div>
       </div>
 
+      {/* Per-window explanation (T-4.26b / D-34) — a full-width row beneath the controls:
+          flex-basis:100% makes the wrapping toolbar drop it onto its own line. It is a
+          direct .reg-toolbar > div so the snapshot captures it (it would be a blind spot
+          otherwise). Copy changes with the selected window and explains WHY the numbers
+          move for that window (instability at ±3, seasonal contamination at ±15/±45). */}
+      <div style={windowExplStyle}>{t(`reg.window_expl_${s.selWindow()}`)}</div>
+
     </div>
   );
 }
@@ -352,7 +390,7 @@ export function RegScatterCard() {
                     {t("reg.no_data")}
                   </div>
                 }>
-                  <RegressionChart data={d} chartId={`reg-${s.selVar()}-${s.doy()}-${s.selLocs().join("_")}`} />
+                  <RegressionChart data={d} chartId={`reg-${s.selVar()}-${s.doy()}-w${s.selWindow()}-${s.selLocs().join("_")}`} />
                 </Show>
               )}
             </Show>
@@ -394,6 +432,8 @@ export function RegYearRoundCard() {
           <div style={{ ...panelSubStyle, "margin-top": "3px" }}>
             {(s.VARIABLES.find(([k]) => k === s.selVar())?.[1] ?? s.selVar()).split("(")[0]!.trim()}
             {" · Theil-Sen + MK"}
+            {/* T-4.26b (D-34) — name the window the calendar's colours are computed at. */}
+            {" · "}{t("reg.window_cal_label", { n: s.selWindow() })}
           </div>
         </div>
         <div style={panelSubStyle}>{t("reg.year_round_sub")}</div>
@@ -688,6 +728,30 @@ const pgkStyle: Record<string, string> = {
   "padding-right": "8px",
   "margin-right":  "2px",
   "white-space":   "nowrap",
+};
+
+// T-4.26b — the transparent chevron <select> used inside a pill (matches the variable
+// selector at RegToolbar; kept a separate const rather than reflowing the variable
+// select's inline style, so that call site stays byte-identical).
+const selectStyle: Record<string, string> = {
+  background: "transparent", border: "none", "font-size": "12px", color: "var(--color-ink)",
+  "font-family": "var(--font-sans)", cursor: "pointer", "padding-right": "16px", appearance: "none",
+  "background-image": "url(\"data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='10' viewBox='0 0 24 24' fill='%236B655B'%3E%3Cpath d='M7 10l5 5 5-5z'/%3E%3C/svg%3E\")",
+  "background-repeat": "no-repeat", "background-position": "right 2px center",
+};
+
+// T-4.26b — the per-window explanatory line. flex-basis:100% drops it to its own
+// full-width row inside the wrapping toolbar; capped width keeps it readable.
+const windowExplStyle: Record<string, string> = {
+  "flex-basis":  "100%",
+  width:         "100%",
+  "max-width":   "660px",
+  margin:        "0",
+  "padding-top": "2px",
+  "font-family": "var(--font-sans)",
+  "font-size":   "12px",
+  color:         "var(--color-ink-soft)",
+  "line-height": "1.5",
 };
 
 const pillStyle: Record<string, string> = {

--- a/code/ali-je-vroce-era5/i18n/sl.ts
+++ b/code/ali-je-vroce-era5/i18n/sl.ts
@@ -254,6 +254,21 @@ export const sl = {
 
     explain_reg: "Theil-Sen regresija + Yue-Wang TFPW Mann-Kendall test · ERA5-Land · nadmorska korekcija",
     explain_cal: "Trend na desetletje za vsak dan v letu · rdeča = ogrevanje · modra = ohlajanje · prosojnost = statistična značilnost",
+
+    // T-4.26b (D-34) — the trend half-window control below the hero. ±7 is the
+    // published default (annual_trend); ±3/±15/±45 read annual_trend_windows. Only
+    // the panel and the year-round calendar follow it; the hero stays at ±7.
+    window: "Okno",
+    window_opt: "±{n} dni",
+    window_cal_label: "okno ±{n} dni",
+    window_expl_3:
+      "Ozko okno: le okoli 7 dni na leto. Ocena postane nestabilna — interval zaupanja se razširi, posamezne vrednosti pa lahko skočijo v obe smeri, tudi navidez močneje. To ni znak manjšega segrevanja, ampak manjšega vzorca.",
+    window_expl_7:
+      "Objavljeno okno: ±7 dni okoli izbranega dne — uravnoteženo med velikostjo vzorca in sezonsko ostrino. To je vrednost, ki jo prikazuje stran.",
+    window_expl_15:
+      "Širše okno: ocena je bolj gladka, ker je v vzorcu več dni — a okno že sega približno mesec dni naokoli, zato vanj vstopa tudi sezonski potek.",
+    window_expl_45:
+      "Zelo široko okno: sega globoko v druge dele sezone in meša sosednje mesece. Videti je lahko bolj prepričljivo, a del te prepričljivosti prispeva sezonski potek in ne trend samega dne.",
   },
 
   // T-5.27 — floating station chooser (the single location control below the hero).

--- a/tests/fixtures/snapshot.json
+++ b/tests/fixtures/snapshot.json
@@ -33688,7 +33688,9 @@
         "rendered": {
           "toolbar": [
             "SpremenljivkaNajvišja temperatura (°C)Najnižja temperatura (°C)Povprečna temperatura (°C)Padavine (mm)ET₀ (mm)",
-            "Dan21. jul."
+            "Okno±3 dni±7 dni±15 dni±45 dni",
+            "Dan21. jul.",
+            "Objavljeno okno: ±7 dni okoli izbranega dne — uravnoteženo med velikostjo vzorca in sezonsko ostrino. To je vrednost, ki jo prikazuje stran."
           ],
           "variable_select": {
             "selected": "temperature_max",
@@ -37212,7 +37214,9 @@
         "rendered": {
           "toolbar": [
             "SpremenljivkaNajvišja temperatura (°C)Najnižja temperatura (°C)Povprečna temperatura (°C)Padavine (mm)ET₀ (mm)",
-            "Dan21. jul."
+            "Okno±3 dni±7 dni±15 dni±45 dni",
+            "Dan21. jul.",
+            "Objavljeno okno: ±7 dni okoli izbranega dne — uravnoteženo med velikostjo vzorca in sezonsko ostrino. To je vrednost, ki jo prikazuje stran."
           ],
           "variable_select": {
             "selected": "temperature_max",
@@ -40736,7 +40740,9 @@
         "rendered": {
           "toolbar": [
             "SpremenljivkaNajvišja temperatura (°C)Najnižja temperatura (°C)Povprečna temperatura (°C)Padavine (mm)ET₀ (mm)",
-            "Dan21. jul."
+            "Okno±3 dni±7 dni±15 dni±45 dni",
+            "Dan21. jul.",
+            "Objavljeno okno: ±7 dni okoli izbranega dne — uravnoteženo med velikostjo vzorca in sezonsko ostrino. To je vrednost, ki jo prikazuje stran."
           ],
           "variable_select": {
             "selected": "temperature_max",
@@ -44069,7 +44075,9 @@
         "rendered": {
           "toolbar": [
             "SpremenljivkaNajvišja temperatura (°C)Najnižja temperatura (°C)Povprečna temperatura (°C)Padavine (mm)ET₀ (mm)",
-            "Dan29. jul."
+            "Okno±3 dni±7 dni±15 dni±45 dni",
+            "Dan29. jul.",
+            "Objavljeno okno: ±7 dni okoli izbranega dne — uravnoteženo med velikostjo vzorca in sezonsko ostrino. To je vrednost, ki jo prikazuje stran."
           ],
           "variable_select": {
             "selected": "temperature_max",
@@ -47593,7 +47601,9 @@
         "rendered": {
           "toolbar": [
             "SpremenljivkaNajvišja temperatura (°C)Najnižja temperatura (°C)Povprečna temperatura (°C)Padavine (mm)ET₀ (mm)",
-            "Dan29. jul."
+            "Okno±3 dni±7 dni±15 dni±45 dni",
+            "Dan29. jul.",
+            "Objavljeno okno: ±7 dni okoli izbranega dne — uravnoteženo med velikostjo vzorca in sezonsko ostrino. To je vrednost, ki jo prikazuje stran."
           ],
           "variable_select": {
             "selected": "temperature_max",
@@ -51117,7 +51127,9 @@
         "rendered": {
           "toolbar": [
             "SpremenljivkaNajvišja temperatura (°C)Najnižja temperatura (°C)Povprečna temperatura (°C)Padavine (mm)ET₀ (mm)",
-            "Dan29. jul."
+            "Okno±3 dni±7 dni±15 dni±45 dni",
+            "Dan29. jul.",
+            "Objavljeno okno: ±7 dni okoli izbranega dne — uravnoteženo med velikostjo vzorca in sezonsko ostrino. To je vrednost, ki jo prikazuje stran."
           ],
           "variable_select": {
             "selected": "temperature_max",
@@ -54450,7 +54462,9 @@
         "rendered": {
           "toolbar": [
             "SpremenljivkaNajvišja temperatura (°C)Najnižja temperatura (°C)Povprečna temperatura (°C)Padavine (mm)ET₀ (mm)",
-            "Dan15. jul."
+            "Okno±3 dni±7 dni±15 dni±45 dni",
+            "Dan15. jul.",
+            "Objavljeno okno: ±7 dni okoli izbranega dne — uravnoteženo med velikostjo vzorca in sezonsko ostrino. To je vrednost, ki jo prikazuje stran."
           ],
           "variable_select": {
             "selected": "temperature_max",
@@ -57974,7 +57988,9 @@
         "rendered": {
           "toolbar": [
             "SpremenljivkaNajvišja temperatura (°C)Najnižja temperatura (°C)Povprečna temperatura (°C)Padavine (mm)ET₀ (mm)",
-            "Dan15. jul."
+            "Okno±3 dni±7 dni±15 dni±45 dni",
+            "Dan15. jul.",
+            "Objavljeno okno: ±7 dni okoli izbranega dne — uravnoteženo med velikostjo vzorca in sezonsko ostrino. To je vrednost, ki jo prikazuje stran."
           ],
           "variable_select": {
             "selected": "temperature_max",
@@ -61498,7 +61514,9 @@
         "rendered": {
           "toolbar": [
             "SpremenljivkaNajvišja temperatura (°C)Najnižja temperatura (°C)Povprečna temperatura (°C)Padavine (mm)ET₀ (mm)",
-            "Dan15. jul."
+            "Okno±3 dni±7 dni±15 dni±45 dni",
+            "Dan15. jul.",
+            "Objavljeno okno: ±7 dni okoli izbranega dne — uravnoteženo med velikostjo vzorca in sezonsko ostrino. To je vrednost, ki jo prikazuje stran."
           ],
           "variable_select": {
             "selected": "temperature_max",
@@ -62341,7 +62359,9 @@
         "rendered": {
           "toolbar": [
             "SpremenljivkaNajvišja temperatura (°C)Najnižja temperatura (°C)Povprečna temperatura (°C)Padavine (mm)ET₀ (mm)",
-            "Dan28. feb."
+            "Okno±3 dni±7 dni±15 dni±45 dni",
+            "Dan28. feb.",
+            "Objavljeno okno: ±7 dni okoli izbranega dne — uravnoteženo med velikostjo vzorca in sezonsko ostrino. To je vrednost, ki jo prikazuje stran."
           ],
           "variable_select": {
             "selected": "temperature_max",
@@ -63184,7 +63204,9 @@
         "rendered": {
           "toolbar": [
             "SpremenljivkaNajvišja temperatura (°C)Najnižja temperatura (°C)Povprečna temperatura (°C)Padavine (mm)ET₀ (mm)",
-            "Dan28. feb."
+            "Okno±3 dni±7 dni±15 dni±45 dni",
+            "Dan28. feb.",
+            "Objavljeno okno: ±7 dni okoli izbranega dne — uravnoteženo med velikostjo vzorca in sezonsko ostrino. To je vrednost, ki jo prikazuje stran."
           ],
           "variable_select": {
             "selected": "temperature_max",
@@ -63978,7 +64000,9 @@
         "rendered": {
           "toolbar": [
             "SpremenljivkaNajvišja temperatura (°C)Najnižja temperatura (°C)Povprečna temperatura (°C)Padavine (mm)ET₀ (mm)",
-            "Dan28. feb."
+            "Okno±3 dni±7 dni±15 dni±45 dni",
+            "Dan28. feb.",
+            "Objavljeno okno: ±7 dni okoli izbranega dne — uravnoteženo med velikostjo vzorca in sezonsko ostrino. To je vrednost, ki jo prikazuje stran."
           ],
           "variable_select": {
             "selected": "temperature_max",
@@ -67484,7 +67508,9 @@
         "rendered": {
           "toolbar": [
             "SpremenljivkaNajvišja temperatura (°C)Najnižja temperatura (°C)Povprečna temperatura (°C)Padavine (mm)ET₀ (mm)",
-            "Dan1. mar."
+            "Okno±3 dni±7 dni±15 dni±45 dni",
+            "Dan1. mar.",
+            "Objavljeno okno: ±7 dni okoli izbranega dne — uravnoteženo med velikostjo vzorca in sezonsko ostrino. To je vrednost, ki jo prikazuje stran."
           ],
           "variable_select": {
             "selected": "temperature_max",
@@ -71008,7 +71034,9 @@
         "rendered": {
           "toolbar": [
             "SpremenljivkaNajvišja temperatura (°C)Najnižja temperatura (°C)Povprečna temperatura (°C)Padavine (mm)ET₀ (mm)",
-            "Dan28. feb."
+            "Okno±3 dni±7 dni±15 dni±45 dni",
+            "Dan28. feb.",
+            "Objavljeno okno: ±7 dni okoli izbranega dne — uravnoteženo med velikostjo vzorca in sezonsko ostrino. To je vrednost, ki jo prikazuje stran."
           ],
           "variable_select": {
             "selected": "temperature_max",
@@ -74532,7 +74560,9 @@
         "rendered": {
           "toolbar": [
             "SpremenljivkaNajvišja temperatura (°C)Najnižja temperatura (°C)Povprečna temperatura (°C)Padavine (mm)ET₀ (mm)",
-            "Dan1. mar."
+            "Okno±3 dni±7 dni±15 dni±45 dni",
+            "Dan1. mar.",
+            "Objavljeno okno: ±7 dni okoli izbranega dne — uravnoteženo med velikostjo vzorca in sezonsko ostrino. To je vrednost, ki jo prikazuje stran."
           ],
           "variable_select": {
             "selected": "temperature_max",
@@ -78056,7 +78086,9 @@
         "rendered": {
           "toolbar": [
             "SpremenljivkaNajvišja temperatura (°C)Najnižja temperatura (°C)Povprečna temperatura (°C)Padavine (mm)ET₀ (mm)",
-            "Dan1. jan."
+            "Okno±3 dni±7 dni±15 dni±45 dni",
+            "Dan1. jan.",
+            "Objavljeno okno: ±7 dni okoli izbranega dne — uravnoteženo med velikostjo vzorca in sezonsko ostrino. To je vrednost, ki jo prikazuje stran."
           ],
           "variable_select": {
             "selected": "temperature_max",
@@ -81572,7 +81604,9 @@
         "rendered": {
           "toolbar": [
             "SpremenljivkaNajvišja temperatura (°C)Najnižja temperatura (°C)Povprečna temperatura (°C)Padavine (mm)ET₀ (mm)",
-            "Dan31. dec."
+            "Okno±3 dni±7 dni±15 dni±45 dni",
+            "Dan31. dec.",
+            "Objavljeno okno: ±7 dni okoli izbranega dne — uravnoteženo med velikostjo vzorca in sezonsko ostrino. To je vrednost, ki jo prikazuje stran."
           ],
           "variable_select": {
             "selected": "temperature_max",
@@ -85088,7 +85122,9 @@
         "rendered": {
           "toolbar": [
             "SpremenljivkaNajvišja temperatura (°C)Najnižja temperatura (°C)Povprečna temperatura (°C)Padavine (mm)ET₀ (mm)",
-            "Dan3. avg."
+            "Okno±3 dni±7 dni±15 dni±45 dni",
+            "Dan3. avg.",
+            "Objavljeno okno: ±7 dni okoli izbranega dne — uravnoteženo med velikostjo vzorca in sezonsko ostrino. To je vrednost, ki jo prikazuje stran."
           ],
           "variable_select": {
             "selected": "temperature_max",
@@ -88604,7 +88640,9 @@
         "rendered": {
           "toolbar": [
             "SpremenljivkaNajvišja temperatura (°C)Najnižja temperatura (°C)Povprečna temperatura (°C)Padavine (mm)ET₀ (mm)",
-            "Dan3. avg."
+            "Okno±3 dni±7 dni±15 dni±45 dni",
+            "Dan3. avg.",
+            "Objavljeno okno: ±7 dni okoli izbranega dne — uravnoteženo med velikostjo vzorca in sezonsko ostrino. To je vrednost, ki jo prikazuje stran."
           ],
           "variable_select": {
             "selected": "temperature_max",
@@ -92128,7 +92166,9 @@
         "rendered": {
           "toolbar": [
             "SpremenljivkaNajvišja temperatura (°C)Najnižja temperatura (°C)Povprečna temperatura (°C)Padavine (mm)ET₀ (mm)",
-            "Dan7. feb."
+            "Okno±3 dni±7 dni±15 dni±45 dni",
+            "Dan7. feb.",
+            "Objavljeno okno: ±7 dni okoli izbranega dne — uravnoteženo med velikostjo vzorca in sezonsko ostrino. To je vrednost, ki jo prikazuje stran."
           ],
           "variable_select": {
             "selected": "temperature_max",
@@ -95665,7 +95705,9 @@
         "rendered": {
           "toolbar": [
             "SpremenljivkaNajvišja temperatura (°C)Najnižja temperatura (°C)Povprečna temperatura (°C)Padavine (mm)ET₀ (mm)",
-            "Dan7. jan."
+            "Okno±3 dni±7 dni±15 dni±45 dni",
+            "Dan7. jan.",
+            "Objavljeno okno: ±7 dni okoli izbranega dne — uravnoteženo med velikostjo vzorca in sezonsko ostrino. To je vrednost, ki jo prikazuje stran."
           ],
           "variable_select": {
             "selected": "temperature_max",


### PR DESCRIPTION
Adds the **Okno** trend-window control (±3 / ±7 / ±15 / ±45) to the "Analiza trendov" toolbar, wires the panel and the year-round calendar to it, and keeps the hero card on the published ±7.

**The catch that shaped the design:** `fetchRegression` is *shared* — the hero card and its significance stars call it (`HeroCards.tsx:78-82`) and so does the regression panel (`RegressionPanel.tsx:77`). An unconditional table switch inside `buildRegressionResult` would have dragged the hero off ±7, which D-34 forbids. The seam is instead an optional `window` param defaulting to 7, threaded `RegressionParams → fetchRegression → buildRegressionResult`. The hero calls it with no window and its request URL stays character-identical.

**±7 keeps one home.** T-4.26a deliberately did not duplicate ±7 into `annual_trend_windows`, so the frontend reads two tables: `annual_trend` at ±7, `annual_trend_windows` otherwise. `annualTrendSource(window)` is the single site that names the windows table, and it returns the table name **and** its `window__exact` filter as one object — so no call site can select the table without the filter, and there is no bare `annual_trend_windows` literal anywhere else.

**Why that matters:** `fetchCalendar` requests `_size=400` for 365 days. Against the windows table without a filter it returns 1,095 rows, silently capped at 400, blending three windows into one calendar. `_size` truncation gives no signal, so the constraint is enforced structurally rather than by discipline.

**The confidence band needed no new code.** It already renders as an `arearange` from `line.lower/upper` (`RegressionChart.tsx:27-40`), legended as `common.ci95`. Windowed `slope_hi/lo` flow through the same reader, so the band widens on its own. Checked against real data rather than assumed: **36 of 626** recorded ±7 rows already have `slope_lo < 0` with `slope > 0` and render fine as an hourglass crossing at the centroid — so a zero-crossing band at ±3 is a shipping shape, not a new risk.

**The copy is the point of the ticket.** D-33 measured that narrowing is *not* monotone weakening: ±7 → ±3 for Tmax moved 363 rows out of significance and **96 into it**, while the slope barely moves and the confidence band widens (Celje `slope_lo` 0.0175 → 0.0062). So the ±3 line says the estimate becomes unstable and can jump **in both directions** — explicitly not that there is less warming. The ±15 line names the cost of smoothness rather than selling it: at a month's span the seasonal gradient that made D-23 reject ±30 has already begun. The ±45 line says outright that part of its apparent conviction comes from the season rather than from the day's trend.

**Calendar labels its window** (`okno ±{n} dni` on the subtitle), so its disagreement with the hero reads as intentional rather than as a bug — the corollary D-34 requires.

**Placement detail worth keeping:** the Okno select sits *after* the variable select, because the snapshot's `variable_select` capture reads `querySelector("select")` and a second select placed first would hijack it.

**⚠ Known coverage gap, deliberate:** the ±3 / ±15 / ±45 paths have **no offline fixture coverage**. Recording them needs an operator-authorised live fetch, which was not done. A green `snapshot:check` here covers ±7 only — the windows paths are exercised on stage or nowhere.

Snapshot moved exactly as predicted: 60 leaf lines, all under `analysis.rendered.toolbar` (Okno text ×21, the ±7 explanatory line ×21, DOY entry reindexed). **No hero leaf, no numeric leaf and no calendar leaf moved.**

Gates: typecheck 0 · typecheck:gate 0 allowlisted · yarn test 79 · snapshot:check identical, 0 misses · pytest 75 · validate.py n/a.
