### PR TITLE
T-5.41 — fix 12k px of scroll past the footer: SR_ONLY was on a <table>

### DIFF
--- a/code/ali-je-vroce-era5/charts/SeasonHeatmap.tsx
+++ b/code/ali-je-vroce-era5/charts/SeasonHeatmap.tsx
@@ -1,6 +1,7 @@
 import { createSignal, createMemo, For, Show, onCleanup } from "solid-js";
 import type { SeasonHeatmapRow } from "../types.ts";
 import { t, fmtNum } from "../i18n/format.ts";
+import { SR_ONLY } from "./sr-only.ts";
 
 const SEASON_ORDER = ["Autumn", "Summer", "Spring", "Winter"] as const;
 type Season = typeof SEASON_ORDER[number];
@@ -30,15 +31,6 @@ const MODES = [
   { key: "Spring",   label: t("season.label_Spring") },
   { key: "Winter",   label: t("season.label_Winter") },
 ];
-
-// T-5.4a — visually-hidden (screen-reader-only) style. Kept off the visual layout
-// entirely, so it changes nothing a sighted reader sees. Kebab-case keys because
-// Solid's style() calls setProperty() and silently drops camelCase.
-const SR_ONLY = {
-  position: "absolute", width: "1px", height: "1px", padding: "0",
-  margin: "-1px", overflow: "hidden", clip: "rect(0,0,0,0)",
-  "white-space": "nowrap", border: "0",
-} as const;
 
 interface Props { data: SeasonHeatmapRow[]; }
 interface TipData { row: SeasonHeatmapRow; px: number; py: number; }
@@ -258,8 +250,11 @@ export function SeasonHeatmap(props: Props) {
       </Show>
 
       {/* T-5.4a — screen-reader data-table fallback (visually hidden). Slovenian
-          caption/headers awaiting operator review. */}
-      <table style={SR_ONLY}>
+          caption/headers awaiting operator review. SR_ONLY sits on the wrapping
+          <div>, not the <table>: a table ignores the 1px clamp and would extend
+          the page's scroll height past the footer (T-5.41). */}
+      <div style={SR_ONLY}>
+      <table>
         <caption>{t("season.table_caption")}</caption>
         <thead>
           <tr>
@@ -284,6 +279,7 @@ export function SeasonHeatmap(props: Props) {
           </For>
         </tbody>
       </table>
+      </div>
     </div>
   );
 }

--- a/code/ali-je-vroce-era5/charts/SpeiHeatmap.tsx
+++ b/code/ali-je-vroce-era5/charts/SpeiHeatmap.tsx
@@ -1,5 +1,6 @@
 import { createSignal, createMemo, For, Show, onCleanup } from "solid-js";
 import { t, fmtNum, fmtSigned } from "../i18n/format.ts";
+import { SR_ONLY } from "./sr-only.ts";
 
 const SEASON_ORDER = ["Autumn", "Summer", "Spring", "Winter"] as const;
 type Season = typeof SEASON_ORDER[number];
@@ -33,14 +34,6 @@ const MODES = [
   { key: "Spring",   label: t("spei.label_Spring") },
   { key: "Winter",   label: t("spei.label_Winter") },
 ];
