### PR TITLE
T-5.51 (E1–E4) — variable-aware comparison language, matching swatches, methodology correction

### DIFF
--- a/code/ali-je-vroce-era5/api.ts
+++ b/code/ali-je-vroce-era5/api.ts
@@ -475,10 +475,8 @@ export async function fetchMeta(): Promise<SiteMeta> {
     map:      { center_lat: 46.1, center_lon: 14.8, zoom: 7 },
     branding: { site_title: t("meta.site_title") },
     stations,
-    strings: {
-      explain_reg: t("reg.explain_reg"),
-      explain_cal: t("reg.explain_cal"),
-    },
+    // T-5.51 (§3) — explain_reg/explain_cal removed: they now vary by selected variable
+    // and are rendered reactively in RegressionPanel (a fixed string here could not).
   };
 }
 

--- a/code/ali-je-vroce-era5/charts/YearRoundChart.tsx
+++ b/code/ali-je-vroce-era5/charts/YearRoundChart.tsx
@@ -3,6 +3,7 @@ import type { CalendarData } from "../api.ts";
 import { EmptyState } from "../components/EmptyState.tsx";
 import { enableChartA11y } from "./highcharts-a11y.ts";
 import { t, fmtNum, fmtSigned, fmtDoy, fmtMonthShort } from "../i18n/format.ts";
