### PR TITLE
T-6.15 — link methodology terms to their glossary entries

### DIFF
--- a/code/ali-je-vroce-era5/components/GlossaryPanel.tsx
+++ b/code/ali-je-vroce-era5/components/GlossaryPanel.tsx
@@ -31,10 +31,14 @@ import { LOCALE } from "../i18n/format.ts";
 // concept interleave alphabetically rather than splitting into two blocks.
 const collator = new Intl.Collator(LOCALE, { numeric: true, sensitivity: "base" });
 
-// Sorted once — the catalogue is static.
-const ENTRIES = Object.values(glossary)
+// Sorted once — the catalogue is static. Kept as [key, entry] pairs (not bare
+// values) so each <dt> can emit a stable, language-neutral id `gloss-${key}` from
+// the ASCII catalogue key — the anchor target the methodology prose links to
+// (T-6.15). The id keys off the key, NEVER the Slovenian `term`, so a translated
+// label cannot break an in-page link.
+const ENTRIES = Object.entries(glossary)
   .slice()
-  .sort((a, b) => collator.compare(a.term, b.term));
+  .sort((a, b) => collator.compare(a[1].term, b[1].term));
 
 export function GlossaryPanel() {
   return (
@@ -44,10 +48,10 @@ export function GlossaryPanel() {
         <div class="methodology-body">
           <dl class="methodology-glossary">
             <For each={ENTRIES}>
-              {(e) => (
+              {([key, entry]) => (
                 <>
-                  <dt class="methodology-glossary-term">{e.term}</dt>
-                  <dd class="methodology-glossary-def">{e.def}</dd>
+                  <dt id={`gloss-${key}`} class="methodology-glossary-term">{entry.term}</dt>
+                  <dd class="methodology-glossary-def">{entry.def}</dd>
                 </>
               )}
             </For>

--- a/code/ali-je-vroce-era5/i18n/hero-content.ts
+++ b/code/ali-je-vroce-era5/i18n/hero-content.ts
@@ -180,11 +180,11 @@ export const methodologyMarkdown = `*Kako nastanejo številke na strani »Ali je
 
 Ta stran prikazuje, kako topel je današnji dan v Sloveniji v primerjavi z zgodovino od leta 1950. Nekaj stvari, ki jih je dobro vedeti pri branju:
 
-- **Podatki niso meritve slovenskih vremenskih postaj (ARSO).** Prihajajo iz **reanalize ERA5-Land** (evropski podatkovni model, dostopen prek arhiva Open-Meteo). Reanaliza združi meritve, satelite in fizikalni model v enotno mrežo vrednosti. Zato **številke niso neposredno primerljive** z uradnimi objavami ARSO, ki temeljijo na meritvah postaj.
-- **Stran privzeto prikazuje najvišjo dnevno temperaturo (Tmax)** — »kako vroč je bil dan«. Povprečno in najnižjo temperaturo lahko izberete ročno, a nista privzeti (razlog je spodaj).
+- **Podatki niso meritve slovenskih vremenskih postaj ([ARSO](#gloss-arso)).** Prihajajo iz **[reanalize](#gloss-reanalysis) [ERA5-Land](#gloss-era5_land)** (evropski podatkovni model, dostopen prek arhiva [Open-Meteo](#gloss-open_meteo)). Reanaliza združi meritve, satelite in fizikalni model v enotno mrežo vrednosti. Zato **številke niso neposredno primerljive** z uradnimi objavami ARSO, ki temeljijo na meritvah postaj.
+- **Stran privzeto prikazuje najvišjo dnevno temperaturo ([Tmax](#gloss-temp_stats))** — »kako vroč je bil dan«. Povprečno in najnižjo temperaturo lahko izberete ročno, a nista privzeti (razlog je spodaj).
 - **Vsaka postaja je višinsko popravljena.** Ker mreža modela ne leži točno na višini postaje, vrednosti prilagodimo za razliko v nadmorski višini. **Za Kredarico je ta popravek −7,85 °C** — daleč največji na strani. Podrobnosti so spodaj; navajamo jih odkrito, ker gre za velik poseg v prikazano vrednost.
 - **»Slovenija« pomeni povprečje 18 postaj**, ne ene same nacionalne meritve. Postaje segajo od morske gladine (10 m) do Kredarice (2514 m).
-- **Referenčno obdobje za odklone je 1991–2020** (veljavna klimatološka norma WMO). Ker je to razmeroma toplo obdobje, se velik del zapisov 1950–2026 prikaže kot negativni odklon.
+- **Referenčno obdobje za [odklone](#gloss-anomaly) je 1991–2020** (veljavna [klimatološka norma](#gloss-climatological_normal) [WMO](#gloss-wmo)). Ker je to razmeroma toplo obdobje, se velik del zapisov 1950–2026 prikaže kot negativni odklon.
 
 Podroben tehnični opis sledi spodaj.
 
@@ -192,11 +192,11 @@ Podroben tehnični opis sledi spodaj.
 
 ## Vir podatkov
 
-Stran uporablja **reanalizo ERA5-Land**, dostopano prek **arhivskega API-ja Open-Meteo** (ne neposredno prek ECMWF/CDS). ERA5-Land je globalni reanalizni niz Evropskega centra za srednjeročne vremenske napovedi (ECMWF) z mrežno ločljivostjo približno 9 km.
+Stran uporablja **reanalizo ERA5-Land**, dostopano prek **arhivskega API-ja Open-Meteo** (ne neposredno prek [ECMWF](#gloss-ecmwf)/[CDS](#gloss-cds)). ERA5-Land je globalni reanalizni niz Evropskega centra za srednjeročne vremenske napovedi (ECMWF) z [mrežno ločljivostjo](#gloss-grid_cell) približno 9 km.
 
 Reanaliza ni isto kot meritev postaje. Je rekonstrukcija preteklega vremena, ki jo model ustvari z asimilacijo številnih virov opazovanj. Prednost je enotna, prostorsko in časovno polna pokritost brez vrzeli; slabost je, da posamezna mrežna celica ne ujame lokalnih posebnosti (npr. mestnega toplotnega otoka ali natančne mikrolokacije postaje).
 
-Zadnjih ~6 dni prihaja iz predhodne različice reanalize (ERA5T), zato se te vrednosti lahko še spremenijo.
+Zadnjih ~6 dni prihaja iz predhodne različice reanalize ([ERA5T](#gloss-era5t)), zato se te vrednosti lahko še spremenijo.
 
 Za današnje in najnovejše vrednosti, kjer reanaliza še ni na voljo, stran uporabi napoved Open-Meteo. Takšna vrednost je na strani označena z **»napoved«**; reanalizne vrednosti oznake nimajo.
 
@@ -204,7 +204,7 @@ Za današnje in najnovejše vrednosti, kjer reanaliza še ni na voljo, stran upo
 
 Stran zajema **18 lokacij** po Sloveniji. Za vsako je vrednost vzeta iz mrežne celice ERA5-Land nad njo. Nabor postaj sega od nižin do visokogorja — med drugim Koper (blizu morske gladine, ~10 m), Postojna (549 m), Rateče (864 m) in Kredarica (2514 m). Celoten razpon nadmorskih višin je **10–2514 m**.
 
-## Višinski popravek (lapse-rate)
+## [Višinski popravek](#gloss-lapse_rate) (lapse-rate)
 
 Mrežna celica ERA5-Land redko leži točno na nadmorski višini postaje. Da bi vrednosti ustrezale višini postaje in ne višini mrežne celice, vsako popravimo s **fiksno stopnjo 6,5 °C na kilometer** razlike med višino postaje in višino mrežne celice. To je standardna vrednost povprečne stopnje ohlajanja ozračja z višino.
 
@@ -213,7 +213,7 @@ Za 17 od 18 postaj je ta popravek majhen. **Za Kredarico je velik: −7,85 °C.*
 Odkrito navajamo njegove omejitve:
 
 - Popravljene vrednosti ERA5-Land za Kredarico smo **primerjali z meritvami ARSO in so bile blizu.** A šlo je za primerjavo, **ne za sistematično validacijo** — ni bila opravljena analiza pristranskosti po mesecih.
-- Fiksna stopnja 6,5 °C/km je **povprečje za prosto ozračje.** Dejanska prizemna stopnja nad gorskim pobočjem se spreminja s sezono in se lahko **splošči ali celo obrne pri zimskih temperaturnih inverzijah.** Popravek je torej lahko dober v letnem povprečju, a sistematično odstopa v posameznih mesecih (predvsem pozimi).
+- Fiksna stopnja 6,5 °C/km je **povprečje za prosto ozračje.** Dejanska prizemna stopnja nad gorskim pobočjem se spreminja s sezono in se lahko **splošči ali celo obrne pri zimskih [temperaturnih inverzijah](#gloss-temperature_inversion).** Popravek je torej lahko dober v letnem povprečju, a sistematično odstopa v posameznih mesecih (predvsem pozimi).
 - Empirični popravek po postaji in mesecu bi bil boljša dolgoročna rešitev; zaenkrat ni izveden.
 
 ## Katera temperatura je privzeta
@@ -238,25 +238,25 @@ Odkloni (koliko je dan topel »glede na normalo«) se merijo proti **referenčne
 
 Ena posledica je pomembna za branje: ker je 1991–2020 razmeroma toplo obdobje, se **velik del zapisov 1950–2026 prikaže kot negativni odklon.** To ni napaka, temveč posledica primerjave s toplo sodobno normalo.
 
-**Izjema — SPEI (suša):** indeks suše SPEI je ločen in umerjen na obdobje **1950–1980**, ne 1991–2020. Absolutni pragovi (npr. za vroče dneve in tropske noči) na referenčno obdobje niso vezani.
+**Izjema — [SPEI](#gloss-spei) (suša):** indeks suše SPEI je ločen in umerjen na obdobje **1950–1980**, ne 1991–2020. [Absolutni pragovi](#gloss-absolute_threshold) (npr. za vroče dneve in tropske noči) na referenčno obdobje niso vezani.
 
 ## Porazdelitev in percentil
 
-Za vsak dan v letu stran prikaže **porazdelitev** preteklih vrednosti (kako pogosti so bili posamezni odkloni) in **percentil** današnje vrednosti (topleje od kolikšnega deleža primerjalnih dni).
+Za vsak dan v letu stran prikaže **[porazdelitev](#gloss-distribution)** preteklih vrednosti (kako pogosti so bili posamezni odkloni) in **[percentil](#gloss-percentile)** današnje vrednosti (topleje od kolikšnega deleža primerjalnih dni).
 
-- Porazdelitev je **empirična ocena gostote (KDE)** — sledi dejanski obliki podatkov — ne simetrična zvonasta (Gaussova) krivulja. Temperaturne porazdelitve so pogosto nesimetrične, zato bi Gaussova krivulja napačno prikazala repe, ravno tam, kjer se presoja »kako izjemen je današnji dan«.
+- Porazdelitev je **empirična ocena gostote ([KDE](#gloss-kde))** — sledi dejanski obliki podatkov — ne simetrična zvonasta (Gaussova) krivulja. Temperaturne porazdelitve so pogosto nesimetrične, zato bi Gaussova krivulja napačno prikazala repe, ravno tam, kjer se presoja »kako izjemen je današnji dan«.
 - Nacionalna krivulja je **povprečje 18 krivulj posameznih postaj**, ne skupni bazen vzorcev — s čimer ohrani pomen »povprečja 18 postaj«.
 - Percentil je **pravi empirični percentil**, izračunan iz te krivulje (integral gostote do današnje vrednosti), ne približek iz barvnega pasu.
 
-Primerjalni vzorec za vsak koledarski dan je **združeno okno ±7 dni** čez vsa leta — tako ima vsak dan dovolj gost in stabilen vzorec. **Isto okno ±7 dni** uporablja tudi letni trend: vsaka letna točka na grafu trenda je **povprečje** vrednosti v tem oknu za posamezno leto — pri padavinah in ET₀ pa **vsota**, saj sta to globini v mm in ima smisel le seštevek. **29. februar** se pri tem pridruži oknu 28. februarja (redki prestopni dnevi se ne obravnavajo kot ločen, statistično šumeč dan). Objavljena vrednost povsod uporablja okno ±7 dni; v panelu z analizo trendov lahko bralec izbere tudi ožje ali širše okno, kar velja le za tisti prikaz.
+Primerjalni vzorec za vsak koledarski dan je **združeno okno ±7 dni** čez vsa leta — tako ima vsak dan dovolj gost in stabilen vzorec. **Isto okno ±7 dni** uporablja tudi letni trend: vsaka letna točka na grafu trenda je **povprečje** vrednosti v tem oknu za posamezno leto — pri [padavinah](#gloss-precipitation) in [ET₀](#gloss-et0) pa **vsota**, saj sta to globini v mm in ima smisel le seštevek. **29. februar** se pri tem pridruži oknu 28. februarja (redki prestopni dnevi se ne obravnavajo kot ločen, statistično šumeč dan). Objavljena vrednost povsod uporablja okno ±7 dni; v panelu z analizo trendov lahko bralec izbere tudi ožje ali širše okno, kar velja le za tisti prikaz.
 
 ## Pragovi za »vroče«
 
-Štetje vročih dni in tropskih noči uporablja **stroge pragove (\`>\`, ne \`≥\`).** To je usklajeno s standardom ETCCDI/ECA&D (medtem ko npr. nemški DWD uporablja \`≥\`). Standard je dejansko sporen; izbrali smo \`>\`. Sprememba na \`≥\` bi premaknila štetje vsakega mejnega dne, zato je izbira zapisana zavestno.
+Štetje [vročih dni in tropskih noči](#gloss-hot_day_tropical_night) uporablja **stroge pragove (\`>\`, ne \`≥\`).** To je usklajeno s standardom [ETCCDI/ECA&D](#gloss-etccdi) (medtem ko npr. nemški [DWD](#gloss-dwd) uporablja \`≥\`). Standard je dejansko sporen; izbrali smo \`>\`. Sprememba na \`≥\` bi premaknila štetje vsakega mejnega dne, zato je izbira zapisana zavestno.
 
 ## Trend vročih dni in tropskih noči
 
-Letni trend na grafih vročih dni in tropskih noči je **model negativne binomske regresije (NB GLM)** čez letno število — primeren za štetne podatke z večjo razpršenostjo od Poissonove. Gre za **približek**, ne za dokončno napoved: prikazana stopnja rasti in projekcija do leta 2050 sta odvisni od izbranega praga in dolžine zaporedja.
+Letni trend na grafih vročih dni in tropskih noči je **model negativne binomske regresije ([NB GLM](#gloss-nb_glm))** čez letno število — primeren za štetne podatke z večjo razpršenostjo od Poissonove. Gre za **približek**, ne za dokončno napoved: prikazana stopnja rasti in [projekcija do leta 2050](#gloss-projection_2050) sta odvisni od izbranega praga in dolžine zaporedja.
 
 **Trenda ne prikažemo, kadar mu ne moremo zaupati.** Za nekatere kombinacije (redki dogodki, skoraj ravna letna vrsta) statistični model ne da zanesljivega rezultata — ne skonvergira ali pa ocena njegove negotovosti ni veljavna. V takih primerih trenda **ne objavimo** (letno štetje ostane prikazano), namesto da bi navedli navidezno natančno, a nezanesljivo številko. Enako velja, kadar je premalo let s podatki (potrebnih je vsaj 10). To je isto načelo kot pri indeksu suše SPEI: raje odklonimo objavo kot da objavimo negotovo vrednost.
 

--- a/styles/era5.css
+++ b/styles/era5.css
@@ -204,6 +204,25 @@
 .methodology-body a      { color: var(--color-accent); }
 .methodology-body code   { font-family: var(--font-mono); font-size: 0.9em; background: var(--color-paper-2); padding: 1px 4px; border-radius: 4px; }
 
+/* T-6.15 — glossary term links inside the methodology prose. Targeted by href
+   prefix so ONLY the in-page `#gloss-…` anchors get the restrained treatment (the
+   contact mailto keeps the accent above). Body ink + a dotted underline reads as a
+   "defined term" cue rather than a blue link, so a paragraph with several linked
+   terms stays annotated, not littered. Hover AND focus-visible reveal the accent —
+   focus-visible is deliberately kept so a keyboard user can see which term is
+   focused; that is the one case where restraint must not win. */
+.methodology-body a[href^="#gloss-"] {
+  color: inherit;
+  text-decoration: underline dotted;
+  text-decoration-color: var(--color-ink-soft);
+  text-underline-offset: 3px;
+}
+.methodology-body a[href^="#gloss-"]:hover,
+.methodology-body a[href^="#gloss-"]:focus-visible {
+  color: var(--color-accent);
+  text-decoration-color: var(--color-accent);
+}
+
 .methodology-furniture {
   font-family: var(--font-mono); font-size: 11px; letter-spacing: 0.04em; color: var(--color-ink-soft);
   margin: 14px 0 0; display: flex; flex-wrap: wrap; align-items: center; gap: 8px;
@@ -224,7 +243,12 @@
    name), definition in the softer body colour at the .methodology-p size, indented
    under its term. */
 .methodology-glossary { margin: 4px 0 0; }
-.methodology-glossary-term { font-family: var(--font-sans); font-size: 14px; font-weight: 600; color: var(--color-ink); margin: 16px 0 2px; }
+/* T-6.15 — each term is an anchor target for the methodology links. A closed
+   <details> auto-opens on fragment navigation (Baseline 2024); scroll-margin keeps
+   the landed term clear of the viewport top, and :target briefly tints the entry the
+   reader jumped to so the jump is legible. */
+.methodology-glossary-term { font-family: var(--font-sans); font-size: 14px; font-weight: 600; color: var(--color-ink); margin: 16px 0 2px; scroll-margin-top: 16px; }
+.methodology-glossary-term:target { background: var(--color-paper-2); border-radius: 4px; box-shadow: 0 0 0 4px var(--color-paper-2); }
 .methodology-glossary-def  { font-family: var(--font-sans); font-size: 14px; line-height: 1.6; color: var(--color-ink-2); margin: 0 0 0 16px; }
 
 /* T-5.47 — the shared elevation-band dot (chooser, station tag, methodology swatch) and


### PR DESCRIPTION
Links the first use of each glossary term in the methodology to its entry in the **Slovarček pojmov** (T-6.14).

**Anchors, not tooltips — and this is the design decision, not a detail.** There is no hover on touch, and the methodology is long prose read on phones as much as desktops. A `title` tooltip would give a phone user nothing. So the link works on its own: tapping a term jumps to its entry, and any hover treatment is an enhancement on top. This is the third design here decided by that rule — T-5.60 chose wrapping over a tooltip, T-5.47 put elevation metres inline (D-48).

**The hard part was that the glossary is collapsed by default**, and a fragment link into a closed `<details>` might do nothing. **This was tested, not assumed** — twice: on a minimal HTTP-served harness, then on the real rendered methodology by clicking *ERA5T* in the prose. Measured: `details.open` went **false → true**, the entry scrolled to **top = 16px** (honouring `scroll-margin-top`), and `:target` fired. That is the Baseline-2024 auto-expand behaviour, so **no JavaScript and no `hidden="until-found"`** are needed. Chromium was the only engine drivable in-session; Safari 17.2+ and Firefox 130+ rest on Baseline support, and the degradation is graceful rather than an error.

**Anchor ids key off the ASCII catalogue key** — `#gloss-reanalysis`, `#gloss-theil_sen` — never the Slovenian label, which a translation would break. `GlossaryPanel` moved from `Object.values` to `Object.entries` to emit them.

**Restrained styling rather than blue words.** The generic `.methodology-body a` rule would have made every linked term accent-blue, littering the prose. Glossary links are targeted by href prefix: body ink with a dotted underline — the conventional "defined term" cue — going accent on hover **and `:focus-visible`**, so a keyboard user can still see what is focused.

**Inflection handled properly.** Slovenian inflects, so the link wraps the surface form **as it appears** while pointing at the nominative entry: *reanalize* → `#gloss-reanalysis`, *odklone* → `#gloss-anomaly`, *temperaturnih inverzijah* → `#gloss-temperature_inversion*, *mrežno ločljivostjo* → `#gloss-grid_cell`. **No prose word was changed** to match a glossary label.

**26 of 34 terms have a first use in the methodology.** The other eight — Theil-Sen, Mann-Kendall, statistična značilnost, interval zaupanja, AR(1), mediana, vodna bilanca, SPEI-3/-30 — appear only in chart labels and panel UI, so they get no link rather than an invented home.

**Three editorial calls, one overruling the session's recommendation.** `lapse_rate` links the **section heading** rather than the participle *"višinsko popravljena"* at its strict first use: a reader tapping an inflected verb form and landing on an entry titled *"višinski popravek"* has to reverse-engineer the connection. Strict first use is a proxy for where a reader wants the link, not the goal itself. Also: `klimatološka norma` as the headword, and *"vročih dni in tropskih noči"* at the line where the counting concept is introduced rather than a passing timezone aside.

**Dual-commit under D-23**, applied to `METHODOLOGY.md` by **content match** rather than line number, since that file carries a title and provenance block that shift its numbering. Verified: the sorted `#gloss-…` list is **byte-identical across both files, 26 = 26**. The known T-5.61 divergence (a missing *Znane omejitve* bullet) contains no first use, so none of those lines were touched and the divergence was not silently reconciled.

**Snapshot byte-identical** and the structural section guard did not fire — no new mount, only ids and inline markup inside already-classified components.

**Needs eyes on stage:** that tapping a term **on a real phone** opens the glossary at the right entry; that the dotted links read as restrained in the real IBM Plex Sans face — particularly the nine terms across five bullets in *Na kratko*, which is dense by nature and may still be worth relocating; and that no Slovenian changed.

Gates: typecheck 0 · typecheck:gate 0 allowlisted · yarn test 79 · text-integrity 5/5 · snapshot:check byte-identical, 0 misses · pytest 75.
