### PR TITLE
T-5.60 — regression card subtitles wrap instead of hiding their unique clause

### DIFF
--- a/code/ali-je-vroce-era5/components/RegressionPanel.tsx
+++ b/code/ali-je-vroce-era5/components/RegressionPanel.tsx
@@ -896,9 +896,14 @@ export const panelSubStyle: Record<string, string> = {
   "letter-spacing": "0.08em",
   "text-transform": "uppercase",
   color:            "var(--color-ink-soft)",
-  "white-space":    "nowrap",
-  overflow:         "hidden",
-  "text-overflow":  "ellipsis",
+  // T-5.60 — WRAP, don't ellipsize. These subtitles carry meaning (variable ·
+  // method · window; "rdeča črta = izbrani dan"; n_years · significance), and the
+  // hidden tail was exactly the non-duplicated part. `nowrap`+`overflow:hidden`+
+  // `text-overflow:ellipsis` clipped the year-round header at every width and the
+  // scatter stats badge / footer at 390px. Wrapping costs a line of height and
+  // makes these two cards behave like every other card on the page, which already
+  // wraps. Do NOT re-add nowrap: it silently conceals text (see PROGRESS T-5.60).
+  "white-space":    "normal",
 };
 
 const statsBoxStyle: Record<string, string> = {

--- a/tests/snapshot/harness.tsx
+++ b/tests/snapshot/harness.tsx
@@ -591,8 +591,15 @@ function captureAnalysis(unit: Unit): any {
       day_label: r.txt(".reg-doy-ctrl > div"),
       title: scatter.txt("[style*='font-size: 15px']"),
       subtitle: scatter.txt("[style*='margin-top: 3px']"),
-      // "<n> YR · <significance>" — RegressionPanel.tsx:262
-      stats_badge: scatter.all("[style*='white-space: nowrap']").slice(-1)[0] ?? null,
+      // The last panelSubStyle line in the scatter card — the footer method+fit_desc
+      // span (RegressionPanel.tsx:478), "Theil-Sen + TFPW MK · τ = …". (The field name
+      // and the old "<n> YR" comment are stale: slice(-1) lands on the footer, not the
+      // years_sig badge.) T-5.60 dropped `white-space:nowrap` from panelSubStyle so the
+      // subtitles wrap instead of ellipsizing; this selector keyed on that nowrap and
+      // matched nothing after. Re-anchored to `letter-spacing: 0.08em`, which panelSubStyle
+      // carries and the (9px) stats sub-label shares — slice(-1) still returns the SAME
+      // footer span, so the recorded value is byte-identical.
+      stats_badge: scatter.all("[style*='letter-spacing: 0.08em']").slice(-1)[0] ?? null,
       total_change: scatter.txt("[style*='font-size: 20px']"),
       total_change_color: scatter.style("[style*='font-size: 20px']", "color"),
       footer: scatter.all("p"),


### PR DESCRIPTION
Makes the regression cards' subtitles **wrap instead of truncating**, so a reader can actually read them.

**The observed defect:** the year-round card's header read *"TREND NA DESETLETJE ZA VSAK DAN V LETU · RDEČA …"*, clipped with an ellipsis, and *"NAJVIŠJA TEMPERATURA · THEIL–SEN + MK…"* beside it.

**The premise was that this text was duplicated in the caption below. It is only half true, and the half that isn't matters.** The clipped header and the always-visible caption share an opening and then diverge: the header ends *"· rdeča črta = izbrani dan"* (the red line marks your selected day) while the caption explains the *bar colours*. So the ellipsis was hiding precisely the part that is **not** duplicated anywhere. Deleting the header would have lost it.

**The whole problem was one style.** `panelSubStyle` — `nowrap` + `overflow:hidden` + `text-overflow:ellipsis` — used only by the two regression cards. Every other card on the page already wraps. Dropping those three properties fixes **all four** clipped strings, because the stats badge and the footer inherit the same rule rather than having their own.

**Why wrapping rather than a tooltip or a deletion:**
- A `title` tooltip gives a phone user **nothing**, and 390 px is where the clipping is worst (123 px of 348 shown).
- Deleting would lose the unique clause.
- Wrapping needs no interaction and works on touch.
- It also fixes the *class*: the two regression cards now behave like every other card on the page.

**The chooser's ellipsis is deliberately untouched.** A truncated station name still identifies a station — an **identifier** may ellipsize; an **explanation** may not, because a reader cannot tell whether the hidden half matters.

| header height | scatter | year-round |
|---|---|---|
| desktop | 74 → 74 | 74 → **92** |
| 390 px | 100 → 100 | 100 → **153** |

Year-round subtitles wrap to two lines at desktop and three at 390 px; the scatter header does not grow. Zero clipped leaves remain at either width, and `align-items: baseline` still aligns the two columns cleanly.

**One follow-on was required, and it is a finding worth keeping.** The snapshot harness selected `stats_badge` by `[style*='white-space: nowrap']` — a **visual** property rather than a semantic one — so removing the clipping unhooked the capture entirely and the zero-match guard threw. Re-anchored to `[style*='letter-spacing: 0.08em']`, which returns the same element. The investigation also showed the field never captured `years_sig` as its comment claimed: `slice(-1)` always landed on the footer. Comment corrected.

**Snapshot byte-identical, no re-record** — wrapping changes layout, not text, exactly as predicted.

**A second cause of the blank-island symptom, documented:** exporting `VITE_DATASETTE_URL` trips the base-mismatch guard in `fixtures/install.ts`. Because `boot()` awaits `installFixtures()` before `render()`, the throw becomes a swallowed unhandled rejection and the island silently blanks — indistinguishable from T-5.56's bug but unrelated to it. Run `yarn fixtures:start` with that variable unset.

**Needs eyes on stage:** that both subtitles, the footer and the stats badge are fully readable at 390 px and desktop with no ellipsis; that the wrapped two-column header looks right rather than ragged; and that nothing below it reflowed.

Gates: typecheck 0 · typecheck:gate 0 allowlisted · yarn test 79 · snapshot:check byte-identical, 0 misses · pytest 75.
