### PR TITLE
T-6.14 — Slovarček pojmov: 34 terms explained below the methodology

### DIFF
--- a/code/ali-je-vroce-era5/AliJeVroceERA5.tsx
+++ b/code/ali-je-vroce-era5/AliJeVroceERA5.tsx
@@ -15,6 +15,7 @@ import { TodayTrendChart } from "./components/TodayTrendChart.tsx";
 //          panelHStyle, panelTitleStyle, panelSubStyle } from "./components/RegressionPanel.tsx";
 import { RegressionPanel, RegToolbar, RegScatterCard, RegYearRoundCard, FloatingStationChooser, useReg } from "./components/RegressionPanel.tsx";
 import { MethodologyPanel } from "./components/MethodologyPanel.tsx";
+import { GlossaryPanel } from "./components/GlossaryPanel.tsx";
 import type { SiteMeta } from "./types.ts";
 import { t, fmtNum, fmtInt, fmtMonthDay, fmtIsoDate } from "./i18n/format.ts";
 
@@ -282,6 +283,9 @@ function Dashboard(props: { meta: SiteMeta }) {
 
       {/* ── Methodology + trust furniture (T-6.1 / T-6.2) — foot of content ── */}
       <MethodologyPanel stations={era5Stations} />
+
+      {/* ── Glossary of terms (T-6.14) — sibling disclosure below the methodology ── */}
+      <GlossaryPanel />
 
     </div>
   );

--- a/code/ali-je-vroce-era5/components/GlossaryPanel.tsx
+++ b/code/ali-je-vroce-era5/components/GlossaryPanel.tsx
@@ -1,0 +1,59 @@
+// T-6.14 — the glossary of terms, a sibling disclosure below the methodology.
+//
+// Companion to MethodologyPanel: the methodology explains HOW the numbers are
+// made; this defines the TERMS a layperson cannot be expected to know. Same
+// disclosure treatment — a native <details>/<summary> inside a
+// <section class="methodology">, reusing the `.methodology-*` classes so the two
+// blocks read as one mechanism — closed by default because it is long reference
+// prose. Native <details>/<summary> is keyboard-operable and screen-reader
+// labelled with no ARIA of our own (matching the T-5.4a accessibility work).
+//
+// Self-contained by design (the operator intends to relocate the glossary to its
+// own menu page later): the term/definition CATALOGUE lives in i18n/glossary.ts
+// and the rendering lives here — a relocation, not a rewrite. The only Slovenian
+// hardcoded nowhere: the heading comes from t("glossary.summary") (sl.ts), the
+// entries from the glossary catalogue.
+//
+// ── Display order ────────────────────────────────────────────────────────────
+// The catalogue does NOT encode display order (a hardcoded Slovenian-alphabetical
+// array would be wrong under translation and mis-sorts č/š/ž). The list is sorted
+// HERE, at render time, with Intl.Collator(LOCALE) on the visible `term` label —
+// LOCALE ("sl-SI") is the single locale boundary in i18n/format.ts. A second
+// locale re-sorts itself for free.
+
+import { For } from "solid-js";
+import { glossary } from "../i18n/glossary.ts";
+import { t } from "../i18n/format.ts";
+import { LOCALE } from "../i18n/format.ts";
+
+// Locale-aware collation on the visible term. `numeric` keeps "ERA5" / "SPEI-3"
+// ordering sane; sensitivity "base" folds case so an acronym and a lower-case
+// concept interleave alphabetically rather than splitting into two blocks.
+const collator = new Intl.Collator(LOCALE, { numeric: true, sensitivity: "base" });
+
+// Sorted once — the catalogue is static.
+const ENTRIES = Object.values(glossary)
+  .slice()
+  .sort((a, b) => collator.compare(a.term, b.term));
+
+export function GlossaryPanel() {
+  return (
+    <section class="methodology sec-p">
+      <details class="methodology-details">
+        <summary class="methodology-summary">{t("glossary.summary")}</summary>
+        <div class="methodology-body">
+          <dl class="methodology-glossary">
+            <For each={ENTRIES}>
+              {(e) => (
+                <>
+                  <dt class="methodology-glossary-term">{e.term}</dt>
+                  <dd class="methodology-glossary-def">{e.def}</dd>
+                </>
+              )}
+            </For>
+          </dl>
+        </div>
+      </details>
+    </section>
+  );
+}

