### PR TITLE
T-5.47 — elevation dots, metres and range line; closes D-7 after the map was hidden

### DIFF
--- a/code/ali-je-vroce-era5/AliJeVroceERA5.tsx
+++ b/code/ali-je-vroce-era5/AliJeVroceERA5.tsx
@@ -247,7 +247,7 @@ function Dashboard(props: { meta: SiteMeta }) {
       </RegressionPanel>
 
       {/* ── Methodology + trust furniture (T-6.1 / T-6.2) — foot of content ── */}
-      <MethodologyPanel stationCount={era5Stations.length} />
+      <MethodologyPanel stations={era5Stations} />
 
     </div>
   );

--- a/code/ali-je-vroce-era5/components/MethodologyPanel.tsx
+++ b/code/ali-je-vroce-era5/components/MethodologyPanel.tsx
@@ -20,8 +20,10 @@
 
 import { For } from "solid-js";
 import type { JSX } from "solid-js";
+import type { SiteMeta } from "../types.ts";
 import { methodologyMarkdown } from "../i18n/hero-content.ts";
 import { t } from "../i18n/format.ts";
+import { ELEV_BANDS, bandKey } from "../i18n/station-bands.ts";
 
 // T-6.2 correction contact. A literal address, not translatable prose.
 const CONTACT_EMAIL = "info@podnebnik.org";
