### PR TITLE
T-5.51 (M1–M4) — precipitation and ET₀ show mm, not °C

### DIFF
--- a/code/ali-je-vroce-era5/api.ts
+++ b/code/ali-je-vroce-era5/api.ts
@@ -74,6 +74,21 @@ export function varLabel(v: string): string {
   return lbl === key ? `${v} (°C)` : lbl;
 }
 
+// T-5.51 (M1–M3) — the base measurement unit for a selectable trend variable, keyed
+// on the same variable string the picker uses. Precipitation and ET₀ are depths in
+// mm (both accumulated over the window; validate_raw.py bounds them in mm); the three
+// temperatures are °C. This is the ONE source for the three api.ts sites that used to
+// hardcode "°C" (fetchRegression + fetchCalendar tooltip units, buildRegressionResult
+// chg_str), so a degree symbol can never again leak onto a precipitation/ET₀ series.
+// It deliberately does NOT subsume the already-variable-aware surfaces (RegressionPanel
+// `isPrecip` big number, YearRoundChart `IS_PRECIP` bar colours, the `varLabel` y-axis
+// title) — folding those into one per-variable metadata object is a refactor out of
+// this ticket's scope (see PROGRESS.md T-5.51).
+const PRECIP_VARS = new Set(["precipitation_sum", "et0_evapotranspiration"]);
+export function varUnit(v: string): string {
+  return PRECIP_VARS.has(v) ? "mm" : "°C";
+}
+
 // ── Helpers ────────────────────────────────────────────────────────────────────
 
 async function dsGet<T>(path: string): Promise<T> {
@@ -643,7 +658,7 @@ export async function fetchRegression(p: RegressionParams): Promise<RegressionRe
     results:    era5Results.filter(Boolean) as RegressionResult[],
     date_label: fmtMonthDay(month, day),
     ylabel:     varLabel(p.var),
-    unit:       "°C",
+    unit:       varUnit(p.var),  // T-5.51 M1 — mm for precip/ET₀, °C otherwise
   };
 }
 