--- a/code/ali-je-vroce-era5/i18n/glossary.ts
+++ b/code/ali-je-vroce-era5/i18n/glossary.ts
@@ -1,0 +1,172 @@
+// T-6.14 (D-8) — the glossary term catalogue for the "Ali je vroče" ERA5 island.
+//
+// Companion to the methodology panel (MethodologyPanel.tsx / hero-content.ts):
+// the methodology explains HOW the numbers are made; this glossary defines the
+// TERMS a layperson cannot be expected to know (reanaliza, percentil, KDE,
+// Theil-Sen, SPEI, lapse-rate, …). Rendered by components/GlossaryPanel.tsx as a
+// <dl> inside a <details>, the same disclosure treatment as the methodology.
+//
+// Slovenian only for v1 (D-8). Wording is the operator's, reviewed and supplied
+// VERBATIM (T-6.14 Step 2); the definitions are condensed from the page's own
+// reviewed prose where it explains a term, and written from the operator's own
+// source where the page does not.
+//
+// ── i18n / l10n SHAPE (operator requirement) ──────────────────────────────────
+// Structurally parallel to i18n/sl.ts: an object keyed by a LANGUAGE-NEUTRAL,
+// ASCII identifier (`era5_land`, `theil_sen`, `stat_significance`) — NEVER the
+// Slovenian term itself. Both the displayed `term` and its `def` are catalogue
+// VALUES: a second locale swaps `term` + `def` and keeps every key. The
+// component hardcodes neither.
+//
+// ── DISPLAY ORDER ─────────────────────────────────────────────────────────────
+// The display order is NOT encoded here. GlossaryPanel.tsx sorts at render time
+// with `Intl.Collator(LOCALE)` on the `term` label (LOCALE = "sl-SI", the SOLE
+// locale boundary in i18n/format.ts), so Slovenian collation places č/š/ž
+// correctly and the order follows whatever locale renders — a hardcoded
+// alphabetical array would be wrong under translation. This object's own key
+// order is therefore irrelevant to the page; it is grouped acronyms-then-concepts
+// only for a human reading the source.
+
+export type GlossaryEntry = { readonly term: string; readonly def: string };
+
+export const glossary: Record<string, GlossaryEntry> = {
+  // ── Acronyms / named identifiers ──────────────────────────────────────────
+  era5_land: {
+    term: "ERA5-Land",
+    def: "Podatkovni niz, ki za vsak košček ozemlja in vsak dan oceni vreme z računalniškim modelom; izdeluje ga ECMWF, prostorska gostota je približno 9 km.",
+  },
+  era5t: {
+    term: "ERA5T",
+    def: "Predhodna, še ne dokončna različica teh podatkov za zadnjih ~6 dni; vrednosti se lahko še popravijo.",
+  },
+  ecmwf: {
+    term: "ECMWF",
+    def: "Evropski center za srednjeročne vremenske napovedi, ki izdeluje niz ERA5-Land.",
+  },
+  open_meteo: {
+    term: "Open-Meteo",
+    def: "Spletni arhiv, prek katerega stran dostopa do podatkov ERA5-Land.",
+  },
+  arso: {
+    term: "ARSO",
+    def: "Agencija Republike Slovenije za okolje, državna služba, ki upravlja slovensko mrežo merilnih postaj.",
+  },
+  wmo: {
+    term: "WMO",
+    def: "Svetovna meteorološka organizacija (World Meteorological Organization), ki določa mednarodne standarde, med njimi 30-letno klimatološko normalo.",
+  },
+  etccdi: {
+    term: "ETCCDI / ECA&D",
+    def: "Mednarodni strokovni skupini, ki sta poenotili definicije podnebnih kazalnikov (npr. kdaj šteje vroč dan).",
+  },
+  cds: {
+    term: "CDS",
+    def: "Copernicus Climate Data Store, uradni evropski portal za dostop do podatkov ERA5.",
+  },
+  spei: {
+    term: "SPEI",
+    def: "Standardiziran indeks padavin in evapotranspiracije; primerja vodno bilanco obdobja z zgodovinsko porazdelitvijo. Negativne vrednosti pomenijo bolj sušno kot običajno.",
+  },
+  spei_scales: {
+    term: "SPEI-3 / SPEI-30",
+    def: "Obdobje, čez katero se vodna bilanca sešteva: tri mesece oziroma trideset dni.",
+  },
+  kde: {
+    term: "KDE",
+    def: "Način, kako iz preteklih vrednosti narišemo gladko krivuljo porazdelitve, ki sledi dejanski obliki podatkov.",
+  },
+  nb_glm: {
+    term: "NB GLM (negativna binomska regresija)",
+    def: "Statistični model, s katerim ocenimo trend letnega števila (npr. vročih dni); primeren za števila, ki so bolj razpršena, kot bi bila naključno.",
+  },
+  temp_stats: {
+    term: "Tmax / Tmean / Tmin",
+    def: "Najvišja / povprečna / najnižja dnevna temperatura. Stran privzeto prikazuje Tmax.",
+  },
+  dwd: {
+    term: "DWD",
+    def: "Nemška državna vremenska služba, navedena kot primer drugačne izbire praga.",
+  },
+
+  // ── Concepts ──────────────────────────────────────────────────────────────
+  reanalysis: {
+    term: "reanaliza",
+    def: "Rekonstrukcija preteklega vremena: računalniški model združi meritve, satelitske posnetke in fiziko ozračja v enotno mrežo vrednosti brez vrzeli. Ni isto kot meritev posamezne postaje.",
+  },
+  percentile: {
+    term: "percentil",
+    def: "Pove, od kolikšnega deleža primerljivih dni v zgodovini je današnji dan toplejši. 90. percentil = topleje kot 90 % primerjalnih dni.",
+  },
+  anomaly: {
+    term: "odklon",
+    def: "Koliko je dan toplejši ali hladnejši od »normale« (referenčnega obdobja 1991–2020).",
+  },
+  climatological_normal: {
+    term: "klimatološka normala / referenčno obdobje",
+    def: "Dogovorjeno 30-letno obdobje (tu 1991–2020), s katerim primerjamo.",
+  },
+  grid_cell: {
+    term: "mrežna celica / mrežna ločljivost",
+    def: "Model ozemlje razdeli na kvadrate ~9 km; vrednost velja za cel kvadrat, zato ne ujame posebnosti, manjših od tega.",
+  },
+  lapse_rate: {
+    term: "višinski popravek (lapse-rate)",
+    def: "Ker mreža ne leži točno na višini postaje, vrednost prilagodimo za razliko v nadmorski višini po pravilu 6,5 °C na kilometer.",
+  },
+  distribution: {
+    term: "porazdelitev",
+    def: "Prikaz, kako pogosti so bili posamezni odkloni na ta dan v letu skozi vsa leta.",
+  },
+  hot_day_tropical_night: {
+    term: "vroč dan / tropska noč",
+    def: "Vroč dan: dnevna temperatura preseže izbrani prag (npr. 30 °C). Tropska noč: temperatura tudi ponoči ostane nad pragom (npr. 20 °C).",
+  },
+  absolute_threshold: {
+    term: "absolutni prag",
+    def: "Fiksna meja v °C, neodvisna od referenčnega obdobja.",
+  },
+  projection_2050: {
+    term: "projekcija do 2050",
+    def: "Groba ocena, kam bi trend vodil do leta 2050, če se nadaljuje po istem tempu; približek, ne napoved.",
+  },
+  precipitation: {
+    term: "padavine",
+    def: "Količina dežja, snega in druge vode, ki v danem obdobju pade na tla; merjena v milimetrih (mm) višine vode. Na strani so vrednosti v oknu seštete, ne povprečene.",
+  },
+  et0: {
+    term: "ET₀ (referenčna evapotranspiracija)",
+    def: "Koliko vode bi v danem obdobju izhlapelo z referenčne travnate površine; merilo »sušilne moči« ozračja, prav tako v mm. Višja vrednost pomeni bolj sušne razmere, ne več vode.",
+  },
+  theil_sen: {
+    term: "Theil-Sen",
+    def: "Način risanja trendne črte: izračuna naklon med vsemi pari let in vzame srednjega. Posamezno izjemno leto tako ne potegne črte za sabo.",
+  },
+  mann_kendall: {
+    term: "Mann-Kendall",
+    def: "Test, ali vrednosti skozi leta dosledno naraščajo ali upadajo. Ne predpostavlja oblike trenda, le vrstni red vrednosti.",
+  },
+  stat_significance: {
+    term: "statistična značilnost (p)",
+    def: "Kako verjetno bi videli tak vzorec, če trenda v resnici ne bi bilo. p = 0,05 pomeni, da bi se to zgodilo po naključju v enem primeru od dvajsetih. Ni verjetnost, da je trend resničen.",
+  },
+  confidence_interval: {
+    term: "interval zaupanja (95 %)",
+    def: "Razpon, znotraj katerega je prava vrednost naklona z 95-odstotno zanesljivostjo. Širši razpon pomeni bolj negotovo oceno.",
+  },
+  autocorrelation: {
+    term: "avtokorelacija / AR(1)",
+    def: "Zaporedna leta si niso povsem neodvisna: toplo leto pogosto sledi toplemu. To lahko lažno okrepi videz trenda, zato ga test popravi.",
+  },
+  median: {
+    term: "mediana",
+    def: "Srednja vrednost: polovica vrednosti je manjših, polovica večjih. Za razliko od povprečja je odporna na osamelce.",
+  },
+  temperature_inversion: {
+    term: "temperaturna inverzija",
+    def: "Ko je zrak v višini toplejši od zraka pri tleh — pogosto pozimi v kotlinah. Takrat višinski popravek slabše deluje.",
+  },
+  water_balance: {
+    term: "vodna bilanca",
+    def: "Razlika med padavinami in izhlapevanjem (P − ET₀). Negativna pomeni, da je izhlapelo več, kot je padlo.",
+  },
+} as const;