@@ -114,7 +116,40 @@ function renderInline(text: string): (string | JSX.Element)[] {
 // Parsed once — the document is static.
 const BLOCKS: Block[] = parseBlocks(methodologyMarkdown);
 
-export function MethodologyPanel(props: { stationCount: number }) {
+// T-5.47 — the four-band elevation legend, rendered as a real table (the markdown
+// parser above has no table block kind, so this lives here rather than in
+// methodologyMarkdown — which keeps the published method prose, and thus
+// hero-content.ts / METHODOLOGY.md, unchanged). Band + range cell reuses the map's old
+// legend strings verbatim (map.legend_*, revived after T-5.46 left them dead); the
+// per-band count is COMPUTED from meta.stations — never hardcoded — so it is the first
+// place D-7's "only one station above 1000 m" fact becomes visible on the page. The
+// swatch is a coloured element (not an emoji), matching the chooser/tag dots exactly.
+function BandLegendTable(props: { stations: SiteMeta["stations"] }) {
+  const countOf = (key: string) =>
+    props.stations.filter((s) => bandKey(s.elevation) === key).length;
+  return (
+    <table class="methodology-bands">
+      <caption class="methodology-bands-cap">{t("methodology.bands_title")}</caption>
+      <tbody>
+        <For each={ELEV_BANDS}>
+          {(band) => (
+            <tr>
+              <td class="methodology-bands-swatch">
+                <i class="station-dot" aria-hidden="true" style={{ background: band.color }} />
+              </td>
+              <td class="methodology-bands-name">{t(`map.legend_${band.key}`)}</td>
+              <td class="methodology-bands-count">
+                {t("methodology.bands_count", { count: countOf(band.key) })}
+              </td>
+            </tr>
+          )}
+        </For>
+      </tbody>
+    </table>
+  );
+}
+
+export function MethodologyPanel(props: { stations: SiteMeta["stations"] }) {
   return (
     <section class="methodology sec-p">
       <details class="methodology-details">
@@ -135,13 +170,14 @@ export function MethodologyPanel(props: { stationCount: number }) {
               )
             }
           </For>
+          <BandLegendTable stations={props.stations} />
         </div>
       </details>
 
       {/* Always-visible trust furniture: station count (derived) + correction contact. */}
       <p class="methodology-furniture">
         <span class="methodology-furniture-stations">
-          {t("methodology.stations", { count: props.stationCount })}
+          {t("methodology.stations", { count: props.stations.length })}
         </span>
         <span class="methodology-furniture-sep" aria-hidden="true">·</span>
         <span class="methodology-furniture-contact">

--- a/code/ali-je-vroce-era5/components/RegressionPanel.tsx
+++ b/code/ali-je-vroce-era5/components/RegressionPanel.tsx
@@ -713,7 +713,17 @@ export function FloatingStationChooser(props: {
     >
       <Show when={open()}>
         <div class="fsc-overlay" onClick={() => closeMenu(false)} />
-        <ul ref={listRef} class="fsc-list" role="listbox" aria-label={t("floc.listbox")} onKeyDown={onListKey}>
+        <ul ref={listRef} class="fsc-list" role="listbox" aria-label={t("floc.listbox")}
+            aria-describedby="fsc-range-hdr" onKeyDown={onListKey}>
+          {/* T-5.47 Layer 4 (T-5.47 revision) — the elevation-range line, now a HEADER
+              ROW at the top of the EXPANDED list, directly above the dots it explains.
+              role="presentation" keeps it OUT of the listbox's option semantics: it is
+              not an option, not focusable, not in `options()` (so not counted and not in
+              the roving-tabindex over optRefs/focusIdx), and carries no setsize/posinset.
+              It is announced as the list's group-level context via the listbox's
+              aria-describedby, not as a 19th station. Nothing shows when the chooser is
+              collapsed. Snapshot-invisible: the harness never mounts this component. */}
+          <li id="fsc-range-hdr" class="fsc-range" role="presentation">{t("today.elev_range")}</li>
           <For each={options()}>
             {(o, i) => {
               const selected = () => o.name === currentLoc();
@@ -740,17 +750,6 @@ export function FloatingStationChooser(props: {
             }}
           </For>
         </ul>
-      </Show>
-      {/* T-5.47 Layer 4 — the ALWAYS-VISIBLE elevation-range line. It lives in the
-          floating chooser because that is the ONLY position:fixed element on the page;
-          a hero line would be "visible on load", not always visible (D-7 needs the
-          latter). Shown whenever the chooser is shown (it fades only mid-scroll and
-          reappears on scroll-stop, at every scroll position) and the menu is closed —
-          the open list occupies the same space above the trigger. NOTE: the snapshot
-          harness never mounts FloatingStationChooser, so this line is unverifiable
-          offline by design (documented in PROGRESS). */}
-      <Show when={!open()}>
-        <div class="fsc-range" role="note">{t("today.elev_range")}</div>
       </Show>
       {/* Resting state: a compact location-pin icon; over the hero it widens to show
           the current location label (self-describing sole control). Its accessible

--- a/code/ali-je-vroce-era5/components/RegressionPanel.tsx
+++ b/code/ali-je-vroce-era5/components/RegressionPanel.tsx
@@ -6,7 +6,8 @@ import type { RegressionParams } from "../api.ts";
 import { fetchRegression, fetchCalendar, varLabel as varLabelOf,
          monthDayToDoy, doyToMonthDay, MONTH_LEN } from "../api.ts";
 import { sectionErrorFallback } from "./SectionError.tsx";
-import { t, fmtSigned, fmtDoy, fmtMonthLong } from "../i18n/format.ts";
+import { t, fmtSigned, fmtInt, fmtDoy, fmtMonthLong } from "../i18n/format.ts";
+import { bandColor, bandKey } from "../i18n/station-bands.ts";
 import { readUiPrefs, writeUiPref } from "../prefs.ts";
 
 const RegressionChart = lazy(() => import("../charts/RegressionChart.tsx").then(m => ({ default: m.RegressionChart })));
@@ -117,10 +118,11 @@ function createStore(props: ProviderProps) {
   };
   const locLabel   = () => stationLabel(selLoc());
   const varLabel   = () => VARIABLES.find(([k]) => k === selVar())?.[1] ?? selVar();
-  // T-5.27 part (3): the scatter card now names its station in the TITLE (it was only
-  // in the subtitle), so a reader whose station is set by the off-screen floating
-  // chooser can read the chart on its own. The day moves to the subtitle.
-  const chartTitle = () => `${stationLabel(selLoc())} · ${varLabel().split("(")[0]!.trim()}`;
+  // T-5.27 part (3): the scatter card names its station in the TITLE (it was only in
+  // the subtitle), so a reader whose station is set by the off-screen floating chooser
+  // can read the chart on its own. The day is in the subtitle. T-5.47: the title is now
+  // rendered as JSX (StationTag dot + metres + " · variable") directly in RegScatterCard,
+  // so the former `chartTitle` string memo is gone — a string cannot carry the dot node.
   const chartSub   = () => doyToLabel(doy());
 
   return {
@@ -130,7 +132,7 @@ function createStore(props: ProviderProps) {
     selWindow, setSelWindow,
     regData, calData, refetchReg, refetchCal,
     isPrecip, stats0, trend10, trendColor, totalChange,
-    stationLabel, locLabel, varLabel, chartTitle, chartSub,
+    stationLabel, locLabel, varLabel, chartSub,
     doyToLabel, VARIABLES, WINDOWS,
   };
 }
@@ -138,6 +140,48 @@ function createStore(props: ProviderProps) {
 type Store = ReturnType<typeof createStore>;
 const RegressionCtx = createContext<Store>();
 export const useReg = () => useContext(RegressionCtx)!;
+
+// ── T-5.47 station tag: coloured elevation dot + name (+ optional metres) ────────
+// Layer 2 of the elevation disclosure: wherever a single station is named as the
+// subject of an analysis header (scatter title, year-round title), show the band dot
+// PLUS the elevation in metres. The tooltip ("<station>, <n> m — <band>") lives on the
+// dot as BOTH `title` (hover) and `aria-label` (mirrored, so it is not hover-only).
+// The band NAME appears only in that tooltip — never inline next to the dot.
+//
+// The dot and the metres are <i>, deliberately NOT <span>: the year-round card's
+// snapshot capture reads `.all("span")`, so a <span> here would add a phantom entry
+// and change that array's length (T-5.47 step-7 / Change 3). Attribute text (title,
+// aria-label) is invisible to `.txt()`, so only the visible metres move a captured leaf.
+function StationTag(props: { name: string; withMetres?: boolean }) {
+  const s = useReg();
+  const st    = () => s.meta.stations.find(x => x.name === props.name);
+  const elev  = () => st()?.elevation;
+  const label = () => s.stationLabel(props.name);
+  const tip   = () => {
+    const e = elev();
+    return e == null ? label() : `${label()}, ${fmtInt(e)} m — ${t(`bands.name_${bandKey(e)}`)}`;
+  };
+  return (
+    <>
+      <Show when={elev() != null}>
+        <i class="station-dot" role="img" aria-label={tip()} title={tip()}
+           style={{ background: bandColor(elev()!) }} />
+      </Show>
+      {label()}
+      <Show when={props.withMetres && elev() != null}>
+        <i class="station-tag-m">{" "}{fmtInt(elev()!)} m</i>
+      </Show>
+    </>
+  );
+}
+
+// The year-round title "Celoletni trend · {station}" (reg.year_round_title) is split on
+// its {station} slot — via a NUL sentinel, so no reliance on the literal separator — so
+// RegYearRoundCard can drop a StationTag node where {station} sits while keeping sl.ts
+// the single source for the surrounding words.
+const SENTINEL = String.fromCharCode(0);
+const [TITLE_BEFORE_STATION, TITLE_AFTER_STATION] =
+  t("reg.year_round_title", { station: SENTINEL }).split(SENTINEL) as [string, string];
 
 // ── Provider ──────────────────────────────────────────────────────────────────
 
@@ -360,7 +404,9 @@ export function RegScatterCard() {
 
       <div style={panelHStyle}>
         <div style={{ "min-width": "0" }}>
-          <div style={panelTitleStyle}>{s.chartTitle()}</div>
+          {/* T-5.47 site 2 — station dot + metres, then " · variable". Captured leaf
+              `analysis.rendered.title` gains " <n> m" (text-only, no numeric value). */}
+          <div style={panelTitleStyle}><StationTag name={s.selLoc()} withMetres /> · {s.varLabel().split("(")[0]!.trim()}</div>
           <div style={{ ...panelSubStyle, "margin-top": "3px" }}>{s.chartSub()}</div>
         </div>
         <Show when={s.stats0()}>
@@ -428,7 +474,11 @@ export function RegYearRoundCard() {
 
       <div style={panelHStyle}>
         <div style={{ "min-width": "0" }}>
-          <div style={panelTitleStyle}>{t("reg.year_round_title", { station: s.stationLabel(s.selLoc()) })}</div>
+          {/* T-5.47 site 3 — station dot + metres. The title template "Celoletni trend ·
+              {station}" is split on its {station} slot so the tag renders as a node, not
+              a string. Captured leaf `year_round_calendar.rendered.title` gains " <n> m"
+              (text-only). The dot is an <i>, so `.all("span")` legend length is unchanged. */}
+          <div style={panelTitleStyle}>{TITLE_BEFORE_STATION}<StationTag name={s.selLoc()} withMetres />{TITLE_AFTER_STATION}</div>
           <div style={{ ...panelSubStyle, "margin-top": "3px" }}>
             {(s.VARIABLES.find(([k]) => k === s.selVar())?.[1] ?? s.selVar()).split("(")[0]!.trim()}
             {" · Theil-Sen + MK"}
@@ -497,7 +547,7 @@ export function RegYearRoundCard() {
 // (no unconditional blinking; T-5.15 guard). It is dismissed permanently on the first
 // OPEN (a selection is not required), persisted in localStorage (prefs.ts); if
 // storage is unavailable the cue simply shows again.
-interface ChooserOpt { name: string; label: string; national: boolean; }
+interface ChooserOpt { name: string; label: string; national: boolean; elevation?: number; }
 export function FloatingStationChooser(props: {
   heroAnchor:      () => HTMLElement | undefined;  // the today-status section
   heroLoc:         () => string | null;            // the hero's current location
@@ -527,7 +577,7 @@ export function FloatingStationChooser(props: {
   const stationOpts = createMemo<ChooserOpt[]>(() =>
     [...s.meta.stations]
       .sort((a, b) => (a.label ?? a.name).localeCompare(b.label ?? b.name, "sl"))
-      .map(st => ({ name: st.name, label: st.label ?? st.name, national: false })),
+      .map(st => ({ name: st.name, label: st.label ?? st.name, national: false, elevation: st.elevation })),
   );
   const options = createMemo<ChooserOpt[]>(() =>
     heroInView()
@@ -542,6 +592,13 @@ export function FloatingStationChooser(props: {
   const currentLabel = () => {
     const l = currentLoc();
     return l === props.nationalLoc ? nationalLabel() : s.stationLabel(l ?? "");
+  };
+  // Elevation of the currently-represented station (undefined for national / unknown),
+  // for the trigger's Layer-1 dot.
+  const currentElev = () => {
+    const l = currentLoc();
+    if (l == null || l === props.nationalLoc) return undefined;
+    return s.meta.stations.find(x => x.name === l)?.elevation;
   };
 
   let triggerRef: HTMLButtonElement | undefined;
@@ -670,12 +727,30 @@ export function FloatingStationChooser(props: {
                   tabindex={focusIdx() === i() ? 0 : -1}
                   onClick={() => choose(o.name)}
                 >
+                  {/* T-5.47 Layer 1 — dot ONLY (no metres, no tooltip): 18 rows, no room,
+                      and the band-collapse fix (Change 1) makes the four dots the sole
+                      encoding here. Decorative → aria-hidden; the option's text label is
+                      already its accessible name. National has no elevation → no dot. */}
+                  <Show when={!o.national && o.elevation != null}>
+                    <i class="fsc-dot" aria-hidden="true" style={{ background: bandColor(o.elevation!) }} />
+                  </Show>
                   {o.label}
                 </li>
               );
             }}
           </For>
         </ul>
+      </Show>
+      {/* T-5.47 Layer 4 — the ALWAYS-VISIBLE elevation-range line. It lives in the
+          floating chooser because that is the ONLY position:fixed element on the page;
+          a hero line would be "visible on load", not always visible (D-7 needs the
+          latter). Shown whenever the chooser is shown (it fades only mid-scroll and
+          reappears on scroll-stop, at every scroll position) and the menu is closed —
+          the open list occupies the same space above the trigger. NOTE: the snapshot
+          harness never mounts FloatingStationChooser, so this line is unverifiable
+          offline by design (documented in PROGRESS). */}
+      <Show when={!open()}>
+        <div class="fsc-range" role="note">{t("today.elev_range")}</div>
       </Show>
       {/* Resting state: a compact location-pin icon; over the hero it widens to show
           the current location label (self-describing sole control). Its accessible
@@ -698,7 +773,13 @@ export function FloatingStationChooser(props: {
           <circle cx="12" cy="10" r="2.5" />
         </svg>
         <Show when={showLabel()}>
-          <span class="fsc-label">{currentLabel()}</span>
+          <span class="fsc-label">
+            {/* T-5.47 Layer 1 — dot only (matches the list); no metres in the trigger. */}
+            <Show when={currentElev() != null}>
+              <i class="fsc-dot" aria-hidden="true" style={{ background: bandColor(currentElev()!) }} />
+            </Show>
+            {currentLabel()}
+          </span>
         </Show>
       </button>
     </div>

--- a/code/ali-je-vroce-era5/i18n/sl.ts
+++ b/code/ali-je-vroce-era5/i18n/sl.ts
@@ -137,6 +137,14 @@ export const sl = {
     explain_station: "Temperatura na postaji {station}, razvrstena glede na zapise ERA5-Land od leta {year_min} za isto ±7-dnevno okno.",
     explain_national: "Današnji vrh je najvišja napovedana temperatura, razvrstena glede na zapise ERA5-Land od leta {year_min} za isto ±7-dnevno okno.",
 
+    // T-5.47 — the always-visible elevation-range line, rendered in the floating
+    // chooser (the one position:fixed element on the page). Carries BOTH endpoints by
+    // name — Koper (10 m) and Kredarica (2514 m) — because those two stations are what
+    // make D-5's Kredarica lapse correction and D-7's rejection of elevation-weighting
+    // comprehensible. Numbers are baked in as literals (not a locale-formatted param):
+    // "18 postaj" and the 10/2514 span are the D-7 facts this line exists to state.
+    elev_range: "18 postaj, od Kopra (10 m) do Kredarice (2514 m).",
+
     // T-5.20 — this 83-word climate background is collapsed behind a <details>
     // disclosure (the same native mechanism as the methodology panel). The
     // summary is the always-visible collapsed-state label.
@@ -486,6 +494,17 @@ export const sl = {
     legend_lowland: "Nižinska (<400m)",
   },
 
+  // T-5.47 — SHORT band names, used ONLY in the dot tooltip/aria (e.g. "Kredarica,
+  // 2514 m — alpska") and nowhere inline. Deliberately NOT the parenthesised `map.
+  // legend_*` strings above: those repeat the metre range, which the tooltip already
+  // prints, so a bare lowercase name is used mid-phrase instead.
+  bands: {
+    name_alpine:   "alpska",
+    name_mountain: "gorska",
+    name_foothill: "predgorska",
+    name_lowland:  "nižinska",
+  },
+
   // Sea level widget
   sea: {
     a11y: "Interaktivni prikaz dviga morske gladine v Kopru po scenarijih IPCC AR6; gumbi izberejo scenarij in verjetnost, drsnik leto, ločnica pa primerja sedanjost s projekcijo.",
@@ -524,6 +543,12 @@ export const sl = {
     summary: "Metodologija",
     stations: "{count, plural, one{# postaja} two{# postaji} few{# postaje} other{# postaj}} ERA5-Land",
     contact_label: "Popravki in vprašanja:",
+    // T-5.47 — the four-band legend table inside the methodology disclosure. This is
+    // the first place D-7's "only one station above 1000 m" fact becomes visible (the
+    // per-band counts are computed from meta.stations, never hardcoded). Band + range
+    // cell reuses map.legend_* verbatim; the count cell is plural-selected.
+    bands_title: "Višinski pasovi postaj",
+    bands_count: "{count, plural, one{# postaja} two{# postaji} few{# postaje} other{# postaj}}",
   },
 
   // Site meta (fallbacks)

--- a/code/ali-je-vroce-era5/i18n/station-bands.ts
+++ b/code/ali-je-vroce-era5/i18n/station-bands.ts
@@ -1,0 +1,45 @@
+// T-5.47 — the ONE source of truth for the elevation-band colours, thresholds and
+// keys, shared by three consumers: the floating chooser dots + the station tags
+// (RegressionPanel.tsx) and the methodology legend table (MethodologyPanel.tsx).
+//
+// ⚠ StationMap.tsx:12-17 (`elevColor`) holds a DEAD DUPLICATE of these thresholds and
+// colours. It is intentionally NOT edited — T-5.46 hid the map but kept it revivable,
+// so its self-contained palette must stay untouched. As of T-5.47 the two DIVERGE:
+// this file's `foothill` is #867c70, StationMap's is still #c8b97a. That divergence is
+// DELIBERATE — the foothill tan (#c8b97a) collapsed against the mountain sage (#a3c4a0)
+// under deuteranopia (Machado 2009 sim distance 39.1, every other pair ≥69.8), and the
+// chooser is the one site where the dot is the sole encoding (no metres, no tooltip),
+// so it had to be fixed HERE. #867c70 clears every pair ≥69.8. Do NOT "resync" the two
+// files — reviving the map is a separate decision that would revisit its whole palette.
+//
+// Thresholds match StationMap's strict `>` ladder exactly (>1500 / >800 / >400 / else),
+// same convention as the tropical-day `>` in D-13.
+
+export type BandKey = "alpine" | "mountain" | "foothill" | "lowland";
+
+export interface Band {
+  readonly key:   BandKey;
+  readonly min:   number;   // metres; a station is in this band when elevation > min
+  readonly color: string;   // fill for the dot / swatch
+}
+
+// High → low, so `.find(elev > min)` picks the first (highest) matching band, and the
+// methodology table renders top-to-bottom.
+export const ELEV_BANDS: readonly Band[] = [
+  { key: "alpine",   min: 1500, color: "#7bafd4" },
+  { key: "mountain", min: 800,  color: "#a3c4a0" },
+  { key: "foothill", min: 400,  color: "#867c70" },  // T-5.47 CHANGE 1 (was #c8b97a)
+  { key: "lowland",  min: 0,    color: "#c25a2c" },
+] as const;
+
+export function bandOf(elevation: number): Band {
+  return ELEV_BANDS.find(b => elevation > b.min) ?? ELEV_BANDS[ELEV_BANDS.length - 1]!;
+}
+
+export function bandColor(elevation: number): string {
+  return bandOf(elevation).color;
+}
+
+export function bandKey(elevation: number): BandKey {
+  return bandOf(elevation).key;
+}

--- a/styles/era5.css
+++ b/styles/era5.css
@@ -269,13 +269,13 @@
    STOPS (.fsc--shown); an open menu, or focus inside it, keeps it shown so a
    keyboard user is never chasing it. The fade is gated on prefers-reduced-motion
    (T-5.15) — reduced-motion users get an instant show/hide. */
-.fsc { position: fixed; right: 20px; bottom: 20px; z-index: 40; opacity: 0; pointer-events: none; display: flex; flex-direction: column; align-items: flex-end; gap: 8px; }
+.fsc { position: fixed; right: 20px; bottom: 20px; z-index: 40; opacity: 0; pointer-events: none; }
 .fsc.fsc--shown { opacity: 1; pointer-events: auto; }
-/* T-5.47 Layer 4 — always-visible range caption, sitting above the trigger. Width is
-   capped so at 390px it wraps to a few lines rather than spanning the viewport; it is
-   right-aligned under the chooser. text-align:right keeps it visually anchored to the
-   bottom-right furniture. */
-.fsc-range { max-width: min(260px, 74vw); font-family: var(--font-mono); font-size: 10px; line-height: 1.4; letter-spacing: 0.01em; color: var(--color-ink-soft); background: var(--color-card); border: 1px solid var(--color-rule-2); border-radius: 10px; padding: 6px 10px; box-shadow: 0 6px 20px rgba(14, 14, 12, 0.14); text-align: right; }
+/* T-5.47 Layer 4 — the elevation-range HEADER ROW at the top of the expanded list
+   (T-5.47 revision). Sticky so it stays above the dots while the list scrolls; full
+   width of the list, left-aligned to sit over the option column; a divider separates it
+   from the options. list-style:none because it is a bare <li>. */
+.fsc-range { position: sticky; top: -4px; list-style: none; margin: -4px -4px 4px; padding: 8px 12px; font-family: var(--font-mono); font-size: 10px; line-height: 1.4; letter-spacing: 0.01em; color: var(--color-ink-soft); background: var(--color-card); border-bottom: 1px solid var(--color-rule); border-radius: var(--radius, 10px) var(--radius, 10px) 0 0; }
 /* T-5.47 Layer 1 — chooser/trigger elevation dot (no metres, no tooltip here). */
 .fsc-dot { display: inline-block; width: 9px; height: 9px; border-radius: 50%; margin-right: 8px; border: 1px solid rgba(14, 14, 12, 0.22); flex-shrink: 0; vertical-align: middle; }
 @media (prefers-reduced-motion: no-preference) {

--- a/styles/era5.css
+++ b/styles/era5.css
@@ -201,6 +201,20 @@
 .methodology-furniture a   { color: var(--color-accent); }
 .methodology-furniture-sep { opacity: 0.5; }
 
+/* T-5.47 — four-band elevation legend table inside the methodology disclosure. */
+.methodology-bands { border-collapse: collapse; margin: 16px 0 4px; font-family: var(--font-mono); font-size: 12px; color: var(--color-ink-2); }
+.methodology-bands-cap { text-align: left; font-family: var(--font-sans); font-size: 12px; font-weight: 600; letter-spacing: 0.06em; text-transform: uppercase; color: var(--color-ink-soft); padding-bottom: 8px; }
+.methodology-bands td { padding: 4px 14px 4px 0; vertical-align: middle; white-space: nowrap; }
+.methodology-bands-swatch { padding-right: 10px; }
+.methodology-bands-name  { color: var(--color-ink); }
+.methodology-bands-count { color: var(--color-ink-soft); text-align: right; padding-right: 0; }
+
+/* T-5.47 — the shared elevation-band dot (chooser, station tag, methodology swatch) and
+   the inline metres run. `.station-dot` is an <i> element (see StationTag / Change 3). */
+.station-dot { display: inline-block; width: 10px; height: 10px; border-radius: 50%; margin-right: 6px; border: 1px solid rgba(14, 14, 12, 0.22); flex-shrink: 0; vertical-align: middle; }
+.methodology-bands-swatch .station-dot { margin-right: 0; }
+.station-tag-m { font-style: normal; font-weight: 400; color: var(--color-ink-soft); }
+
 /* ── Responsive: Regression toolbar ──────────────────────────────────────── */
 .reg-toolbar {
   margin: 20px 40px 0;
@@ -255,8 +269,15 @@
    STOPS (.fsc--shown); an open menu, or focus inside it, keeps it shown so a
    keyboard user is never chasing it. The fade is gated on prefers-reduced-motion
    (T-5.15) — reduced-motion users get an instant show/hide. */
-.fsc { position: fixed; right: 20px; bottom: 20px; z-index: 40; opacity: 0; pointer-events: none; }
+.fsc { position: fixed; right: 20px; bottom: 20px; z-index: 40; opacity: 0; pointer-events: none; display: flex; flex-direction: column; align-items: flex-end; gap: 8px; }
 .fsc.fsc--shown { opacity: 1; pointer-events: auto; }
+/* T-5.47 Layer 4 — always-visible range caption, sitting above the trigger. Width is
+   capped so at 390px it wraps to a few lines rather than spanning the viewport; it is
+   right-aligned under the chooser. text-align:right keeps it visually anchored to the
+   bottom-right furniture. */
+.fsc-range { max-width: min(260px, 74vw); font-family: var(--font-mono); font-size: 10px; line-height: 1.4; letter-spacing: 0.01em; color: var(--color-ink-soft); background: var(--color-card); border: 1px solid var(--color-rule-2); border-radius: 10px; padding: 6px 10px; box-shadow: 0 6px 20px rgba(14, 14, 12, 0.14); text-align: right; }
+/* T-5.47 Layer 1 — chooser/trigger elevation dot (no metres, no tooltip here). */
+.fsc-dot { display: inline-block; width: 9px; height: 9px; border-radius: 50%; margin-right: 8px; border: 1px solid rgba(14, 14, 12, 0.22); flex-shrink: 0; vertical-align: middle; }
 @media (prefers-reduced-motion: no-preference) {
   .fsc { transition: opacity 0.18s ease; }
 }

--- a/tests/fixtures/snapshot.json
+++ b/tests/fixtures/snapshot.json
@@ -17323,7 +17323,7 @@
           ]
         },
         "rendered": {
-          "title": "Celoletni trend · Ljubljana",
+          "title": "Celoletni trend · Ljubljana 299 m",
           "legend": [
             "Segrevanje",
             "Ohlajanje",
@@ -27906,7 +27906,7 @@
           ]
         },
         "rendered": {
-          "title": "Celoletni trend · Kredarica",
+          "title": "Celoletni trend · Kredarica 2514 m",
           "legend": [
             "Segrevanje",
             "Ohlajanje",
@@ -33703,7 +33703,7 @@
             ]
           },
           "day_label": "21. jul.",
-          "title": "Ljubljana · Najvišja temperatura",
+          "title": "Ljubljana 299 m · Najvišja temperatura",
           "subtitle": "21. jul.",
           "stats_badge": "Theil-Sen + TFPW MK · τ = 0,34",
           "total_change": "+4,35°C",
@@ -37229,7 +37229,7 @@
             ]
           },
           "day_label": "21. jul.",
-          "title": "Ljubljana · Najvišja temperatura",
+          "title": "Ljubljana 299 m · Najvišja temperatura",
           "subtitle": "21. jul.",
           "stats_badge": "Theil-Sen + TFPW MK · τ = 0,34",
           "total_change": "+4,35°C",
@@ -40755,7 +40755,7 @@
             ]
           },
           "day_label": "21. jul.",
-          "title": "Kredarica · Najvišja temperatura",
+          "title": "Kredarica 2514 m · Najvišja temperatura",
           "subtitle": "21. jul.",
           "stats_badge": "Theil-Sen + TFPW MK · τ = 0,25",
           "total_change": "+2,74°C",
@@ -44090,7 +44090,7 @@
             ]
           },
           "day_label": "29. jul.",
-          "title": "Ljubljana · Najvišja temperatura",
+          "title": "Ljubljana 299 m · Najvišja temperatura",
           "subtitle": "29. jul.",
           "stats_badge": "Theil-Sen + TFPW MK · τ = 0,33",
           "total_change": "+3,76°C",
@@ -47616,7 +47616,7 @@
             ]
           },
           "day_label": "29. jul.",
-          "title": "Ljubljana · Najvišja temperatura",
+          "title": "Ljubljana 299 m · Najvišja temperatura",
           "subtitle": "29. jul.",
           "stats_badge": "Theil-Sen + TFPW MK · τ = 0,33",
           "total_change": "+3,76°C",
@@ -51142,7 +51142,7 @@
             ]
           },
           "day_label": "29. jul.",
-          "title": "Kredarica · Najvišja temperatura",
+          "title": "Kredarica 2514 m · Najvišja temperatura",
           "subtitle": "29. jul.",
           "stats_badge": "Theil-Sen + TFPW MK · τ = 0,26",
           "total_change": "+2,40°C",
@@ -54477,7 +54477,7 @@
             ]
           },
           "day_label": "15. jul.",
-          "title": "Ljubljana · Najvišja temperatura",
+          "title": "Ljubljana 299 m · Najvišja temperatura",
           "subtitle": "15. jul.",
           "stats_badge": "Theil-Sen + TFPW MK · τ = 0,30",
           "total_change": "+3,54°C",
@@ -58003,7 +58003,7 @@
             ]
           },
           "day_label": "15. jul.",
-          "title": "Ljubljana · Najvišja temperatura",
+          "title": "Ljubljana 299 m · Najvišja temperatura",
           "subtitle": "15. jul.",
           "stats_badge": "Theil-Sen + TFPW MK · τ = 0,30",
           "total_change": "+3,54°C",
@@ -61529,7 +61529,7 @@
             ]
           },
           "day_label": "15. jul.",
-          "title": "Kredarica · Najvišja temperatura",
+          "title": "Kredarica 2514 m · Najvišja temperatura",
           "subtitle": "15. jul.",
           "stats_badge": "Theil-Sen + TFPW MK · τ = 0,19",
           "total_change": "+1,72°C",
@@ -62374,7 +62374,7 @@
             ]
           },
           "day_label": "28. feb.",