-
-// T-5.4a — visually-hidden (screen-reader-only) style. Kebab-case keys because
-// Solid's style() calls setProperty() and silently drops camelCase.
-const SR_ONLY = {
-  position: "absolute", width: "1px", height: "1px", padding: "0",
-  margin: "-1px", overflow: "hidden", clip: "rect(0,0,0,0)",
-  "white-space": "nowrap", border: "0",
-} as const;
 
 interface SpeiRow {
   season:  string;
@@ -290,8 +283,11 @@ export function SpeiHeatmap(props: SpeiHeatmapProps) {
       </Show>
 
       {/* T-5.4a — screen-reader data-table fallback (visually hidden). Slovenian
-          caption/headers awaiting operator review. */}
-      <table style={SR_ONLY}>
+          caption/headers awaiting operator review. SR_ONLY sits on the wrapping
+          <div>, not the <table>: a table ignores the 1px clamp and would extend
+          the page's scroll height past the footer (T-5.41). */}
+      <div style={SR_ONLY}>
+      <table>
         <caption>{t("spei.table_caption")}</caption>
         <thead>
           <tr>
@@ -318,6 +314,7 @@ export function SpeiHeatmap(props: SpeiHeatmapProps) {
           </For>
         </tbody>
       </table>
+      </div>
     </div>
   );
 }

--- a/code/ali-je-vroce-era5/charts/sr-only.ts
+++ b/code/ali-je-vroce-era5/charts/sr-only.ts
@@ -1,0 +1,20 @@
+// T-5.4a / T-5.41 — visually-hidden (screen-reader-only) style, shared by the
+// heatmap data-table fallbacks (SeasonHeatmap, SpeiHeatmap). One definition so a
+// future component cannot inherit a stale copy.
+//
+// ⚠ Apply this to a BLOCK WRAPPER (a <div>), never directly to a <table> or any
+// other intrinsically-sized / replaced element. Table layout treats width/height
+// as MINIMUMS and expands to its content, so the 1px clamp is silently ignored;
+// `clip` then clips only the painting, not the layout box, leaving a full-size
+// position:absolute box. With no positioned ancestor its containing block is the
+// initial containing block (<html>), so it extends the document's scroll height —
+// the empty space below the footer fixed in T-5.41. A block <div> honours
+// width:1px + height:1px + overflow:hidden and clips the table inside.
+//
+// Kebab-case keys because Solid's style() calls setProperty() and silently drops
+// camelCase.
+export const SR_ONLY = {
+  position: "absolute", width: "1px", height: "1px", padding: "0",
+  margin: "-1px", overflow: "hidden", clip: "rect(0,0,0,0)",
+  "white-space": "nowrap", border: "0",
+} as const;


### PR DESCRIPTION
Fixes the page scrolling far past its own footer: **12,406 px of empty scroll at desktop, 8,824 px at 390 px, now 0 at both.**

**The suspected cause was wrong.** The ticket suspected T-5.35's fixed floating chooser. Measured, it contributes **exactly 0 px** to scroll height, collapsed or expanded, including T-5.47's sticky range header. `position: fixed` is out of normal flow and cannot extend scroll height; the chooser only *appeared* at the bottom of an element enumeration because, being fixed, it rides the viewport.

**The real cause:** `SR_ONLY` — the standard visually-hidden pattern — applied directly to a `<table>` in both `SeasonHeatmap.tsx:262` and `SpeiHeatmap.tsx:294`. Three things compound:

- Table layout treats `width` and `height` as **minimums** and expands to intrinsic content, so the `1px` clamp is silently ignored — each table ballooned to ~15,054 px across 307 rows.
- `clip` clips **painting**, not the layout box.
- The table is `position: absolute` with **no positioned ancestor**, so its containing block is the initial containing block. It extended `documentElement.scrollHeight` while `body.scrollHeight` stayed at the true footer bottom.

That `<html>`/`<body>` divergence was the diagnostic tell: body ended at 6,665 px, html scrolled to 19,071.

**The fix** moves `SR_ONLY` onto a wrapping `<div>`, making the table a normal static child that the div actually clips. A block element honours `width`/`height`/`overflow`, so the table stops extending the layout while remaining fully in the accessibility tree.

**Accessibility verified, not assumed** — this is the whole purpose of those tables. Both remain `display: table`, `visibility: visible`, no `aria-hidden`, no `display: none`; captions and `<th scope>` intact. The wrapper is a plain `<div>` with no role.

**Swept the whole island** rather than fixing only the two that were visible. `SR_ONLY` appears at exactly those two sites, both unsafe, both fixed. Everything else that looked similar is safe: the screen-reader summaries in the other charts are Highcharts `accessibility.description` config strings (not DOM), `highcharts-a11y.ts`'s clipped region is Highcharts' own proxy which it sizes itself, and `SpeiTrendChart.tsx:245`'s `1px` span is a visible decorative divider. Two tables were found because they were 15,000 px tall — a third instance a few hundred pixels tall would never have stood out, which is why the sweep mattered.

**Consolidated** the two byte-identical `SR_ONLY` definitions into `charts/sr-only.ts`, with a warning that it must go on a block wrapper and never on a table or replaced element — so the next component cannot inherit the bug.

**Island-only, not the shell.** The footer belongs to the Eleventy layout, but the home page has zero overflow before and after, so the fix correctly lives in the ERA5 components rather than in shared layout.

| viewport | before (html / body / footer → overflow) | after |
|---|---|---|
| desktop 1280 px | 19071 / 6665 / 6665 → **12406 px** | 6665 / 6665 / 6665 → **0** |
| mobile 390 px | 18184 / 9360 / 9360 → **8824 px** | 9360 / 9360 / 9360 → **0** |

Heatmap grids still render 308 cells each. Zero absolutely-positioned tables remain.

**Needs eyes on stage** (no previews, T-6.9): that the page stops at its footer at 390 px and desktop, that both heatmaps render normally, and that a screen reader still reaches both data tables.

Gates: typecheck 0 · typecheck:gate 0 allowlisted · yarn test 79 · snapshot:check identical, 0 movement, 0 misses · pytest 75.
