### PR TITLE
T-5.56 — a decorative line could blank the whole island; fix the call site and the boundary

### DIFF
--- a/code/ali-je-vroce-era5/AliJeVroceERA5.tsx
+++ b/code/ali-je-vroce-era5/AliJeVroceERA5.tsx
@@ -119,22 +119,34 @@ function Dashboard(props: { meta: SiteMeta }) {
           <div class="today-heading-text">
             <span class="today-heading-title">{t("sections.today_title")}</span>
             <span class="today-heading-subtitle">{t("sections.today_subtitle")}</span>
-            <Show when={lastDataDay()}>
-              {(d) => (
-                <span class="today-heading-date">
-                  {t("sections.today_data_age", { date: fmtIsoDate(d()) })}
-                  {/* T-6.13 — suffix only while the hero shows a forecast value
-                      (the same is_preliminary flag as TodayCard's "napoved" badge,
-                      api.ts:503-507/534-546). The separator is bundled into the
-                      catalogue string and gated here, so it never renders alone. The
-                      DATE is national/location-independent; only this suffix follows
-                      the reader's current selection (accepted — see PROGRESS). */}
-                  <Show when={todayData()?.is_preliminary}>
-                    {t("sections.today_forecast_suffix")}
-                  </Show>
-                </span>
-              )}
-            </Show>
+            {/* T-5.56 (c1) — the data-age line has its OWN boundary with an EMPTY
+                fallback, because it lives in the section heading, OUTSIDE the
+                today-grid ErrorBoundary below. A throw from any resource read here
+                (lastDataDay today, or the next inline fetch someone adds to
+                sec-heading) would otherwise escape to the page-level boundary at
+                :54 and blank the WHOLE island. A decorative line that fails should
+                VANISH, not render an error card in the heading — so the fallback is
+                null, matching the <Show>'s own hide-on-null behaviour. c2 makes
+                fetchLastDataDay itself return null on failure, so this boundary is
+                defence for the shape of the failure, not this call site. */}
+            <ErrorBoundary fallback={null}>
+              <Show when={lastDataDay()}>
+                {(d) => (
+                  <span class="today-heading-date">
+                    {t("sections.today_data_age", { date: fmtIsoDate(d()) })}
+                    {/* T-6.13 — suffix only while the hero shows a forecast value
+                        (the same is_preliminary flag as TodayCard's "napoved" badge,
+                        api.ts:503-507/534-546). The separator is bundled into the
+                        catalogue string and gated here, so it never renders alone. The
+                        DATE is national/location-independent; only this suffix follows
+                        the reader's current selection (accepted — see PROGRESS). */}
+                    <Show when={todayData()?.is_preliminary}>
+                      {t("sections.today_forecast_suffix")}
+                    </Show>
+                  </span>
+                )}
+              </Show>
+            </ErrorBoundary>
           </div>
         </div>
 

--- a/code/ali-je-vroce-era5/api.ts
+++ b/code/ali-je-vroce-era5/api.ts
@@ -646,10 +646,27 @@ export async function fetchPageData(
 // fetchMeta and asserts no fixture misses (harness.tsx:695), but never mounts the hero,
 // so keeping this out of fetchMeta leaves the snapshot surface untouched.
 export async function fetchLastDataDay(): Promise<string | null> {
-  const rows = await dsGet<Array<{ date: string }>>(
-    `daily.json?_shape=array&_sort_desc=date&_size=1&${dsCols(DAILY_LAST_DAY_COLS)}`
-  );
-  return rows[0]?.date ?? null;
+  // T-5.56 — this line is DECORATIVE, and the contract above already promises
+  // "null on an empty/failed read". Honour it: catch the fetch error and return
+  // null so a failed read HIDES the line (the caller's <Show when={lastDataDay()}>
+  // does exactly that) instead of leaving the resource in an errored state whose
+  // read re-throws during render. Because this read sits in the section HEADING —
+  // outside the today-grid ErrorBoundary — that throw escaped to the page-level
+  // boundary and blanked the WHOLE island (the offline fixtures build could not
+  // render at all: fetchLastDataDay's URL was never added to record.mjs's plan).
+  // The offline fixture shim still records the miss in window.__FIXTURE_MISSES__
+  // BEFORE it throws (fixtures/install.ts miss()), so the fixture-miss guard stays
+  // honest — this only stops a decorative failure from being fatal. c1 (its own
+  // empty-fallback boundary in AliJeVroceERA5.tsx) hardens the heading against the
+  // next inline fetch someone adds there.
+  try {
+    const rows = await dsGet<Array<{ date: string }>>(
+      `daily.json?_shape=array&_sort_desc=date&_size=1&${dsCols(DAILY_LAST_DAY_COLS)}`
+    );
+    return rows[0]?.date ?? null;
+  } catch {
+    return null;
+  }
 }
 
 // ── fetchSeasonHeatmap ─────────────────────────────────────────────────────────


### PR DESCRIPTION
Fixes `yarn fixtures:start` and `fixtures:build` failing to render the ERA5 island at all.

**Why this mattered.** That command is the only pre-merge visual check that exists — there are no PR previews (T-6.9). It had been broken since T-6.12 merged, so everything shipped in that window was verified on stage only, and two sessions had to hand-patch a route into a throwaway build just to measure the page.

**The real defect was error-boundary placement, not a missing fixture.** `fetchLastDataDay` is a resource; reading it in an errored state re-throws synchronously during render. That read sits in `sec-heading` (`AliJeVroceERA5.tsx:122`), a **sibling** of `today-grid` whose boundary opens at `:142` — so the nearest boundary was the page-level one at `:54`. A decorative one-line "podatki do …" label took down the hero, all sixteen charts and every section. Losing one line would be acceptable; losing the page is not.

**Two changes, fixing two different things:**
- **c2 — the call site.** `fetchLastDataDay` now catches internally and returns null, honouring its own JSDoc contract (*"null on an empty/failed read; the caller hides the line"*). The caller's `<Show>` already hides the line on null. This also hardens production: a real datasette hiccup now hides the line instead of erroring the island.
- **c1 — the shape of the failure.** The line's read is wrapped in its own `<ErrorBoundary fallback={null}>`. Any *future* throw in the section heading now degrades that line rather than the page. c2 fixes this call site; c1 stops the next inline fetch repeating the whole-island blank.

**The fixture-miss guard is unchanged in strength.** `install.ts`'s `miss()` pushes to `misses[]` **before** throwing, and c2 catches after that push — so the miss is still counted, it just stops being fatal to a decorative line. Verified against the live offline DOM: `missCount: 1`, exactly the one URL. `miss()` was not moved, weakened or bypassed. A lenient shim that skipped the push would have kept `snapshot:check` green while data was genuinely absent — strictly worse than a loud failure, and explicitly rejected.

**No recording was done.** `record.mjs:404` does `rm -rf http/` and re-fetches all 2,087 requests live; stage was last recorded 2026-07-31. That is a full re-baseline event and belongs to T-5.48 on its own terms, not riding along inside a bug fix.

**A correction worth keeping:** the recorder is **not** harness-driven. It fetches a hand-enumerated plan of URL templates, each with a file:line citation derived by reading the code. T-6.12 added the fetch and never added its shape to the plan — a more brittle failure mode than "the harness didn't mount it".

**Verified by looking, not by gates.** Offline build served and loaded: full hero, gauge, badges, the expander, both chart cards, the floating chooser; live DOM probe reports `hasErrorCard: false`, 8 sections, 16 charts mounted. The data-age line is correctly **absent** offline — no recorded response, so c2 returns null and the `<Show>` hides it. It renders against a live datasette.

**Latent finding, reported not fixed:** `annual_trend_windows.json?…&window__exact=N` for N ∈ {3,15,45} is also unrecorded, fired when a reader moves the Okno control offline. It blanks only the `RegressionPanel` section — because that component's boundaries are placed correctly, which is precisely the contrast that makes c1 worth doing. Latent since T-4.26b; belongs to T-5.48.

Gates: typecheck 0 · typecheck:gate 0 allowlisted · yarn test 79 · snapshot:check identical, 0 misses · pytest 75.