-          "title": "Ljubljana · Najvišja temperatura",
+          "title": "Ljubljana 299 m · Najvišja temperatura",
           "subtitle": "28. feb.",
           "stats_badge": "Theil-Sen + TFPW MK · τ = 0,21",
           "total_change": "+4,40°C",
@@ -63219,7 +63219,7 @@
             ]
           },
           "day_label": "28. feb.",
-          "title": "Kredarica · Najvišja temperatura",
+          "title": "Kredarica 2514 m · Najvišja temperatura",
           "subtitle": "28. feb.",
           "stats_badge": "Theil-Sen + TFPW MK · τ = 0,16",
           "total_change": "+2,90°C",
@@ -64015,7 +64015,7 @@
             ]
           },
           "day_label": "28. feb.",
-          "title": "Ljubljana · Najvišja temperatura",
+          "title": "Ljubljana 299 m · Najvišja temperatura",
           "subtitle": "28. feb.",
           "stats_badge": "Theil-Sen + TFPW MK · τ = 0,21",
           "total_change": "+4,40°C",
@@ -67523,7 +67523,7 @@
             ]
           },
           "day_label": "1. mar.",
-          "title": "Ljubljana · Najvišja temperatura",
+          "title": "Ljubljana 299 m · Najvišja temperatura",
           "subtitle": "1. mar.",
           "stats_badge": "Theil-Sen + TFPW MK · τ = 0,21",
           "total_change": "+4,29°C",