@@ -686,7 +701,11 @@ async function buildRegressionResult(
       method: "Theil-Sen + TFPW MK", trend10: r.trend10, metric: r.trend10,
       metric_lbl: "trend / 10 let", p_val: r.p_val,
       direction: r.trend10 >= 0 ? "up" : "down",
-      chg_str: `${r.trend10 >= 0 ? "+" : ""}${r.trend10.toFixed(2)} °C/10y`,
+      // T-5.51 M3 — unit derived per variable. NOTE: chg_str is still DEAD (nothing
+      // renders it; grep confirms only this assignment + the types.ts declaration).
+      // Fixed anyway so the value is not wrong if a future consumer renders it; its
+      // correctness here is not evidence of anything on the page.
+      chg_str: `${r.trend10 >= 0 ? "+" : ""}${r.trend10.toFixed(2)} ${varUnit(variable)}/10y`,
       fit_desc: `τ = ${fmtNum(r.tau, 2)}`,
       sig_label: r.p_val < 0.05 ? "p < 0,05" : `p = ${fmtNum(r.p_val, 3)}`,
       n_years: r.n_years, ar1: null,
@@ -835,7 +854,9 @@ export async function fetchCalendar(
   const rows = await dsGet<CalendarRow[]>(
     `${src.table}.json?_shape=array&${atCol("era5_name")}__exact=${encodeURIComponent(loc)}&${atCol("variable")}__exact=${encodeURIComponent(variable)}&${dsCols(CALENDAR_COLS)}${src.filter}&_size=400`
   );
-  return { loc, var: variable, unit: "°C", method_label: "Theil-Sen + TFPW MK", rows };
+  // T-5.51 M2 — unit derived per variable (mm for precip/ET₀), feeds the year-round
+  // tooltip "{trend} {unit}/desetletje".
+  return { loc, var: variable, unit: varUnit(variable), method_label: "Theil-Sen + TFPW MK", rows };
 }
 
 // ── fetchAnnualTrend ───────────────────────────────────────────────────────────

--- a/data/climate-si/datapackage.yaml
+++ b/data/climate-si/datapackage.yaml
@@ -70,7 +70,17 @@ resources:
     - name: trend10
       type: number
       title: Trend per decade
-      unit: °C/decade
+      # T-5.51 M4 — this column holds the per-decade trend for EVERY value of the
+      # `variable` column, so a single `unit` cannot describe it: temperatures are
+      # °C/decade, but precipitation_sum and et0_evapotranspiration are mm/decade
+      # (both stored as depths in mm). The former `unit: °C/decade` was wrong for two
+      # of the five variables; `unit` is documentation only (neither validate.py nor
+      # generate_frontend_schema.py reads it — both use field name/type), so the honest
+      # per-variable unit lives in the description instead.
+      description: >-
+        Theil-Sen trend per decade. Unit depends on the `variable` column:
+        °C/decade for temperature_max/temperature_min/temperature_mean;
+        mm/decade for precipitation_sum and et0_evapotranspiration.
     - name: p_val
       type: number
       title: Mann-Kendall p-value
@@ -141,7 +151,17 @@ resources:
     - name: trend10
       type: number
       title: Trend per decade
-      unit: °C/decade
+      # T-5.51 M4 — this column holds the per-decade trend for EVERY value of the
+      # `variable` column, so a single `unit` cannot describe it: temperatures are
+      # °C/decade, but precipitation_sum and et0_evapotranspiration are mm/decade
+      # (both stored as depths in mm). The former `unit: °C/decade` was wrong for two
+      # of the five variables; `unit` is documentation only (neither validate.py nor
+      # generate_frontend_schema.py reads it — both use field name/type), so the honest
+      # per-variable unit lives in the description instead.
+      description: >-
+        Theil-Sen trend per decade. Unit depends on the `variable` column:
+        °C/decade for temperature_max/temperature_min/temperature_mean;
+        mm/decade for precipitation_sum and et0_evapotranspiration.
     - name: p_val
       type: number
       title: Mann-Kendall p-value


### PR DESCRIPTION
Fixes the units shown for precipitation and ET₀. **Mechanical half only** — the comparison language is a separate ticket awaiting editorial decisions.

**The observed bug:** selecting precipitation or ET₀ still showed **°C** in chart tooltips. Both are depths in **mm** (confirmed against `validate_raw.py`), summed over the window rather than averaged like temperatures.

**Scope is narrower than it looked.** The variable selector is one `<select>` in the trend toolbar and its signal reaches only two surfaces — the scatter/trend card and the year-round calendar. Every other section is fixed to `temperature_max` and cannot be driven to a non-temperature variable. So the defect family lives in two cards, not across the page.

**Half the page already adapted correctly**, which is why the tooltips looked so wrong: the scatter's big number, the trend colour, the y-axis label and the year-round bar colours are all variable-aware. Only the tooltips were left behind.

One `varUnit()` helper now feeds the three sites that hardcoded `"°C"`: the scatter tooltip, the year-round tooltip, and `chg_str` — which is currently unrendered and was fixed anyway, so a later reader can't inherit a wrong unit. Its correctness proves nothing on-page and is flagged as such.

**The schema change could not be made as written, and that is the interesting part.** `datapackage.yaml` declared `trend10` as `unit: °C/decade`. But `trend10` holds the trend for *every* value of the `variable` column — three temperatures in °C/decade and two depths in mm/decade — so **no single unit string can be correct**. Rather than write one wrong for two of five variables, the false `unit` was removed and the per-variable units documented in `description`. Verified first that nothing consumes the field: `validate.py:187` reads `fld["name"]` and `generate_frontend_schema.py:85` reads `(name, type)`, so this moves no generated output and trips no freshness assert.

**ET₀ needs no distinct unit treatment** — it is mm, like precipitation. The two differ in *direction*, not unit: more precipitation is wetter, more ET₀ is greater evaporative demand and therefore drier. That distinction belongs to the editorial half, where they will get separate wording rather than a shared "non-temperature" phrasing.

**⚠ Unverified offline, by construction.** The snapshot's default variable is `temperature_max`, so every captured tooltip resolves `varUnit("temperature_max")` = `"°C"`, byte-identical to the old hardcode — and the harness stubs Highcharts, so tooltips never render at all. Zero movement was predicted and observed, but that proves only that the temperature path is unchanged. The non-temperature path has no offline coverage.

**Still open (separate ticket):** the `warming`/`cooling` legend, which is not merely mislabelled but the wrong *axis* of comparison — and which currently contradicts the chart's own variable-aware bar colours; `explain_cal`'s red-means-warming text; `explain_reg`'s elevation-correction clause, which is temperature-only; and a methodology correction — the published text calls the yearly point an **average** when for these two variables it is a **sum**, which is a dual-commit under D-23.

**Needs eyes on stage:** that selecting precipitation and ET₀ shows mm in both the scatter and year-round tooltips, while temperature still shows °C.

Gates: typecheck 0 · typecheck:gate 0 allowlisted · yarn test 79 · snapshot:check identical, 0 misses · pytest 75 incl. frontend-schema freshness · validate.py all 10 tables valid.