--- a/code/ali-je-vroce-era5/i18n/sl.ts
+++ b/code/ali-je-vroce-era5/i18n/sl.ts
@@ -572,6 +572,16 @@ export const sl = {
     bands_count: "{count, plural, one{# postaja} two{# postaji} few{# postaje} other{# postaj}}",
   },
 
+  // T-6.14 (D-8) — the glossary disclosure. Mirrors the methodology block exactly:
+  // MethodologyPanel renders a SINGLE heading — its <details> <summary> — with no
+  // separate section <h2>; `summary` here is the glossary's equivalent, rendered by
+  // GlossaryPanel with the same `.methodology-summary` treatment. The term/definition
+  // catalogue itself lives in i18n/glossary.ts (structurally parallel to this file),
+  // exactly as the methodology PROSE lives in hero-content.ts.
+  glossary: {
+    summary: "Slovarček pojmov",
+  },
+
   // Site meta (fallbacks)
   meta: {
     name: "Slovenija",

--- a/styles/era5.css
+++ b/styles/era5.css
@@ -219,6 +219,14 @@
 .methodology-bands-name  { color: var(--color-ink); }
 .methodology-bands-count { color: var(--color-ink-soft); text-align: right; padding-right: 0; }
 
+/* T-6.14 — glossary definition list inside its own <details>, reusing the
+   .methodology-* disclosure chrome. Term in the sans ink colour (like the band
+   name), definition in the softer body colour at the .methodology-p size, indented
+   under its term. */
+.methodology-glossary { margin: 4px 0 0; }
+.methodology-glossary-term { font-family: var(--font-sans); font-size: 14px; font-weight: 600; color: var(--color-ink); margin: 16px 0 2px; }
+.methodology-glossary-def  { font-family: var(--font-sans); font-size: 14px; line-height: 1.6; color: var(--color-ink-2); margin: 0 0 0 16px; }
+
 /* T-5.47 — the shared elevation-band dot (chooser, station tag, methodology swatch) and
    the inline metres run. `.station-dot` is an <i> element (see StationTag / Change 3). */
 .station-dot { display: inline-block; width: 10px; height: 10px; border-radius: 50%; margin-right: 6px; border: 1px solid rgba(14, 14, 12, 0.22); flex-shrink: 0; vertical-align: middle; }

--- a/tests/fixtures/snapshot.json
+++ b/tests/fixtures/snapshot.json
@@ -65,6 +65,7 @@
       "Era5Charts",
       "ErrorBoundary",
       "FloatingStationChooser",
+      "GlossaryPanel",
       "RegressionPanel",
       "Show",
       "SiteMeta",

--- a/tests/snapshot/sections.json
+++ b/tests/snapshot/sections.json
@@ -107,7 +107,8 @@
     "Suspense": "solid-js control flow.",
     "ErrorBoundary": "solid-js control flow (T-5.1). Wraps each section's fetch consumer so a failed fetch shows a visible SectionError instead of vanishing or blanking the page. Renders its children unchanged on success (no DOM wrapper), so it is transparent to the happy-path snapshot; the error branch is never exercised by the fixtures.",
     "EmptyState": "The shared no-data message (EmptyState.tsx, T-5.14), used as the <Show> fallback for the two SPEI sections. Renders the static common.no_data string only when a fetch resolved to no rows; every snapshot case has data, so this branch is never exercised by the fixtures and it captures no numbers of its own.",
-    "SiteMeta": "NOT a component. A type argument in createResource<SiteMeta> (AliJeVroceERA5.tsx:35) that the tag regex cannot distinguish from JSX. Classified explicitly rather than special-cased in the extractor, so the extractor stays dumb and auditable."
+    "SiteMeta": "NOT a component. A type argument in createResource<SiteMeta> (AliJeVroceERA5.tsx:35) that the tag regex cannot distinguish from JSX. Classified explicitly rather than special-cased in the extractor, so the extractor stays dumb and auditable.",
+    "GlossaryPanel": "T-6.14 glossary disclosure (GlossaryPanel.tsx), a sibling <details> below MethodologyPanel. Renders only STATIC term/definition prose from the i18n/glossary.ts catalogue plus the t(\"glossary.summary\") heading — no derived value, no number the snapshot must watch. Like the methodology PROSE (uncaptured per the capture-surface rule) and EmptyState, it captures nothing, so it is structural rather than covered."
   },
 
   "excluded": {},