@@ -71049,7 +71049,7 @@
             ]
           },
           "day_label": "28. feb.",
-          "title": "Ljubljana · Najvišja temperatura",
+          "title": "Ljubljana 299 m · Najvišja temperatura",
           "subtitle": "28. feb.",
           "stats_badge": "Theil-Sen + TFPW MK · τ = 0,21",
           "total_change": "+4,40°C",
@@ -74575,7 +74575,7 @@
             ]
           },
           "day_label": "1. mar.",
-          "title": "Ljubljana · Najvišja temperatura",
+          "title": "Ljubljana 299 m · Najvišja temperatura",
           "subtitle": "1. mar.",
           "stats_badge": "Theil-Sen + TFPW MK · τ = 0,21",
           "total_change": "+4,29°C",
@@ -78101,7 +78101,7 @@
             ]
           },
           "day_label": "1. jan.",
-          "title": "Ljubljana · Najvišja temperatura",
+          "title": "Ljubljana 299 m · Najvišja temperatura",
           "subtitle": "1. jan.",
           "stats_badge": "Theil-Sen + TFPW MK · τ = 0,24",
           "total_change": "+3,73°C",
@@ -81619,7 +81619,7 @@
             ]
           },
           "day_label": "31. dec.",
-          "title": "Ljubljana · Najvišja temperatura",
+          "title": "Ljubljana 299 m · Najvišja temperatura",
           "subtitle": "31. dec.",
           "stats_badge": "Theil-Sen + TFPW MK · τ = 0,27",
           "total_change": "+3,90°C",
