### PR TITLE
T-6.12 — show the last data day in the hero

### DIFF
--- a/code/ali-je-vroce-era5/AliJeVroceERA5.tsx
+++ b/code/ali-je-vroce-era5/AliJeVroceERA5.tsx
@@ -1,5 +1,5 @@
 import { createSignal, createResource, createMemo, Show, Suspense, ErrorBoundary, lazy } from "solid-js";
-import { fetchMeta, fetchPageData, fetchSpeiHeatmap, fetchSpeiStationSeasonal, dateToDoy, ERA5_NATIONAL, BASELINE_LABEL } from "./api.ts";
+import { fetchMeta, fetchPageData, fetchLastDataDay, fetchSpeiHeatmap, fetchSpeiStationSeasonal, dateToDoy, ERA5_NATIONAL, BASELINE_LABEL } from "./api.ts";
 import { today as todayIso } from "./clock.ts";
 import { sectionErrorFallback } from "./components/SectionError.tsx";
 import { EmptyState } from "./components/EmptyState.tsx";
@@ -16,7 +16,7 @@ import { TodayTrendChart } from "./components/TodayTrendChart.tsx";
 import { RegressionPanel, RegToolbar, RegScatterCard, RegYearRoundCard, FloatingStationChooser, useReg } from "./components/RegressionPanel.tsx";
 import { MethodologyPanel } from "./components/MethodologyPanel.tsx";
 import type { SiteMeta } from "./types.ts";
-import { t, fmtNum, fmtInt, fmtMonthDay } from "./i18n/format.ts";
+import { t, fmtNum, fmtInt, fmtMonthDay, fmtIsoDate } from "./i18n/format.ts";
 
 const Era5SeasonHeatmapChart = lazy(() => import("./charts/Era5SeasonHeatmap.tsx").then(m => ({ default: m.Era5SeasonHeatmap })));
 // T-5.46: station map hidden for v1 (D-31). Code retained deliberately — revive by
@@ -88,6 +88,12 @@ function Dashboard(props: { meta: SiteMeta }) {
   const todayData = () => pageDataResolved()?.status;
   const last7Data = () => pageDataResolved()?.last7;
 
+  // T-6.12 — last measured day in the served data, for the "podatki do …" hero line.
+  // A standalone resource (not folded into pageData/fetchMeta) so it never enters the
+  // snapshot harness's fetch surface; it fetches once, is location-independent, and the
+  // line is simply hidden while it resolves or if it fails.
+  const [lastDataDay] = createResource(fetchLastDataDay);
+
   // T-5.46: station map hidden for v1 (D-31). Code retained deliberately — revive by
   // uncommenting; StationMap.tsx is untouched.
   // T-5.39 — `mapLoc` now MIRRORS the below-hero selection; it no longer writes it.
@@ -113,6 +119,9 @@ function Dashboard(props: { meta: SiteMeta }) {
           <div class="today-heading-text">
             <span class="today-heading-title">{t("sections.today_title")}</span>
             <span class="today-heading-subtitle">{t("sections.today_subtitle")}</span>
+            <Show when={lastDataDay()}>
+              {(d) => <span class="today-heading-date">{t("sections.today_data_age", { date: fmtIsoDate(d()) })}</span>}
+            </Show>
           </div>
         </div>
 

--- a/code/ali-je-vroce-era5/api.ts
+++ b/code/ali-je-vroce-era5/api.ts
@@ -114,6 +114,7 @@ async function dsGet<T>(path: string): Promise<T> {
 const STATIONS_COLS       = ["era5_name", "name", "lat", "lon", "elevation", "station_id"] as const satisfies readonly StationsCol[];
 const DAILY_TODAY_COLS    = ["temperature_max_2m"] as const satisfies readonly DailyCol[];
 const DAILY_LAST7_COLS    = ["date", "temperature_max_2m", "month", "day"] as const satisfies readonly DailyCol[];
+const DAILY_LAST_DAY_COLS = ["date"] as const satisfies readonly DailyCol[];
 const SEASON_HEATMAP_COLS = ["x", "y", "season", "avg", "percentile", "cat", "rank", "total", "color", "n_days"] as const satisfies readonly SeasonHeatmapCol[];
 const SPEI_COLS           = ["y", "spei", "balance", "cat", "rank", "total", "color", "season", "n_days"] as const satisfies readonly SpeiCol[];
 const SPEI_STATION_COLS   = ["era5_name", "series", "years_json", "spei_json", "trend_json"] as const satisfies readonly SpeiStationCol[];
@@ -621,6 +622,28 @@ export async function fetchPageData(
     fetchLast7(date, loc),
   ]);
   return { status, last7 };
+}
+
+// ── fetchLastDataDay ─────────────────────────────────────────────────────────────
+
+// T-6.12 — the "podatki do …" line under the hero. Returns the LAST measured day in
+// the served `daily` table (the global max `date`, `_sort_desc=date&_size=1`), so the
+// displayed date derives from the DATA and stops advancing the moment the pipeline
+// stops — unlike a build/deploy timestamp, which would read "just now" during an
+// outage. It is always a reanalysis row (final `era5` or preliminary `era5t`): the
+// client-side Open-Meteo forecast fallback is never persisted here, so the max date
+// can never be a forecast. The `daily` table carries no `source` column, so the
+// frontend cannot tell final from preliminary — "last measured day" is the honest
+// grain either way. `null` on an empty/failed read; the caller hides the line.
+//
+// A dedicated query (not folded into fetchMeta) BY DESIGN: the snapshot harness calls
+// fetchMeta and asserts no fixture misses (harness.tsx:695), but never mounts the hero,
+// so keeping this out of fetchMeta leaves the snapshot surface untouched.
+export async function fetchLastDataDay(): Promise<string | null> {
+  const rows = await dsGet<Array<{ date: string }>>(
+    `daily.json?_shape=array&_sort_desc=date&_size=1&${dsCols(DAILY_LAST_DAY_COLS)}`
+  );
+  return rows[0]?.date ?? null;
 }
 
 // ── fetchSeasonHeatmap ─────────────────────────────────────────────────────────

--- a/code/ali-je-vroce-era5/i18n/format.ts
+++ b/code/ali-je-vroce-era5/i18n/format.ts
@@ -110,6 +110,14 @@ export function fmtMonthDayYear(month: number, day: number, year: number): strin
   return dtShortYear.format(new Date(year, month - 1, day));
 }
 
