### PR TITLE
T-5.59 — Tropski dnevi → Vroči dnevi; the nights keep their defined term

### DIFF
--- a/code/ali-je-vroce-era5/i18n/hero-content.ts
+++ b/code/ali-je-vroce-era5/i18n/hero-content.ts
@@ -254,9 +254,9 @@ Primerjalni vzorec za vsak koledarski dan je **združeno okno ±7 dni** čez vsa
 
 Štetje vročih dni in tropskih noči uporablja **stroge pragove (\`>\`, ne \`≥\`).** To je usklajeno s standardom ETCCDI/ECA&D (medtem ko npr. nemški DWD uporablja \`≥\`). Standard je dejansko sporen; izbrali smo \`>\`. Sprememba na \`≥\` bi premaknila štetje vsakega mejnega dne, zato je izbira zapisana zavestno.
 
-## Trend tropskih dni in noči
+## Trend vročih dni in tropskih noči
 
-Letni trend na grafih tropskih dni in noči je **model negativne binomske regresije (NB GLM)** čez letno število — primeren za štetne podatke z večjo razpršenostjo od Poissonove. Gre za **približek**, ne za dokončno napoved: prikazana stopnja rasti in projekcija do leta 2050 sta odvisni od izbranega praga in dolžine zaporedja.
+Letni trend na grafih vročih dni in tropskih noči je **model negativne binomske regresije (NB GLM)** čez letno število — primeren za štetne podatke z večjo razpršenostjo od Poissonove. Gre za **približek**, ne za dokončno napoved: prikazana stopnja rasti in projekcija do leta 2050 sta odvisni od izbranega praga in dolžine zaporedja.
 
 **Trenda ne prikažemo, kadar mu ne moremo zaupati.** Za nekatere kombinacije (redki dogodki, skoraj ravna letna vrsta) statistični model ne da zanesljivega rezultata — ne skonvergira ali pa ocena njegove negotovosti ni veljavna. V takih primerih trenda **ne objavimo** (letno štetje ostane prikazano), namesto da bi navedli navidezno natančno, a nezanesljivo številko. Enako velja, kadar je premalo let s podatki (potrebnih je vsaj 10). To je isto načelo kot pri indeksu suše SPEI: raje odklonimo objavo kot da objavimo negotovo vrednost.
 
@@ -267,7 +267,7 @@ Letni trend na grafih tropskih dni in noči je **model negativne binomske regres
 - **ERA5-Land Tmin** je v mestih nezanesljiv (toplotni otok); zato stran privzeto ne vodi s Tmean/Tmin.
 - **Mrežna ločljivost** (~9 km) ne ujame lokalnih posebnosti pod to velikostjo.
 - **Najnovejše vrednosti** so lahko napoved (označene z »napoved«), dokler reanaliza ni na voljo.
-- **Trend tropskih dni/noči je približek** in ni na voljo za vse kombinacije praga in zaporedja: kjer se model ne ustali, trenda ne prikažemo (glej zgoraj).
+- **Trend vročih dni/tropskih noči je približek** in ni na voljo za vse kombinacije praga in zaporedja: kjer se model ne ustali, trenda ne prikažemo (glej zgoraj).
 
 ---
 

--- a/code/ali-je-vroce-era5/i18n/sl.ts
+++ b/code/ali-je-vroce-era5/i18n/sl.ts
@@ -94,7 +94,7 @@ export const sl = {
     spei: "Sezonski sušni indeks (SPEI)",
     spei_trend: "Sušni trend po postaji — SPEI",
     spei_trend_sub: "Sezonski (SPEI-3) in mesečni (SPEI-30) indeks vodne bilance · Theil-Sen · ERA5-Land",
-    tropical_days: "Tropski dnevi",
+    tropical_days: "Vroči dnevi",
     tropical_days_sub: "Število dni z najvišjo temperaturo nad pragom · ERA5-Land · lapsna korekcija nadmorske višine",
     tropical_nights: "Tropske noči",
     tropical_nights_sub: "Število noči z najnižjo temperaturo nad pragom · ERA5-Land · lapsna korekcija nadmorske višine",
@@ -457,18 +457,18 @@ export const sl = {
   tropical: {
     unit_days: "dni",
     unit_nights: "noči",
-    noun_days: "Tropski dnevi",
+    noun_days: "Vroči dnevi",
     noun_nights: "Tropske noči",
     // T-5.19 — `plain_noun_days`/`plain_noun_nights` are the nominative-singular
     // forms; they are now UNUSED (their only consumer, no_trend, moved to the
     // pre-declined instrumental forms below). Left in place, not deleted, per the
     // ticket — removal is its own change.
-    plain_noun_days: "tropski dan",
+    plain_noun_days: "vroč dan",
     plain_noun_nights: "tropska noč",
     // Instrumental-plural forms for no_trend's "z {instr}" — Slovene morphology the
     // old "z {plainNoun}i" concatenation could not produce (it rendered the
     // ungrammatical "z tropski dani" / "z tropska noči").
-    instr_days: "tropskimi dnevi",
+    instr_days: "vročimi dnevi",
     instr_nights: "tropskimi nočmi",
     ctrl_threshold: "Prag:",
     ctrl_streak_days: "Min. zap. dni:",
@@ -480,7 +480,7 @@ export const sl = {
     tooltip_trend: "<b>{x}</b><br>Trend: <b>{y}</b> {unit}",
     tooltip_bar: "<b>{x}</b>{partial}<br>{noun}: <b>{y}</b>",
     nb_fit: "NB fit ({dpd} {unit}/des · {p})",
-    plain_desc_days: "Tropski dan — ko dnevna temperatura preseže {th} °C — povečuje toplotni stres in zdravstvena tveganja.",
+    plain_desc_days: "Vroč dan — ko dnevna temperatura preseže {th} °C — povečuje toplotni stres in zdravstvena tveganja.",
     plain_desc_nights: "Tropska noč — ko temperatura čez noč ostane nad {th} °C — preprečuje telesu okrevanje po dnevni vročini.",
     tech: "NB GLM: {rate}%/leto · {dpd} {unit}/desetletje · 95% CI · {sigphrase} · AIC {aic} · α={alpha}.",
     sig_yes: "statistično značilen ({p})",

--- a/tests/fixtures/snapshot.json
+++ b/tests/fixtures/snapshot.json
@@ -20134,11 +20134,11 @@
           ]
         },
         "rendered": {
-          "header": "Tropski dnevi · Ljubljana",
+          "header": "Vroči dnevi · Ljubljana",
           "coverage": "77 let · 48 z vrednostjo > 0",
           "paragraphs": [
             "NB GLM: +3,32%/leto · +1,6 dni/desetletje · 95% CI · statistično značilen (p < 0,001) · AIC 387 · α=2.059.",
-            "Tropski dan — ko dnevna temperatura preseže 30 °C — povečuje toplotni stres in zdravstvena tveganja. Postaja Ljubljana kaže statistično značilen trend: grobe 1,6 več dni na desetletje. Če trend nadaljuje, bi bilo do 2050 tipičnih okoli 34 dni na leto."
+            "Vroč dan — ko dnevna temperatura preseže 30 °C — povečuje toplotni stres in zdravstvena tveganja. Postaja Ljubljana kaže statistično značilen trend: grobe 1,6 več dni na desetletje. Če trend nadaljuje, bi bilo do 2050 tipičnih okoli 34 dni na leto."
           ]
         },
         "current_year_bar": {
@@ -20181,7 +20181,7 @@
             "zones": null,
             "series": [
               {
-                "name": "Tropski dnevi",
+                "name": "Vroči dnevi",
                 "type": "column",
                 "data": [
                   {
@@ -30247,10 +30247,10 @@
           "alpha": 0
         },
         "rendered": {
-          "header": "Tropski dnevi · Kredarica",
+          "header": "Vroči dnevi · Kredarica",
           "coverage": "77 let · 0 z vrednostjo > 0",
           "paragraphs": [
-            "Premalo let z tropskimi dnevi za izračun trenda (0 let z vrednostjo > 0). Potrebnih je vsaj 10."
+            "Premalo let z vročimi dnevi za izračun trenda (0 let z vrednostjo > 0). Potrebnih je vsaj 10."
           ]
         },
         "current_year_bar": {
@@ -30293,7 +30293,7 @@
             "zones": null,
             "series": [
               {
-                "name": "Tropski dnevi",
+                "name": "Vroči dnevi",
                 "type": "column",
                 "data": [
                   {


### PR DESCRIPTION
Renames the user-visible Slovenian **"Tropski dnevi" → "Vroči dnevi"**. The nights keep their name.

**The reason is terminological, not stylistic.** *Tropska noč* is a **defined** meteorological term (Tmin above a threshold, ETCCDI/ECA&D). ***Tropski dan* is not** — it was coined for this page. Pairing a real term with an invented one implies both are standard.

**The methodology already agreed and was contradicting itself.** `hero-content.ts:255` said *"Štetje **vročih dni** in tropskih noči"* while `:257`, `:259` and `:270` said *"tropskih dni"*. This resolves it in the direction the prose already leaned.

**Not a `sed` job**, and the grammar is why. A blind substitution on *tropsk* would have renamed the nights, rewritten an explanatory comment, and left the inflections wrong. Five day-values changed, each inflected at its own case:

- `sections.tropical_days` and `noun_days` → *Vroči dnevi* (nominative plural — the `<h2>` and the chart header/series)
- `plain_noun_days` → *vroč dan* (this key is unused; renamed anyway so no stray old term survives)
- `instr_days` → *vročimi dnevi* — instrumental, landing in *"Premalo let z **vročimi dnevi** za izračun trenda…"*. This key exists precisely because a naive concatenation once produced the ungrammatical *"z tropski dani"*.
- `plain_desc_days` → *Vroč dan — ko dnevna temperatura preseže {th} °C — …*

**The shared adjective had to split.** *"Trend tropskih dni in noči"* used one adjective to govern both nouns; with days renamed and nights unchanged, each needs its own: **"vročih dni in tropskih noči"**, matching the genitive already used at `:255`.

**Dual-commit under D-23.** `METHODOLOGY.md:105,107` were edited for parity with `hero-content.ts:257,259`. It is a git-excluded symlink into the private repo, so the commit contains only `sl.ts`, `hero-content.ts` and `snapshot.json` — the draft change is saved separately.

**⚠ A pre-existing divergence was found, not created and not fixed here.** `hero-content.ts:270`'s *Znane omejitve* bullet **has no twin in `METHODOLOGY.md` at all** — that file's *Znane omejitve* carries five different bullets. The published text and its reviewed draft have already drifted, which is exactly the trap the draft's own provenance note warns about. `:270` was renamed in `hero-content.ts` only, since there is nothing to keep in parity. A full parity audit of the two files is warranted as its own ticket.

**Kept deliberately:** every nights string; all key names (`tropical_days`, `tropical_nights`) and the `tropical:` object key; the comment documenting *"z tropski dani"*, which still explains accurately why the instrumental form exists; component names; the `tropical` table and its columns; and two unrelated files (`docs/i18n/sl_default.json`, which mentions tropical *diseases*, and a Fable page mentioning tropical *regions*).

**Snapshot: six text leaves, no numbers.** Six insertions, six deletions — Ljubljana and Kredarica headers, series names and one description each. The embedded numbers in the Ljubljana description (1,6 / 34) are unchanged, and the **night leaves at `22170`, `22174`, `22217`, `30716`, `30719`, `30762` are byte-identical**.

**Needs eyes on stage:** that the section heading, both chart headers and the day description read *Vroči dnevi* while every nights surface still reads *Tropske noči*, and that the renamed sentences are grammatical — particularly the instrumental and the split adjective.

Gates: typecheck 0 · typecheck:gate 0 allowlisted · yarn test 79 · snapshot:check identical after re-record · pytest 75.
