### PR TITLE
T-5.53 — adopt the site's two typefaces on the ERA5 page

### DIFF
--- a/styles/era5.css
+++ b/styles/era5.css
@@ -5,8 +5,12 @@
  */
 
 /* ── Font imports ─────────────────────────────────────────────────────────── */
-/* Space Grotesk, Playfair Display, JetBrains Mono */
-@import url('https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Playfair+Display:ital,wght@0,400;0,700;1,400&family=JetBrains+Mono:wght@400;600&display=swap');
+/* T-5.53: page text now adopts the site families (Bitter + IBM Plex Sans), which
+   the Eleventy shell already loads (base.html). Playfair Display dropped — nothing
+   renders it after the token swap. Space Grotesk kept: 8 Highcharts configs still
+   name it (out of scope to restyle), so it must keep loading or those charts fall
+   back silently. JetBrains Mono kept: the whole mono "data/lab" register stays. */
+@import url('https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&display=swap');
 
 /* ── Design tokens ────────────────────────────────────────────────────────── */
 
@@ -23,8 +27,11 @@
   --color-rule:       rgba(14,14,12,0.10);
   --color-rule-2:     rgba(14,14,12,0.18);
 
-  --font-sans:  'Space Grotesk', system-ui, sans-serif;
-  --font-serif: 'Playfair Display', Georgia, serif;
+  /* T-5.53: adopt the site families so this page reads as one site with
+     /ali-je-vroce/. Values mirror styles/main.css:12-13. --font-mono is
+     deliberately unchanged — its register has no counterpart to adopt. */
+  --font-sans:  'IBM Plex Sans', 'sans-serif';
+  --font-serif: 'Bitter', 'Arial', 'Helvetica', 'serif';
   --font-mono:  'JetBrains Mono', 'Fira Mono', monospace;
   --radius:     10px;
 
@@ -57,11 +64,11 @@
 
 .today-status .sec-heading { display: flex; flex-direction: column; align-items: center; text-align: center; gap: 8px; padding: 0 0 16px; }
 .today-heading-text { display: flex; flex-direction: column; gap: 2px; align-items: center; }
-.today-heading-title { font-family: 'Playfair Display', serif; font-weight: 400; font-size: 40px; letter-spacing: 0.01em; color: var(--color-ink); }
-.today-heading-subtitle { font-family: 'Space Grotesk', sans-serif; font-size: 13px; font-weight: 400; color: var(--color-ink-soft); }
+.today-heading-title { font-family: var(--font-serif); font-weight: 400; font-size: 40px; letter-spacing: 0.01em; color: var(--color-ink); }
+.today-heading-subtitle { font-family: var(--font-sans); font-size: 13px; font-weight: 400; color: var(--color-ink-soft); }
 /* T-6.12 — the "podatki do …" data-age line, smaller than the 13px subtitle. A
    dedicated class (one restyle point for the open T-5.53 typography adoption). */
-.today-heading-date { font-family: 'Space Grotesk', sans-serif; font-size: 11px; font-weight: 400; color: var(--color-ink-soft); opacity: 0.85; }
+.today-heading-date { font-family: var(--font-sans); font-size: 11px; font-weight: 400; color: var(--color-ink-soft); opacity: 0.85; }
 
 .today-date-control { display: flex; align-items: center; gap: 3px; flex-shrink: 0; justify-content: center; }
 /* T-5.32: the date badge doubles as the hero calendar trigger; the popover (styled by


### PR DESCRIPTION
The ERA5 page now uses the same two typefaces as the rest of podnebnik.

**Why.** Both pages sit in the same Eleventy shell, but the ERA5 island had its own families — Space Grotesk and Playfair Display — while `/ali-je-vroce/` uses the site's IBM Plex Sans and Bitter. Two pages on one site with different type is what a reader notices without being able to name it.

**Families only.** `--font-sans` → IBM Plex Sans, `--font-serif` → Bitter, plus the three rules that bypassed the tokens (`.today-heading-title`, `.today-heading-subtitle`, `.today-heading-date`) repointed at them — so the next swap is one line. One file, +14/−7. Everything else is token-driven, so all 21 sans rules, the serif rule and every inline `var()` style swing together.

**The type scale was deliberately not touched.** The page has no font-size token system — every size is a literal px — so aligning the scale would be ~30 edits against 3, and it would change the density of a dashboard to match a page built around a single large number. That is a redesign, not a consistency fix. If it is wanted later it should be its own ticket, and it should tokenise the scale first.

**The JetBrains Mono register stays entirely.** All 33 uses — badges, all-caps micro-labels, the last-7 caption `36,5 °C · 100. PERCENTIL · 1147 VZORCEV` — with their letter-spacing and uppercase. It is a consistent, deliberate "data/lab" voice, and `/ali-je-vroce/` offers nothing to adopt in its place; removing it would flatten a real distinction to match a page that never made one.

**The `@import` was grepped before trimming, and that mattered.** **Space Grotesk had to stay** — eight out-of-scope Highcharts configs still name it (`TropicalChart:162`, `SpeiTrendChart:90`, `RegressionChart:95`, `YearRoundChart:61,122`, `DistributionChart:67`, `StationMap:100,126`), and dropping it would have silently changed chart text. **Playfair Display was dropped**: no chart references it, correcting an overstatement in the investigation. Bitter and IBM Plex Sans are already loaded by the shell, so this adds no webfont request and removes one.

**The overflow risk was measured, and the premise was wrong in the safe direction.** IBM Plex Sans was expected to be wider per glyph; measured with both fonts loaded it is **slightly narrower** at small UI sizes. Chooser options are narrower for every station (widest, "Murska Sobota", 87 px; full option ≈128 px against a ~350 px budget at 390 px). Toolbar labels are narrower throughout. Card titles carrying `· 2514 m` move within ±2 px.

**Snapshot unchanged** — family is invisible to the harness, as predicted.

**Needs eyes on stage** (T-5.56 blocks a full offline island render, so these are measurements of strings rather than of the composed page): that the two pages read as one site — Bitter against the old Playfair at the 40/26 px hero heading is a visual judgement; that the toolbar still holds SPREMENLJIVKA + DAN + Okno without wrapping a row earlier; that the chooser's 18 rows each still sit on one line; and that nothing overflows at 390 px.

Gates: typecheck 0 · typecheck:gate 0 allowlisted · yarn test 79 · snapshot:check identical, 0 misses · pytest 75.