+/** Slovenian short date for an ISO "YYYY-MM-DD" string, e.g. "2026-07-22" →
+ * "22. jul. 2026". Parses the parts by hand (not `new Date(iso)`, which would apply a
+ * UTC/local offset) and defers all formatting to fmtMonthDayYear (T-6.12). */
+export function fmtIsoDate(iso: string): string {
+  const [y, m, d] = iso.split("-").map(Number);
+  return fmtMonthDayYear(m!, d!, y!);
+}
+
 /** Slovenian short date for a day-of-year (1..365 on the 2001 non-leap calendar). */
 export function fmtDoy(doy: number): string {
   const d = new Date(Date.UTC(2001, 0, 1));

--- a/code/ali-je-vroce-era5/i18n/sl.ts
+++ b/code/ali-je-vroce-era5/i18n/sl.ts
@@ -80,6 +80,8 @@ export const sl = {
   sections: {
     today_title: "ERA5 — Ali je vroče?",
     today_subtitle: "reanaliza ERA5-Land v primerjavi z zgodovinskimi percentili",
+    // T-6.12 — last measured day in the served data (interpolated via Intl sl-SI).
+    today_data_age: "podatki do {date}",
     trends_analysis: "Analiza trendov · ERA5-Land reanaliza",
     location_details: "Podrobnosti lokacije",
     season_overview: "Sezonski pregled",

--- a/styles/era5.css
+++ b/styles/era5.css
@@ -59,6 +59,9 @@
 .today-heading-text { display: flex; flex-direction: column; gap: 2px; align-items: center; }
 .today-heading-title { font-family: 'Playfair Display', serif; font-weight: 400; font-size: 40px; letter-spacing: 0.01em; color: var(--color-ink); }
 .today-heading-subtitle { font-family: 'Space Grotesk', sans-serif; font-size: 13px; font-weight: 400; color: var(--color-ink-soft); }
+/* T-6.12 — the "podatki do …" data-age line, smaller than the 13px subtitle. A
+   dedicated class (one restyle point for the open T-5.53 typography adoption). */
+.today-heading-date { font-family: 'Space Grotesk', sans-serif; font-size: 11px; font-weight: 400; color: var(--color-ink-soft); opacity: 0.85; }
 
 .today-date-control { display: flex; align-items: center; gap: 3px; flex-shrink: 0; justify-content: center; }
 /* T-5.32: the date badge doubles as the hero calendar trigger; the popover (styled by


### PR DESCRIPTION
Adds a small line under the hero subtitle naming the last day of served data: **`podatki do <date>`**.

**Why now.** The D-29 daily refresh is live, so this is what tells a reader when it has *stopped*. T-6.2 deferred this ticket when there was no refresh to go stale; that premise no longer holds. On 2026-08-03 stage-data went down entirely and the charts simply did not render — nothing on the page distinguished stale data from absent data from a broken page.

**It shows the last data day, not a build timestamp.** A build or deploy stamp advances on every unrelated merge and would have read "updated 5 minutes ago" on the morning the data was dead. This date derives from the served data, so when the pipeline stops the date stops with it.

**The date is guaranteed to be a measured day.** The `daily` table has no `source` column, so the frontend cannot distinguish final `era5` from preliminary `era5t` — but the Open-Meteo forecast fallback is client-side and never persisted, so `max(date)` is always a reanalysis row and never a forecast. The line therefore never claims measurement where there is prediction. It does silently include preliminary era5t days, which are subject to revision.

**A new query was needed** — the national view the page opens on does not already carry this date. It is one row, one column.

**Placement** is a third sibling span under `.today-heading-subtitle`, at 11px against the subtitle's 13px. The page has no font-size token system — literal px throughout — so rather than adding another literal, this introduces one semantic class, `.today-heading-date`, giving the open T-5.53 (typography adoption) a single restyle point instead of a scattered value.

**What it does not cover**, stated plainly: a total outage. The hero mounts only once `fetchMeta` resolves, so during a blackout this line is absent along with everything else. It distinguishes **stale from fresh**, not **present from absent**.

**No staleness warning was built.** A threshold-based "data is old" treatment would cry wolf during ERA5-Land's normal 5–10 day lag, and picking that threshold is an editorial decision, not an implementation one. Reported and left open.

**⚠ Snapshot is byte-identical, and that proves nothing here.** The harness never mounts the hero header and never issues the new query, so it is structurally blind to this change. Predicted and confirmed — but confirmation of blindness, not of correctness.

**Needs eyes on stage:** that the line shows the real current data date rather than the pinned fixture date `2026-07-29`, that it sits correctly under the subtitle at 390px and desktop, and that 11px is legible.

Gates: typecheck 0 · typecheck:gate 0 allowlisted · yarn test 79 · snapshot:check identical, 0 misses · pytest 75.