### PR DESCRIPTION
Adds a **Slovarček pojmov** glossary below the methodology: 34 terms explained in plain Slovenian, in a collapsed disclosure matching the methodology's own treatment.

**Why.** The page uses *reanaliza*, ERA5-Land, ECMWF, *percentil*, *odklon*, KDE, Theil-Sen, Mann-Kendall, SPEI, *statistična značilnost* and more. A reader who does not know what a reanalysis **is** cannot judge anything else the page says. This is the companion to T-6.8 (the methodology cites nothing) — comprehension before verification.

**The finding that shaped it:** the trend machinery the page leans on hardest — **Theil-Sen, Mann-Kendall, confidence interval, statistical significance** — is named in labels everywhere and defined **nowhere**. A reader looking at `77 LET · P = 0,696` or `τ = 0,01` had nothing on the page to decode it with. Those entries are the reason the glossary exists.

**Definitions were derived from the page's own reviewed prose, not invented.** The investigation split every term into DERIVED (condensed from a cited line in `methodologyMarkdown`) or GAP (defined nowhere), and left the GAPs for the operator rather than filling them with plausible sentences. All 34 entries are the operator's approved wording (D-8).

**One entry is deliberately worded and should not be "clarified" later:** *statistična značilnost* ends with **"Ni verjetnost, da je trend resničen"** — correcting the common misreading. The year-round calendar encodes significance as opacity across 365 cells, so a reader who misunderstands this misreads the whole chart.