@@ -85137,7 +85137,7 @@
             ]
           },
           "day_label": "3. avg.",
-          "title": "Ljubljana · Najvišja temperatura",
+          "title": "Ljubljana 299 m · Najvišja temperatura",
           "subtitle": "3. avg.",
           "stats_badge": "Theil-Sen + TFPW MK · τ = 0,28",
           "total_change": "+3,13°C",
@@ -88655,7 +88655,7 @@
             ]
           },
           "day_label": "3. avg.",
-          "title": "Kredarica · Najvišja temperatura",
+          "title": "Kredarica 2514 m · Najvišja temperatura",
           "subtitle": "3. avg.",
           "stats_badge": "Theil-Sen + TFPW MK · τ = 0,22",
           "total_change": "+2,04°C",
@@ -92181,7 +92181,7 @@
             ]
           },
           "day_label": "7. feb.",
-          "title": "Ljubljana · Najvišja temperatura",
+          "title": "Ljubljana 299 m · Najvišja temperatura",
           "subtitle": "7. feb.",
           "stats_badge": "Theil-Sen + TFPW MK · τ = 0,25",
           "total_change": "+4,38°C",
@@ -95720,7 +95720,7 @@
             ]
           },
           "day_label": "7. jan.",
-          "title": "Kredarica · Najvišja temperatura",
+          "title": "Kredarica 2514 m · Najvišja temperatura",
           "subtitle": "7. jan.",
           "stats_badge": "Theil-Sen + TFPW MK · τ = 0,28",
           "total_change": "+4,16°C",

