### PR TITLE
T-6.13 — show '· danes napoved' when the hero value is a forecast

### DIFF
--- a/code/ali-je-vroce-era5/AliJeVroceERA5.tsx
+++ b/code/ali-je-vroce-era5/AliJeVroceERA5.tsx
@@ -120,7 +120,20 @@ function Dashboard(props: { meta: SiteMeta }) {
             <span class="today-heading-title">{t("sections.today_title")}</span>
             <span class="today-heading-subtitle">{t("sections.today_subtitle")}</span>
             <Show when={lastDataDay()}>
-              {(d) => <span class="today-heading-date">{t("sections.today_data_age", { date: fmtIsoDate(d()) })}</span>}
+              {(d) => (
+                <span class="today-heading-date">
+                  {t("sections.today_data_age", { date: fmtIsoDate(d()) })}
+                  {/* T-6.13 — suffix only while the hero shows a forecast value
+                      (the same is_preliminary flag as TodayCard's "napoved" badge,
+                      api.ts:503-507/534-546). The separator is bundled into the
+                      catalogue string and gated here, so it never renders alone. The
+                      DATE is national/location-independent; only this suffix follows
+                      the reader's current selection (accepted — see PROGRESS). */}
+                  <Show when={todayData()?.is_preliminary}>
+                    {t("sections.today_forecast_suffix")}
+                  </Show>
+                </span>
+              )}
             </Show>
           </div>
         </div>

--- a/code/ali-je-vroce-era5/i18n/sl.ts
+++ b/code/ali-je-vroce-era5/i18n/sl.ts
@@ -82,6 +82,11 @@ export const sl = {
     today_subtitle: "reanaliza ERA5-Land v primerjavi z zgodovinskimi percentili",
     // T-6.12 — last measured day in the served data (interpolated via Intl sl-SI).
     today_data_age: "podatki do {date}",
+    // T-6.13 — appended to today_data_age ONLY when the hero is currently showing an
+    // Open-Meteo forecast value (todayData().is_preliminary). The leading " · " lives
+    // inside the string and is rendered inside the same <Show>, so the separator can
+    // never appear without the words. The date itself is never advanced (see PROGRESS).
+    today_forecast_suffix: " · danes napoved",
     trends_analysis: "Analiza trendov · ERA5-Land reanaliza",
     location_details: "Podrobnosti lokacije",
     season_overview: "Sezonski pregled",


### PR DESCRIPTION
Conditional suffix on T-6.12's data-age line: `podatki do 2. 8. · danes napoved`.

Reuses the existing `is_preliminary` flag (`types.ts:29`) — set at the Open-Meteo fallback point itself, and the same flag driving the hero's *napoved* badge — so the suffix and the badge can never disagree. It was already in scope at the render site, so no new fetch and no second definition of "forecast". The separator is bundled inside the conditional, so it can never render alone.

**The date deliberately does not advance for forecast days.** Its value is that it freezes when the refresh dies; a date that advanced on Open-Meteo forecasts would keep moving even if podnebnik's own pipeline had been dead for a week — the exact failure T-6.12 exists to reveal.

Note the two halves answer questions at different scopes: the date is national and location-independent, the suffix follows the reader's current selection. Accepted deliberately — a per-station date would add a query and make the line jump around as a reader browses.

Snapshot byte-identical. The harness never mounts the hero header, so that proves blindness rather than correctness.

Gates: typecheck 0 · typecheck:gate 0 allowlisted · yarn test 79 · snapshot:check identical, 0 misses · pytest 75.
