### PR TITLE
T-5.54 — remove a doubled 40px inset; three sections were 558px against the page's 638

### DIFF
--- a/code/ali-je-vroce-era5/AliJeVroceERA5.tsx
+++ b/code/ali-je-vroce-era5/AliJeVroceERA5.tsx
@@ -281,7 +281,7 @@ function TropControls(props: {
 }) {
   const ctlLabel = { "font-family": "var(--font-mono)", "font-size": "10px", "letter-spacing": "0.06em", "text-transform": "uppercase", color: "var(--color-ink-soft)" } as const;
   return (
-    <div style={{ display: "flex", gap: "24px", "align-items": "center", "flex-wrap": "wrap", margin: "0 40px 12px" }}>
+    <div style={{ display: "flex", gap: "24px", "align-items": "center", "flex-wrap": "wrap", margin: "0 0 12px" }}>
       <label style={{ display: "flex", "align-items": "center", gap: "8px" }}>
         <span style={ctlLabel}>{t("tropical.ctrl_threshold")}</span>
         <input type="range" min={props.min} max={props.max} step={1} value={props.threshold}

--- a/code/ali-je-vroce-era5/charts/Era5TropicalChart.tsx
+++ b/code/ali-je-vroce-era5/charts/Era5TropicalChart.tsx
@@ -109,7 +109,7 @@ export function Era5TropicalChart(props: Props) {
   };
 
   return (
-    <div style={{ margin: "0 40px" }}>
+    <div>
       <ErrorBoundary fallback={sectionErrorFallback(refetch, "300px")}>
       <div style={{ background: "var(--color-card)", border: "1px solid var(--color-rule)", "border-radius": "var(--radius,10px)", overflow: "hidden" }}>
 

--- a/code/ali-je-vroce-era5/charts/SpeiTrendChart.tsx
+++ b/code/ali-je-vroce-era5/charts/SpeiTrendChart.tsx
@@ -238,7 +238,7 @@ export function SpeiTrendChart(props: SpeiTrendChartProps) {
     <div>
 
       {/* Season + month row (the station is set by the page-wide floating chooser) */}
-      <div style={{ display: "flex", "flex-wrap": "wrap", gap: "5px", "align-items": "center", margin: "0 40px 14px" }}>
+      <div style={{ display: "flex", "flex-wrap": "wrap", gap: "5px", "align-items": "center", margin: "0 0 14px" }}>
         <For each={SEASONS}>
           {(s) => <button style={periodBtnStyle(s)} onClick={() => setPeriod(s)}>{periodLabel(s)}</button>}
         </For>
@@ -249,7 +249,7 @@ export function SpeiTrendChart(props: SpeiTrendChartProps) {
       </div>
 
       {/* Chart card */}
-      <div style={{ margin: "0 40px" }}>
+      <div>
         <div style={{ background: "var(--color-card)", border: "1px solid var(--color-rule)", "border-radius": "var(--radius,10px)", overflow: "hidden" }}>
 
           {/* Panel header */}


### PR DESCRIPTION
Removes a doubled inset that made three sections narrower than the rest of the page.

**What was measured before anything was changed.** A full sweep of every section found exactly two width regimes at desktop: **638 px** for eight sections (hero, last-7, both trend cards, hero cards, both heatmaps, methodology) and **558 px** for three (SPEI trend, tropical days, tropical nights). The trend card was **not** the outlier — the three narrow sections were.

**The cause was the same value applied twice.** 40 px is the page's inset token, applied independently by four rules. These three sections added a **fifth** — an inline `margin: 0 40px` on the card inside an already-40px `.sec-p`, doubling to 80. No comment, no token, no spec declared 558 as an intended narrower measure; it reads as a double application.

**It was worse on mobile.** `.sec-p` drops 40 → 14 below 700 px, but the inline 40 did not, so these cards fell to **250 px against their siblings' 330** — proportionally more pinched than at desktop.

**The fix removes the inner margin rather than compensating for it** — no negative margin, no widened width, no transform. `.sec-p`'s padding was already correct.

| | desktop before | after | mobile before | after |
|---|---|---|---|---|
| Tropical days | L=80 W=558 | **L=40 W=638** | L=54 W=250 | **L=14 W=330** |
| Tropical nights | L=80 W=558 | **L=40 W=638** | L=54 W=250 | **L=14 W=330** |
| SPEI trend | L=80 W=558 | **L=40 W=638** | L=54 W=250 | **L=14 W=330** |

The control rows (`PRAG:`, `MIN. ZAP. DNI:`) move with the cards, which is intended — they now align under their own heading rather than sitting inset with the chart.

**The descriptions deliberately stay at 80.** That inset comes from `.sec-hs2`'s own `padding-inline` (`era5.css:156`), a different mechanism, and it is page-wide: the untouched "Sezonski pregled" section has the identical heading-40 / description-80 / card-40 shape. Leaving it makes these three match the rest exactly; changing it would be a separate page-wide decision.

**T-5.46 was checked and cleared.** It widened the trend card by collapsing `.main-row`, but the `margin: 0 40px` wrappers predate that commit — the split existed before the map was hidden and is independent of it.

**Regime A was not touched**, and the four independent 40px rules were deliberately not consolidated: that is a larger refactor with a wider blast radius and is not what was broken.

**Snapshot unchanged** — layout is invisible to the harness, as predicted.

**Needs eyes on stage:** that the three sections sit flush-left with the rest at desktop and 390 px, that the controls align under their headings, and that nothing else shifted.

Gates: typecheck 0 · typecheck:gate 0 allowlisted · yarn test 79 · snapshot:check identical, 0 misses · pytest 75.