--- a/tests/snapshot/harness.tsx
+++ b/tests/snapshot/harness.tsx
@@ -725,7 +725,7 @@ export async function run(): Promise<RunResult> {
   // label are read; the static methodology prose is deliberately not captured.
   const methodologyUnit = await mount(
     "global.methodology",
-    () => <MethodologyPanel stationCount={era5Stations.length} />,
+    () => <MethodologyPanel stations={era5Stations} />,
     0,
   );
 


### PR DESCRIPTION
Brings station elevation back to the page after T-5.46 hid the map, and closes D-7 properly.

**Why this exists.** D-7 defines "Slovenija" as the unweighted mean of 18 stations and requires the station list **and** the 10–2514 m range to be visible. That is load-bearing elsewhere: D-5's Kredarica lapse correction (−7.85 °C) is incomprehensible unless a reader knows one station sits at 2514 m, and D-7 rejected elevation-weighting precisely because **only one station is above 1000 m**. The map's banded legend used to carry that unconditionally. Hiding the map moved the disclosure into a `<details>` that is collapsed by design, so D-7's "visible" quietly became "visible if you click".

**Four layers, deliberately different per site:**
- **Floating chooser** — a coloured elevation dot on each of the 18 options. No metres (the list is 200 px and nowrap), no tooltip.
- **Scatter and year-round card titles** — dot + elevation in metres.
- **Those dots** carry `title` and `aria-label`: `"Kredarica, 2514 m — alpska"`.
- **The range line** — `18 postaj, od Kopra (10 m) do Kredarice (2514 m).` — in the **floating chooser**, because investigation showed it is the *only* element that is genuinely fixed; a hero line would be visible on load and then scroll away. It sits with `today.loc_national`, the very claim the range justifies.

**A colour-blindness defect was found and fixed rather than deferred.** The map's original bands put mountain `#a3c4a0` (sage) and foothill `#c8b97a` (tan) at a Machado deuteranopia distance of **39.1** — they collapse to the same dull yellow — while every other pair was ≥69.8. The chooser is exactly the site where the dot is the *sole* encoding, so a deutan reader could not separate Rateče from the four foothill stations. Foothill is now `#867c70`; the pair is **99.7**, and all six pairs clear 69.8. Darkening toward amber was tried first and rejected: it collapses foothill against the lowland terracotta instead.

**Band definitions now have one home.** The four hex values and thresholds moved into `station-bands.ts`, read by the dots, the tooltip and the methodology table. `StationMap.tsx` keeps its own dead copy — untouched, so T-5.46's revival stays a pure uncomment — and it now differs by the fixed foothill colour. That divergence is deliberate and commented, so it is not "fixed" later.

**The methodology gains a band table** rendered as a component rather than markdown (the panel's parser has no table block), with counts derived from the live station list: **1 / 1 / 4 / 12**. This is the first place D-7's own argument — one station above 1000 m, twelve below 400 — is visible to a reader. Published method text is unchanged, so `hero-content.ts` and `METHODOLOGY.md` do not move.

**Snapshot moved exactly as predicted:** 23 leaves — 21 `analysis.rendered.title` and 2 `year_round_calendar.rendered.title`, each gaining ` <n> m`. **Zero numeric leaves.** No legend array changed length, confirming the dots render as `<i>` rather than `<span>` (a span would have added an empty entry to `.all("span")`).

**⚠ Known blind spot:** the harness never mounts the floating chooser, so **layers 1 and 4 — the 18 dots and the range line — are unverifiable offline**. A green snapshot says nothing about them.

**Needs eyes on stage** (no previews, T-6.9): that the four dots are distinguishable at real size on a real screen; that the range line is legible at 390 px without the fixed chooser occluding content unacceptably (it wraps to ~2 lines at a 260 px cap and overlays the bottom-right corner); and that the tooltip works where intended.

Gates: typecheck 0 · typecheck:gate 0 allowlisted · yarn test 79 · snapshot:check identical after re-baseline · pytest 75 · bundle smoke and text-integrity guards pass.