+import { barColor } from "./trend-colors.ts";
 
 interface Props {
   data: CalendarData;
@@ -16,25 +17,11 @@ const MONTH_MIDS = MONTH_DOYS.map((d, i) =>
 );
 const MONTH_LABELS = Array.from({ length: 12 }, (_, i) => fmtMonthShort(i + 1));
 
-const IS_PRECIP = new Set(["precipitation_sum","et0_evapotranspiration"]);
-const POS_TEMP  = [210, 55,  35] as const;   // red   — warming
-const NEG_TEMP  = [35,  90,  210] as const;   // blue  — cooling
-const POS_PRECIP = [35,  100, 210] as const;  // blue  — wetter
-const NEG_PRECIP = [180, 105, 25] as const;   // amber — drier
-
+// T-5.51 (E1) — the trend palette + `barColor` moved to ./trend-colors.ts so the
+// legend swatches (RegressionPanel) read the SAME constants and cannot drift.
 function mdToDoy(month: number, day: number): number {
   const jan1 = new Date(2001, 0, 1).getTime();
   return Math.round((new Date(2001, month - 1, day).getTime() - jan1) / 86400000) + 1;
-}
-
-function barColor(trend10: number, p_val: number, variable: string): string {
-  const isPos  = trend10 >= 0;
-  const isPrecip = IS_PRECIP.has(variable);
-  const [r, g, b] = isPrecip
-    ? (isPos ? POS_PRECIP : NEG_PRECIP)
-    : (isPos ? POS_TEMP   : NEG_TEMP);
-  const alpha = p_val < 0.001 ? 0.95 : p_val < 0.01 ? 0.70 : p_val < 0.05 ? 0.40 : 0.12;
-  return `rgba(${r},${g},${b},${alpha})`;
 }
 
 export function YearRoundChart(props: Props) {

--- a/code/ali-je-vroce-era5/charts/trend-colors.ts
+++ b/code/ali-je-vroce-era5/charts/trend-colors.ts
@@ -1,0 +1,41 @@
+// T-5.51 (E1) — the single source for the year-round trend palette, shared by the
+// chart bars (`barColor`, YearRoundChart) and the legend swatches (`swatchColors`,
+// RegressionPanel). These MUST NOT be duplicated: a second copy would let the legend
+// and the bars drift apart — the exact contradiction T-5.51e removes, where the legend
+// said warming/cooling while the precipitation bars were already blue/amber. Both
+// surfaces read these constants, so the words follow the colours by construction.
+//
+// Colour semantics, verified against `barColor` (trend10 >= 0 → pos, < 0 → neg):
+//   temperature     red   = warming (pos)   ·  blue  = cooling (neg)
+//   precip / ET₀     blue  = more    (pos)   ·  amber = less    (neg)
+// Red never appears for precipitation or ET₀.
+const IS_PRECIP = new Set(["precipitation_sum", "et0_evapotranspiration"]);
+
+const POS_TEMP   = [210, 55,  35] as const;  // red   — warming
+const NEG_TEMP   = [35,  90,  210] as const; // blue  — cooling
+const POS_PRECIP = [35,  100, 210] as const; // blue  — more (wetter / greater drying power)
+const NEG_PRECIP = [180, 105, 25] as const;  // amber — less (drier / lower drying power)
+
+type RGB = readonly [number, number, number];
+
+/** The (positive-trend, negative-trend) colour pair for a variable. */
+function trendPair(variable: string): { pos: RGB; neg: RGB } {
+  return IS_PRECIP.has(variable)
+    ? { pos: POS_PRECIP, neg: NEG_PRECIP }
+    : { pos: POS_TEMP,   neg: NEG_TEMP };
+}
+
+/** Per-bar colour: sign of the trend picks pos/neg, significance sets the alpha. */
+export function barColor(trend10: number, p_val: number, variable: string): string {
+  const { pos, neg } = trendPair(variable);
+  const [r, g, b] = trend10 >= 0 ? pos : neg;
+  const alpha = p_val < 0.001 ? 0.95 : p_val < 0.01 ? 0.70 : p_val < 0.05 ? 0.40 : 0.12;
+  return `rgba(${r},${g},${b},${alpha})`;
+}
+
+/** Legend swatch colours (opaque) for a variable — the SAME palette the bars use. */
+export function swatchColors(variable: string): { pos: string; neg: string } {
+  const rgba = ([r, g, b]: RGB) => `rgba(${r},${g},${b},0.9)`;
+  const { pos, neg } = trendPair(variable);
+  return { pos: rgba(pos), neg: rgba(neg) };
+}

--- a/code/ali-je-vroce-era5/components/RegressionPanel.tsx
+++ b/code/ali-je-vroce-era5/components/RegressionPanel.tsx
@@ -9,6 +9,9 @@ import { sectionErrorFallback } from "./SectionError.tsx";
 import { t, fmtSigned, fmtInt, fmtDoy, fmtMonthLong } from "../i18n/format.ts";
 import { bandColor, bandKey } from "../i18n/station-bands.ts";
 import { readUiPrefs, writeUiPref } from "../prefs.ts";
+// T-5.51 (E1) — legend swatch colours, from the SAME palette module the chart bars use
+// (trend-colors.ts). Plain function, no Highcharts, so a static import is bundle-safe.
+import { swatchColors } from "../charts/trend-colors.ts";
 
 const RegressionChart = lazy(() => import("../charts/RegressionChart.tsx").then(m => ({ default: m.RegressionChart })));
 const YearRoundChart  = lazy(() => import("../charts/YearRoundChart.tsx").then(m => ({ default: m.YearRoundChart })));
@@ -19,6 +22,26 @@ const VAR_KEYS = [
   "precipitation_sum", "et0_evapotranspiration",
 ];
 const VARIABLES: [string, string][] = VAR_KEYS.map(k => [k, varLabelOf(k)]);
+
+// T-5.51 (E1–E3) — the comparison language is per-variable: the trend axis for precip/ET₀
+// is "more/less", not "warmer/cooler". These select among catalogue keys (D-8: no
+// sentences built in code) by the selected variable. Called reactively with s.selVar().
+function calLegend(variable: string): { pos: string; neg: string } {
+  if (variable === "precipitation_sum")     return { pos: t("reg.more_precip"), neg: t("reg.less_precip") };
+  if (variable === "et0_evapotranspiration") return { pos: t("reg.more_et0"),   neg: t("reg.less_et0") };
+  return { pos: t("reg.warming"), neg: t("reg.cooling") };
+}
+function explainCal(variable: string): string {
+  if (variable === "precipitation_sum")     return t("reg.explain_cal_precip");
+  if (variable === "et0_evapotranspiration") return t("reg.explain_cal_et0");
+  return t("reg.explain_cal");
+}
+function explainReg(variable: string): string {
+  // Precip/ET₀ read raw columns — no elevation correction — so drop that clause (E3).
+  return variable === "precipitation_sum" || variable === "et0_evapotranspiration"
+    ? t("reg.explain_reg_nocorr")
+    : t("reg.explain_reg");
+}
 
 // T-4.26b (D-34) — the selectable trend half-windows, ascending. ±7 is the published
 // default and the ONLY one served by the `annual_trend` table (api.annualTrendSource);
@@ -456,9 +479,9 @@ export function RegScatterCard() {
         </Show>
       </div>
 
-      <Show when={s.meta.strings?.explain_reg}>
-        <p style={panelExplainStyle}>{s.meta.strings.explain_reg}</p>
-      </Show>
+      {/* T-5.51 (E3/§3) — rendered reactively via t() keyed on the selected variable
+          (moved out of the non-reactive meta.strings); precip/ET₀ drop the elevation clause. */}
+      <p style={panelExplainStyle}>{explainReg(s.selVar())}</p>
 
       </ErrorBoundary>
     </div>
@@ -500,14 +523,15 @@ export function RegYearRoundCard() {
       </div>
 
       <div style={{ ...chartFooterStyle, "justify-content": "flex-start", gap: "16px" }}>
-        <span style={swatchStyle}><i style={{ background: "rgba(210,55,35,0.9)", "border-radius": "2px", display: "inline-block", width: "10px", height: "10px" }} />{t("reg.warming")}</span>
-        <span style={swatchStyle}><i style={{ background: "rgba(35,90,210,0.9)", "border-radius": "2px", display: "inline-block", width: "10px", height: "10px" }} />{t("reg.cooling")}</span>
+        {/* T-5.51 (E1) — swatch colour AND word both track the selected variable: they
+            read the same palette (swatchColors) the bars use, so legend ⇄ bars can't diverge. */}
+        <span style={swatchStyle}><i style={{ background: swatchColors(s.selVar()).pos, "border-radius": "2px", display: "inline-block", width: "10px", height: "10px" }} />{calLegend(s.selVar()).pos}</span>
+        <span style={swatchStyle}><i style={{ background: swatchColors(s.selVar()).neg, "border-radius": "2px", display: "inline-block", width: "10px", height: "10px" }} />{calLegend(s.selVar()).neg}</span>
         <span style={{ ...panelSubStyle, "margin-left": "auto" }}>{t("reg.year_round_footer")}</span>
       </div>
 
-      <Show when={s.meta.strings?.explain_cal}>
-        <p style={panelExplainStyle}>{s.meta.strings.explain_cal}</p>
-      </Show>
+      {/* T-5.51 (E2/§3) — reactive per-variable colour legend (moved out of meta.strings). */}
+      <p style={panelExplainStyle}>{explainCal(s.selVar())}</p>
 
     </div>
   );

--- a/code/ali-je-vroce-era5/i18n/hero-content.ts
+++ b/code/ali-je-vroce-era5/i18n/hero-content.ts
@@ -248,7 +248,7 @@ Za vsak dan v letu stran prikaže **porazdelitev** preteklih vrednosti (kako pog
 - Nacionalna krivulja je **povprečje 18 krivulj posameznih postaj**, ne skupni bazen vzorcev — s čimer ohrani pomen »povprečja 18 postaj«.
 - Percentil je **pravi empirični percentil**, izračunan iz te krivulje (integral gostote do današnje vrednosti), ne približek iz barvnega pasu.
 
-Primerjalni vzorec za vsak koledarski dan je **združeno okno ±7 dni** čez vsa leta — tako ima vsak dan dovolj gost in stabilen vzorec. **Isto okno ±7 dni** uporablja tudi letni trend: vsaka letna točka na grafu trenda je povprečje vrednosti v tem oknu za posamezno leto. **29. februar** se pri tem pridruži oknu 28. februarja (redki prestopni dnevi se ne obravnavajo kot ločen, statistično šumeč dan).
+Primerjalni vzorec za vsak koledarski dan je **združeno okno ±7 dni** čez vsa leta — tako ima vsak dan dovolj gost in stabilen vzorec. **Isto okno ±7 dni** uporablja tudi letni trend: vsaka letna točka na grafu trenda je **povprečje** vrednosti v tem oknu za posamezno leto — pri padavinah in ET₀ pa **vsota**, saj sta to globini v mm in ima smisel le seštevek. **29. februar** se pri tem pridruži oknu 28. februarja (redki prestopni dnevi se ne obravnavajo kot ločen, statistično šumeč dan). Objavljena vrednost povsod uporablja okno ±7 dni; v panelu z analizo trendov lahko bralec izbere tudi ožje ali širše okno, kar velja le za tisti prikaz.
 
 ## Pragovi za »vroče«
 

--- a/code/ali-je-vroce-era5/i18n/sl.ts
+++ b/code/ali-je-vroce-era5/i18n/sl.ts
@@ -256,12 +256,26 @@ export const sl = {
 
     year_round_title: "Celoletni trend · {station}",
     year_round_sub: "trend na desetletje za vsak dan v letu · rdeča črta = izbrani dan",
-    warming: "Segrevanje",
-    cooling: "Ohlajanje",
+    // T-5.51 (E1) — the year-round legend pair, three-way by selected variable.
+    // The WORDS match the bar colours (trend-colors.ts): temperature red/blue, but
+    // precip/ET₀ are blue = more, amber = less — red never appears for those two.
+    warming: "Segrevanje",           // temperature, positive trend (red)
+    cooling: "Ohlajanje",            // temperature, negative trend (blue)
+    more_precip: "Več padavin",      // precipitation, positive trend (blue)
+    less_precip: "Manj padavin",     // precipitation, negative trend (amber)
+    more_et0: "Večja sušilna moč",   // ET₀, positive trend (blue)
+    less_et0: "Manjša sušilna moč",  // ET₀, negative trend (amber)
     year_round_footer: "prosojnost = značilnost · p < 0,001 povsem neprosojno",
 
+    // T-5.51 (E3) — precip/ET₀ read raw columns with NO elevation correction, so the
+    // "· nadmorska korekcija" clause is dropped for them (it is simply false there).
     explain_reg: "Theil-Sen regresija + Yue-Wang TFPW Mann-Kendall test · ERA5-Land · nadmorska korekcija",
-    explain_cal: "Trend na desetletje za vsak dan v letu · rdeča = ogrevanje · modra = ohlajanje · prosojnost = statistična značilnost",
+    explain_reg_nocorr: "Theil-Sen regresija + Yue-Wang TFPW Mann-Kendall test · ERA5-Land",
+    // T-5.51 (E2) — the calendar colour legend, three-way; only the colour clause
+    // varies. "segrevanje" (was "ogrevanje") unifies with the reg.warming legend word.
+    explain_cal: "Trend na desetletje za vsak dan v letu · rdeča = segrevanje · modra = ohlajanje · prosojnost = statistična značilnost",
+    explain_cal_precip: "Trend na desetletje za vsak dan v letu · modra = več padavin · oranžna = manj padavin · prosojnost = statistična značilnost",
+    explain_cal_et0: "Trend na desetletje za vsak dan v letu · modra = večja sušilna moč · oranžna = manjša sušilna moč · prosojnost = statistična značilnost",
 
     // T-4.26b (D-34) — the trend half-window control below the hero. ±7 is the
     // published default (annual_trend); ±3/±15/±45 read annual_trend_windows. Only

--- a/code/ali-je-vroce-era5/types.ts
+++ b/code/ali-je-vroce-era5/types.ts
@@ -90,7 +90,8 @@ export interface SiteMeta {
   map:              { center_lat: number; center_lon: number; zoom: number };
   branding:         { site_title: string };
   stations: Array<{ name: string; label: string; source: "era5" | "arso"; lat: number; lon: number; elevation: number }>;
-  strings:          { explain_reg: string; explain_cal: string };
+  // T-5.51 (§3) — explain_reg/explain_cal moved out of meta: they now vary by selected
+  // variable and are rendered reactively via t() in RegressionPanel, not baked once here.
 }
 
 /** Datasette si_season_heatmap row */

--- a/tests/fixtures/snapshot.json
+++ b/tests/fixtures/snapshot.json
@@ -90,10 +90,6 @@
       "branding": {
         "site_title": "Podnebnik · Ali je vroče?"
       },
-      "strings": {
-        "explain_reg": "Theil-Sen regresija + Yue-Wang TFPW Mann-Kendall test · ERA5-Land · nadmorska korekcija",
-        "explain_cal": "Trend na desetletje za vsak dan v letu · rdeča = ogrevanje · modra = ohlajanje · prosojnost = statistična značilnost"
-      },
       "station_count": 18,
       "stations": [
         {

--- a/tests/snapshot/harness.tsx
+++ b/tests/snapshot/harness.tsx
@@ -798,7 +798,8 @@ export async function run(): Promise<RunResult> {
       default_language: meta.default_language,
       map: meta.map,
       branding: meta.branding,
-      strings: meta.strings,
+      // T-5.51 (§3) — meta.strings removed; explain_reg/explain_cal are now rendered
+      // reactively per variable in RegressionPanel, captured via the panel mounts below.
       station_count: era5Stations.length,
       stations: era5Stations.map((s) => ({
         name: s.name,


### PR DESCRIPTION
Fixes the comparison language for precipitation and ET₀ in the trend panel and year-round calendar. The mechanical half — units — shipped as `6578cce`.

**The defect was a contradiction, not just a mislabelling.** The calendar's bars are already variable-aware, but its legend still said *Segrevanje / Ohlajanje* — so a reader selecting precipitation got two incompatible readings of one picture. And *"toplejše"* is the wrong **axis** for a depth in mm, not merely the wrong word.

**Step 1 corrected the ticket's central premise.** The brief assumed red = "more" for precipitation. It does not: for both non-temperature variables the palette is **blue = more, amber = less**, and red never appears at all. So the fix was a rewrite naming the true colours, not a red↔blue swap of the supplied strings.

**And it found the larger half of the problem:** the legend swatches were hardcoded temperature red/blue and blind to the variable, so even relabelling correctly would have left a red box beside *Več padavin* for a colour absent from the chart. The swatches now take colour and word from the selected variable.

| variable | more | less |
|---|---|---|
| temperature | Segrevanje (red) | Ohlajanje (blue) |
| precipitation | Več padavin (blue) | Manj padavin (amber) |
| ET₀ | Večja sušilna moč (blue) | Manjša sušilna moč (amber) |

**The palette is shared, not duplicated.** The four constants, `IS_PRECIP` and `barColor` moved into a new `charts/trend-colors.ts`, with a `swatchColors(variable)` alongside; `YearRoundChart` and `RegressionPanel` both read it, so bars and legend cannot diverge. A shared module was chosen over exporting from `YearRoundChart` to avoid pulling that lazy Highcharts component into the eager bundle — `trend-colors.ts` carries no Highcharts.

**`explain_cal` and `explain_reg` had to become reactive.** They were baked once into `meta.strings` at fetch time, which does not react to the variable selector — so they were moved out and are now rendered via `t()` keyed on the selection. `explain_reg` additionally drops its trailing *"· nadmorska korekcija"* clause for precipitation and ET₀, since those read raw columns with no elevation correction and the claim is simply false for them. The temperature `explain_cal` also unifies *ogrevanje* → *segrevanje*, which previously disagreed with its own legend.

**Methodology correction (dual-commit under D-23).** The published text said each yearly trend point is the **average** of the window's values; for precipitation and ET₀ it is a **sum**, since both are depths in mm and only a total is meaningful. Added alongside: a note that ±7 is the published window everywhere and that the panel's selector applies only to that view — true since T-4.26b, and previously implicit.

**Snapshot:** the only diff is `global.meta.strings → absent`, the removal of the two explains from the non-reactive object. **No number moved**; every rendered leaf byte-identical. Note the swatch colours and the `explain_cal` paragraph are not captured by the harness at all.

**⚠ No offline coverage for what this fixes.** The harness never moves off `temperature_max`, so the precipitation and ET₀ branches are exercised on stage or nowhere.

**Needs eyes on stage:** that the right words sit beside the right colours (blue = more, amber = less), that the swatches match the bars, that the elevation clause disappears for those two variables, and that the methodology reads correctly.

Gates: typecheck 0 · typecheck:gate 0 allowlisted · yarn test 79 · snapshot:check identical after re-record · pytest 75.