**Built for i18n from the start.** Terms are keyed by language-neutral ASCII ids (`era5_land`, `theil_sen`, `stat_significance`), with `term` and `def` as the translatable values — a second locale swaps values only. Ordering is **not** a hardcoded array: `Intl.Collator("sl-SI")` sorts at render time, so č/š/ž land correctly and a translation does not inherit Slovenian alphabetical order. Verified on-page that DOM order matches a fresh `sl-SI` sort.

**Self-contained by design.** A `GlossaryPanel` component reading an `i18n/glossary.ts` catalogue, mounted as a **sibling** section after `MethodologyPanel` rather than nested inside it — so the later move to a menu page is a relocation, not a rewrite. The markdown parser has only four block kinds (`lede | h | p | ul`) and no definition list, which is the same reason T-5.47's elevation legend is a component.

**Snapshot: one line.** `sections.json` asserts an exhaustive section set, so the guard fired as predicted — the entire diff is `+ "GlossaryPanel"` in `sections.structural`. No rendered value, no glossary text, no other section moved.

**Text integrity clean.** T-5.12's guard passes 5/5, plus an independent codepoint sweep of the new content: zero Cyrillic, Greek or invisible characters. U+2212 and U+2080 used to match the existing `P − ET₀`.

**Sea-level terms deliberately excluded** — that widget is gated out of v1 (D-10 / T-4.21), so those strings render nowhere.

**Cross-linking each first use in the methodology to its entry is a follow-up**, not this ticket: it needs anchor ids and edits to reviewed Slovenian prose.

**Needs eyes on stage:** that the glossary opens and reads like the methodology; that all 34 entries are correct character-for-character; and that it works at 390 px.

Gates: typecheck 0 · typecheck:gate 0 allowlisted · yarn test 79 · text-integrity 5/5 · snapshot:check byte-identical after the one-line structural re-record · pytest 75.
