### PR TITLE
T-5.62 — the page named a method it does not run: drop TFPW from six labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ reachable the page renders empty**, which looks like a build failure but is not.
 ### Charts
 
 - **Today status** — national temperature percentile vs ERA5 history (1950–present), with last-7-days strip
-- **Regression chart** — per-station Theil-Sen trend + TFPW Mann-Kendall significance, with projection to 2050
+- **Regression chart** — per-station Theil-Sen trend + Mann-Kendall significance, with projection to 2050
 - **Season heatmap** — seasonal anomaly calendar across all stations
 - **SPEI heatmap + drought trend** — standardised precipitation-evapotranspiration index, per station and season
 - **Tropical days / nights** — annual event counts above a user-chosen threshold, fitted with Negative Binomial GLM

--- a/code/ali-je-vroce-era5/api.ts
+++ b/code/ali-je-vroce-era5/api.ts
@@ -742,7 +742,7 @@ async function buildRegressionResult(
     },
     baseline,
     stats: {
-      method: "Theil-Sen + TFPW MK", trend10: r.trend10, metric: r.trend10,
+      method: "Theil-Sen + MK", trend10: r.trend10, metric: r.trend10,
       metric_lbl: "trend / 10 let", p_val: r.p_val,
       direction: r.trend10 >= 0 ? "up" : "down",
       // T-5.51 M3 — unit derived per variable. NOTE: chg_str is still DEAD (nothing
@@ -900,7 +900,7 @@ export async function fetchCalendar(
   );
   // T-5.51 M2 — unit derived per variable (mm for precip/ET₀), feeds the year-round
   // tooltip "{trend} {unit}/desetletje".
-  return { loc, var: variable, unit: varUnit(variable), method_label: "Theil-Sen + TFPW MK", rows };
+  return { loc, var: variable, unit: varUnit(variable), method_label: "Theil-Sen + MK", rows };
 }
 
 // ── fetchAnnualTrend ───────────────────────────────────────────────────────────

--- a/code/ali-je-vroce-era5/components/RegressionPanel.tsx
+++ b/code/ali-je-vroce-era5/components/RegressionPanel.tsx
@@ -338,7 +338,7 @@ export function RegToolbar() {
           RegressionParams.corr/method, but fetchRegression reads the precomputed
           annual_trend table and ignores both; the values never reached a request or
           computation. The controls also carried false labels: the data is always
-          Theil-Sen + TFPW MK with elevation correction baked in (D-5), so "OLS" and
+          Theil-Sen + MK with elevation correction baked in (D-5), so "OLS" and
           the toggle promised a switch that never happened. The genuine method/colour
           readouts (stats.method footer, precip-vs-temp trend colour) are sourced
           elsewhere and are untouched. */}

--- a/code/ali-je-vroce-era5/i18n/references.ts
+++ b/code/ali-je-vroce-era5/i18n/references.ts
@@ -99,9 +99,10 @@ export const references: Record<string, ReferenceEntry> = {
   //
   // ⚠ yue_wang cites Yue & Wang (2004) — the effective-sample-size variance
   // correction the code actually runs (pymannkendall.yue_wang_modification_test).
-  // The prose label "Yue-Wang TFPW" in reg.explain_reg is a DIFFERENT method
-  // (trend-free pre-whitening, Yue/Pilon/Phinney/Cavadias 2002); that mislabel is
-  // its own fix (T-5.62) and is deliberately NOT papered over here.
+  // T-5.62 removed the earlier "Yue-Wang TFPW" mislabel from reg.explain_reg; the
+  // footer now reads "Yue-Wang Mann-Kendall". Do NOT reintroduce "TFPW" — that is a
+  // DIFFERENT method (trend-free pre-whitening, Yue/Pilon/Phinney/Cavadias 2002)
+  // that this pipeline never ran.
   theil_sen: {
     desc: "Izvirni članek o Theil-Senovi oceni naklona trenda.",
     cite: "Sen, P. K. (1968), Journal of the American Statistical Association 63, 1379–1389",

--- a/code/ali-je-vroce-era5/i18n/sl.ts
+++ b/code/ali-je-vroce-era5/i18n/sl.ts
@@ -230,7 +230,7 @@ export const sl = {
     explain: "Vsaka pika je povprečna vrednost ({source}) v ±7-dnevnem oknu okoli tega datuma za vsako leto od {yearMin}. Trend Theil-Sen je {trend} °C/desetletje ({sig}). Po tem tempu projekcija kaže {proj2050} °C do leta 2050. Zasenčeni pas je 95% interval zaupanja za nagib.",
     explain_source_station: "lapsno popravljene dnevne najvišje temperature na postaji {station}",
     explain_source_nat: "nacionalne povprečne dnevne najvišje temperature vseh {count, plural, one{# postaje} two{# postaj} few{# postaj} other{# postaj}}",
-    foot: "Theil-Sen + TFPW MK: {trend} °C/desetletje · {sig} · τ = {tau} · 95% CI · {count, plural, one{# leto} two{# leti} few{# leta} other{# let}}",
+    foot: "Theil-Sen + MK: {trend} °C/desetletje · {sig} · τ = {tau} · 95% CI · {count, plural, one{# leto} two{# leti} few{# leta} other{# let}}",
     tooltip_annual: "<b>{x}</b>: {y} °C",
     tooltip_milestone: "<b>{x}</b>: {y} °C <em>(projekcija)</em>",
     a11y: "Letni trend najvišjih temperatur okoli izbranega datuma z linijo Theil-Sen, 95-odstotnim intervalom zaupanja in projekcijo do leta 2050. Vsaka pika je vrednost enega leta.",
@@ -276,8 +276,8 @@ export const sl = {
 
     // T-5.51 (E3) — precip/ET₀ read raw columns with NO elevation correction, so the
     // "· nadmorska korekcija" clause is dropped for them (it is simply false there).
-    explain_reg: "Theil-Sen regresija + Yue-Wang TFPW Mann-Kendall test · ERA5-Land · nadmorska korekcija",
-    explain_reg_nocorr: "Theil-Sen regresija + Yue-Wang TFPW Mann-Kendall test · ERA5-Land",
+    explain_reg: "Theil-Sen regresija + Yue-Wang Mann-Kendall test · ERA5-Land · nadmorska korekcija",
+    explain_reg_nocorr: "Theil-Sen regresija + Yue-Wang Mann-Kendall test · ERA5-Land",
     // T-5.51 (E2) — the calendar colour legend, three-way; only the colour clause
     // varies. "segrevanje" (was "ogrevanje") unifies with the reg.warming legend word.
     explain_cal: "Trend na desetletje za vsak dan v letu · rdeča = segrevanje · modra = ohlajanje · prosojnost = statistična značilnost",
@@ -325,7 +325,7 @@ export const sl = {
     verdict_warming: "Sto let segrevanja za <em>{t100} {unit}</em> – pri trenutnem tempu vsaka <em>{yrs} let</em> doda eno stopinjo.",
     verdict_cooling: "Sto let ohlajanja za <em>{t100} {unit}</em> – pri trenutnem tempu vsaka <em>{yrs} let</em> odšteje eno stopinjo.",
     verdict_none: "Na ta dan v letu ni zaznati trenda.",
-    method_theilsen: "Theil-Sen + TFPW Mann-Kendall",
+    method_theilsen: "Theil-Sen + Mann-Kendall",
 
     cat_catastrophic: "Katastrofalno",
     cat_extreme: "Ekstremno",

--- a/tests/fixtures/snapshot.json
+++ b/tests/fixtures/snapshot.json
@@ -15856,7 +15856,7 @@
         "loc": "Ljubljana",
         "variable": "temperature_max",
         "unit": "°C",
-        "method_label": "Theil-Sen + TFPW MK",
+        "method_label": "Theil-Sen + MK",
         "n_rows": 365,
         "rows": {
           "01-01": [
@@ -26439,7 +26439,7 @@
         "loc": "Kredarica",
         "variable": "temperature_max",
         "unit": "°C",
-        "method_label": "Theil-Sen + TFPW MK",
+        "method_label": "Theil-Sen + MK",
         "n_rows": 365,
         "rows": {
           "01-01": [
@@ -33247,7 +33247,7 @@
         "rendered": {
           "title": "Najvišje temperature v Sloveniji okoli 21. jul. · 1950–2026 · trend s projekcijo do 2050",
           "explain": "Vsaka pika je povprečna vrednost (nacionalne povprečne dnevne najvišje temperature vseh 18 postaj) v ±7-dnevnem oknu okoli tega datuma za vsako leto od 1950. Trend Theil-Sen je +0,45 °C/desetletje (p < 0,001). Po tem tempu projekcija kaže 27,2 °C do leta 2050. Zasenčeni pas je 95% interval zaupanja za nagib.",
-          "footer": "Theil-Sen + TFPW MK: +0,45 °C/desetletje · p < 0,001 · τ = 0,295 · 95% CI · 77 let",
+          "footer": "Theil-Sen + MK: +0,45 °C/desetletje · p < 0,001 · τ = 0,295 · 95% CI · 77 let",
           "current_year_plotline": {
             "value": 2026,
             "label": "2026",
@@ -33703,11 +33703,11 @@
           "day_label": "21. jul.",
           "title": "Ljubljana 299 m · Najvišja temperatura",
           "subtitle": "21. jul.",
-          "stats_badge": "Theil-Sen + TFPW MK · τ = 0,34",
+          "stats_badge": "Theil-Sen + MK · τ = 0,34",
           "total_change": "+4,35°C",
           "total_change_color": "rgb(204, 34, 34)",
           "footer": [
-            "Theil-Sen regresija + Yue-Wang TFPW Mann-Kendall test · ERA5-Land · nadmorska korekcija"
+            "Theil-Sen regresija + Yue-Wang Mann-Kendall test · ERA5-Land · nadmorska korekcija"
           ]
         },
         "charts": [
@@ -34407,7 +34407,7 @@
           "paragraphs": [
             "Podaljšani poletni vročinski valovi presegajo hladilne zmogljivosti mesta. Hudourniške poplave iz okrepljenih alpskih padavin večkrat ogrozijo nizko ležečo kotlino.",
             "Sto let segrevanja za +5,65 °C – pri trenutnem tempu vsaka 17,7 let doda eno stopinjo.",
-            "Theil-Sen + TFPW Mann-Kendall"
+            "Theil-Sen + Mann-Kendall"
           ],
           "stats": [
             "Mestni toplotni otok — poletni vročinski stres in tveganje hudourniških poplav v Ljubljanski kotlini",
@@ -36773,7 +36773,7 @@
         "rendered": {
           "title": "Najvišje temperature na postaji Ljubljana okoli 21. jul. · 1950–2026 · trend s projekcijo do 2050",
           "explain": "Vsaka pika je povprečna vrednost (lapsno popravljene dnevne najvišje temperature na postaji Ljubljana) v ±7-dnevnem oknu okoli tega datuma za vsako leto od 1950. Trend Theil-Sen je +0,56 °C/desetletje (p < 0,001). Po tem tempu projekcija kaže 28,4 °C do leta 2050. Zasenčeni pas je 95% interval zaupanja za nagib.",
-          "footer": "Theil-Sen + TFPW MK: +0,56 °C/desetletje · p < 0,001 · τ = 0,335 · 95% CI · 77 let",
+          "footer": "Theil-Sen + MK: +0,56 °C/desetletje · p < 0,001 · τ = 0,335 · 95% CI · 77 let",
           "current_year_plotline": {
             "value": 2026,
             "label": "2026",
@@ -37229,11 +37229,11 @@
           "day_label": "21. jul.",
           "title": "Ljubljana 299 m · Najvišja temperatura",
           "subtitle": "21. jul.",
-          "stats_badge": "Theil-Sen + TFPW MK · τ = 0,34",
+          "stats_badge": "Theil-Sen + MK · τ = 0,34",
           "total_change": "+4,35°C",
           "total_change_color": "rgb(204, 34, 34)",
           "footer": [
-            "Theil-Sen regresija + Yue-Wang TFPW Mann-Kendall test · ERA5-Land · nadmorska korekcija"
+            "Theil-Sen regresija + Yue-Wang Mann-Kendall test · ERA5-Land · nadmorska korekcija"
           ]
         },
         "charts": [
@@ -37933,7 +37933,7 @@
           "paragraphs": [
             "Podaljšani poletni vročinski valovi presegajo hladilne zmogljivosti mesta. Hudourniške poplave iz okrepljenih alpskih padavin večkrat ogrozijo nizko ležečo kotlino.",
             "Sto let segrevanja za +5,65 °C – pri trenutnem tempu vsaka 17,7 let doda eno stopinjo.",
-            "Theil-Sen + TFPW Mann-Kendall"
+            "Theil-Sen + Mann-Kendall"
           ],
           "stats": [
             "Mestni toplotni otok — poletni vročinski stres in tveganje hudourniških poplav v Ljubljanski kotlini",
@@ -40299,7 +40299,7 @@
         "rendered": {
           "title": "Najvišje temperature na postaji Kredarica okoli 21. jul. · 1950–2026 · trend s projekcijo do 2050",
           "explain": "Vsaka pika je povprečna vrednost (lapsno popravljene dnevne najvišje temperature na postaji Kredarica) v ±7-dnevnem oknu okoli tega datuma za vsako leto od 1950. Trend Theil-Sen je +0,36 °C/desetletje (p < 0,001). Po tem tempu projekcija kaže 13,4 °C do leta 2050. Zasenčeni pas je 95% interval zaupanja za nagib.",
-          "footer": "Theil-Sen + TFPW MK: +0,36 °C/desetletje · p < 0,001 · τ = 0,254 · 95% CI · 77 let",
+          "footer": "Theil-Sen + MK: +0,36 °C/desetletje · p < 0,001 · τ = 0,254 · 95% CI · 77 let",
           "current_year_plotline": {
             "value": 2026,
             "label": "2026",
@@ -40755,11 +40755,11 @@
           "day_label": "21. jul.",
           "title": "Kredarica 2514 m · Najvišja temperatura",
           "subtitle": "21. jul.",
-          "stats_badge": "Theil-Sen + TFPW MK · τ = 0,25",
+          "stats_badge": "Theil-Sen + MK · τ = 0,25",
           "total_change": "+2,74°C",
           "total_change_color": "rgb(204, 34, 34)",
           "footer": [
-            "Theil-Sen regresija + Yue-Wang TFPW Mann-Kendall test · ERA5-Land · nadmorska korekcija"
+            "Theil-Sen regresija + Yue-Wang Mann-Kendall test · ERA5-Land · nadmorska korekcija"
           ]
         },
         "charts": [
@@ -41459,7 +41459,7 @@
           "paragraphs": [
             "Popolna izguba Triglavskega ledenika — narodni simbol in vir savinjskih rek. Propad alpskega ekosistema sproži kaskadne učinke.",
             "Sto let segrevanja za +3,56 °C – pri trenutnem tempu vsaka 28,1 let doda eno stopinjo.",
-            "Theil-Sen + TFPW Mann-Kendall"
+            "Theil-Sen + Mann-Kendall"
           ],
           "stats": [
             "Izguba Triglavskega ledenika — izsušitev izvirnih vod za Slovenijo reke",
@@ -43634,7 +43634,7 @@
         "rendered": {
           "title": "Najvišje temperature v Sloveniji okoli 29. jul. · 1950–2026 · trend s projekcijo do 2050",
           "explain": "Vsaka pika je povprečna vrednost (nacionalne povprečne dnevne najvišje temperature vseh 18 postaj) v ±7-dnevnem oknu okoli tega datuma za vsako leto od 1950. Trend Theil-Sen je +0,40 °C/desetletje (p < 0,001). Po tem tempu projekcija kaže 27,2 °C do leta 2050. Zasenčeni pas je 95% interval zaupanja za nagib.",
-          "footer": "Theil-Sen + TFPW MK: +0,40 °C/desetletje · p < 0,001 · τ = 0,279 · 95% CI · 77 let",
+          "footer": "Theil-Sen + MK: +0,40 °C/desetletje · p < 0,001 · τ = 0,279 · 95% CI · 77 let",
           "current_year_plotline": {
             "value": 2026,
             "label": "2026",
@@ -44090,11 +44090,11 @@
           "day_label": "29. jul.",
           "title": "Ljubljana 299 m · Najvišja temperatura",
           "subtitle": "29. jul.",
-          "stats_badge": "Theil-Sen + TFPW MK · τ = 0,33",
+          "stats_badge": "Theil-Sen + MK · τ = 0,33",
           "total_change": "+3,76°C",
           "total_change_color": "rgb(204, 34, 34)",
           "footer": [
-            "Theil-Sen regresija + Yue-Wang TFPW Mann-Kendall test · ERA5-Land · nadmorska korekcija"
+            "Theil-Sen regresija + Yue-Wang Mann-Kendall test · ERA5-Land · nadmorska korekcija"
           ]
         },
         "charts": [
@@ -44794,7 +44794,7 @@
           "paragraphs": [
             "Podaljšani poletni vročinski valovi presegajo hladilne zmogljivosti mesta. Hudourniške poplave iz okrepljenih alpskih padavin večkrat ogrozijo nizko ležečo kotlino.",
             "Sto let segrevanja za +4,88 °C – pri trenutnem tempu vsaka 20,5 let doda eno stopinjo.",
-            "Theil-Sen + TFPW Mann-Kendall"
+            "Theil-Sen + Mann-Kendall"
           ],
           "stats": [
             "Mestni toplotni otok — poletni vročinski stres in tveganje hudourniških poplav v Ljubljanski kotlini",
@@ -47160,7 +47160,7 @@
         "rendered": {
           "title": "Najvišje temperature na postaji Ljubljana okoli 29. jul. · 1950–2026 · trend s projekcijo do 2050",
           "explain": "Vsaka pika je povprečna vrednost (lapsno popravljene dnevne najvišje temperature na postaji Ljubljana) v ±7-dnevnem oknu okoli tega datuma za vsako leto od 1950. Trend Theil-Sen je +0,49 °C/desetletje (p < 0,001). Po tem tempu projekcija kaže 28,0 °C do leta 2050. Zasenčeni pas je 95% interval zaupanja za nagib.",
-          "footer": "Theil-Sen + TFPW MK: +0,49 °C/desetletje · p < 0,001 · τ = 0,327 · 95% CI · 77 let",
+          "footer": "Theil-Sen + MK: +0,49 °C/desetletje · p < 0,001 · τ = 0,327 · 95% CI · 77 let",
           "current_year_plotline": {
             "value": 2026,
             "label": "2026",
@@ -47616,11 +47616,11 @@
           "day_label": "29. jul.",
           "title": "Ljubljana 299 m · Najvišja temperatura",
           "subtitle": "29. jul.",
-          "stats_badge": "Theil-Sen + TFPW MK · τ = 0,33",
+          "stats_badge": "Theil-Sen + MK · τ = 0,33",
           "total_change": "+3,76°C",
           "total_change_color": "rgb(204, 34, 34)",
           "footer": [
-            "Theil-Sen regresija + Yue-Wang TFPW Mann-Kendall test · ERA5-Land · nadmorska korekcija"
+            "Theil-Sen regresija + Yue-Wang Mann-Kendall test · ERA5-Land · nadmorska korekcija"
           ]
         },
         "charts": [
@@ -48320,7 +48320,7 @@
           "paragraphs": [
             "Podaljšani poletni vročinski valovi presegajo hladilne zmogljivosti mesta. Hudourniške poplave iz okrepljenih alpskih padavin večkrat ogrozijo nizko ležečo kotlino.",
             "Sto let segrevanja za +4,88 °C – pri trenutnem tempu vsaka 20,5 let doda eno stopinjo.",
-            "Theil-Sen + TFPW Mann-Kendall"
+            "Theil-Sen + Mann-Kendall"
           ],
           "stats": [
             "Mestni toplotni otok — poletni vročinski stres in tveganje hudourniških poplav v Ljubljanski kotlini",
@@ -50686,7 +50686,7 @@
         "rendered": {
           "title": "Najvišje temperature na postaji Kredarica okoli 29. jul. · 1950–2026 · trend s projekcijo do 2050",
           "explain": "Vsaka pika je povprečna vrednost (lapsno popravljene dnevne najvišje temperature na postaji Kredarica) v ±7-dnevnem oknu okoli tega datuma za vsako leto od 1950. Trend Theil-Sen je +0,31 °C/desetletje (p < 0,001). Po tem tempu projekcija kaže 13,3 °C do leta 2050. Zasenčeni pas je 95% interval zaupanja za nagib.",
-          "footer": "Theil-Sen + TFPW MK: +0,31 °C/desetletje · p < 0,001 · τ = 0,258 · 95% CI · 77 let",
+          "footer": "Theil-Sen + MK: +0,31 °C/desetletje · p < 0,001 · τ = 0,258 · 95% CI · 77 let",
           "current_year_plotline": {
             "value": 2026,
             "label": "2026",
@@ -51142,11 +51142,11 @@
           "day_label": "29. jul.",
           "title": "Kredarica 2514 m · Najvišja temperatura",
           "subtitle": "29. jul.",
-          "stats_badge": "Theil-Sen + TFPW MK · τ = 0,26",
+          "stats_badge": "Theil-Sen + MK · τ = 0,26",
           "total_change": "+2,40°C",
           "total_change_color": "rgb(204, 34, 34)",
           "footer": [
-            "Theil-Sen regresija + Yue-Wang TFPW Mann-Kendall test · ERA5-Land · nadmorska korekcija"
+            "Theil-Sen regresija + Yue-Wang Mann-Kendall test · ERA5-Land · nadmorska korekcija"
           ]
         },
         "charts": [
@@ -51846,7 +51846,7 @@
           "paragraphs": [
             "Popolna izguba Triglavskega ledenika — narodni simbol in vir savinjskih rek. Propad alpskega ekosistema sproži kaskadne učinke.",
             "Sto let segrevanja za +3,12 °C – pri trenutnem tempu vsaka 32,1 let doda eno stopinjo.",
-            "Theil-Sen + TFPW Mann-Kendall"
+            "Theil-Sen + Mann-Kendall"
           ],
           "stats": [
             "Izguba Triglavskega ledenika — izsušitev izvirnih vod za Slovenijo reke",
@@ -54021,7 +54021,7 @@
         "rendered": {
           "title": "Najvišje temperature v Sloveniji okoli 15. jul. · 1950–2026 · trend s projekcijo do 2050",
           "explain": "Vsaka pika je povprečna vrednost (nacionalne povprečne dnevne najvišje temperature vseh 18 postaj) v ±7-dnevnem oknu okoli tega datuma za vsako leto od 1950. Trend Theil-Sen je +0,34 °C/desetletje (p < 0,001). Po tem tempu projekcija kaže 26,1 °C do leta 2050. Zasenčeni pas je 95% interval zaupanja za nagib.",
-          "footer": "Theil-Sen + TFPW MK: +0,34 °C/desetletje · p < 0,001 · τ = 0,257 · 95% CI · 77 let",
+          "footer": "Theil-Sen + MK: +0,34 °C/desetletje · p < 0,001 · τ = 0,257 · 95% CI · 77 let",
           "current_year_plotline": {
             "value": 2026,
             "label": "2026",
@@ -54477,11 +54477,11 @@
           "day_label": "15. jul.",
           "title": "Ljubljana 299 m · Najvišja temperatura",
           "subtitle": "15. jul.",
-          "stats_badge": "Theil-Sen + TFPW MK · τ = 0,30",
+          "stats_badge": "Theil-Sen + MK · τ = 0,30",
           "total_change": "+3,54°C",
           "total_change_color": "rgb(204, 34, 34)",
           "footer": [
-            "Theil-Sen regresija + Yue-Wang TFPW Mann-Kendall test · ERA5-Land · nadmorska korekcija"
+            "Theil-Sen regresija + Yue-Wang Mann-Kendall test · ERA5-Land · nadmorska korekcija"
           ]
         },
         "charts": [
@@ -55181,7 +55181,7 @@
           "paragraphs": [
             "Podaljšani poletni vročinski valovi presegajo hladilne zmogljivosti mesta. Hudourniške poplave iz okrepljenih alpskih padavin večkrat ogrozijo nizko ležečo kotlino.",
             "Sto let segrevanja za +4,60 °C – pri trenutnem tempu vsaka 21,7 let doda eno stopinjo.",
-            "Theil-Sen + TFPW Mann-Kendall"
+            "Theil-Sen + Mann-Kendall"
           ],
           "stats": [
             "Mestni toplotni otok — poletni vročinski stres in tveganje hudourniških poplav v Ljubljanski kotlini",
@@ -57547,7 +57547,7 @@
         "rendered": {
           "title": "Najvišje temperature na postaji Ljubljana okoli 15. jul. · 1950–2026 · trend s projekcijo do 2050",
           "explain": "Vsaka pika je povprečna vrednost (lapsno popravljene dnevne najvišje temperature na postaji Ljubljana) v ±7-dnevnem oknu okoli tega datuma za vsako leto od 1950. Trend Theil-Sen je +0,46 °C/desetletje (p < 0,001). Po tem tempu projekcija kaže 27,2 °C do leta 2050. Zasenčeni pas je 95% interval zaupanja za nagib.",
-          "footer": "Theil-Sen + TFPW MK: +0,46 °C/desetletje · p < 0,001 · τ = 0,305 · 95% CI · 77 let",
+          "footer": "Theil-Sen + MK: +0,46 °C/desetletje · p < 0,001 · τ = 0,305 · 95% CI · 77 let",
           "current_year_plotline": {
             "value": 2026,
             "label": "2026",
@@ -58003,11 +58003,11 @@
           "day_label": "15. jul.",
           "title": "Ljubljana 299 m · Najvišja temperatura",
           "subtitle": "15. jul.",
-          "stats_badge": "Theil-Sen + TFPW MK · τ = 0,30",
+          "stats_badge": "Theil-Sen + MK · τ = 0,30",
           "total_change": "+3,54°C",
           "total_change_color": "rgb(204, 34, 34)",
           "footer": [
-            "Theil-Sen regresija + Yue-Wang TFPW Mann-Kendall test · ERA5-Land · nadmorska korekcija"
+            "Theil-Sen regresija + Yue-Wang Mann-Kendall test · ERA5-Land · nadmorska korekcija"
           ]
         },
         "charts": [
@@ -58707,7 +58707,7 @@
           "paragraphs": [
             "Podaljšani poletni vročinski valovi presegajo hladilne zmogljivosti mesta. Hudourniške poplave iz okrepljenih alpskih padavin večkrat ogrozijo nizko ležečo kotlino.",
             "Sto let segrevanja za +4,60 °C – pri trenutnem tempu vsaka 21,7 let doda eno stopinjo.",
-            "Theil-Sen + TFPW Mann-Kendall"
+            "Theil-Sen + Mann-Kendall"
           ],
           "stats": [
             "Mestni toplotni otok — poletni vročinski stres in tveganje hudourniških poplav v Ljubljanski kotlini",
@@ -61073,7 +61073,7 @@
         "rendered": {
           "title": "Najvišje temperature na postaji Kredarica okoli 15. jul. · 1950–2026 · trend s projekcijo do 2050",
           "explain": "Vsaka pika je povprečna vrednost (lapsno popravljene dnevne najvišje temperature na postaji Kredarica) v ±7-dnevnem oknu okoli tega datuma za vsako leto od 1950. Trend Theil-Sen je +0,22 °C/desetletje (p < 0,001). Po tem tempu projekcija kaže 12,1 °C do leta 2050. Zasenčeni pas je 95% interval zaupanja za nagib.",
-          "footer": "Theil-Sen + TFPW MK: +0,22 °C/desetletje · p < 0,001 · τ = 0,189 · 95% CI · 77 let",
+          "footer": "Theil-Sen + MK: +0,22 °C/desetletje · p < 0,001 · τ = 0,189 · 95% CI · 77 let",
           "current_year_plotline": {
             "value": 2026,
             "label": "2026",
@@ -61529,11 +61529,11 @@
           "day_label": "15. jul.",
           "title": "Kredarica 2514 m · Najvišja temperatura",
           "subtitle": "15. jul.",
-          "stats_badge": "Theil-Sen + TFPW MK · τ = 0,19",
+          "stats_badge": "Theil-Sen + MK · τ = 0,19",
           "total_change": "+1,72°C",
           "total_change_color": "rgb(204, 34, 34)",
           "footer": [
-            "Theil-Sen regresija + Yue-Wang TFPW Mann-Kendall test · ERA5-Land · nadmorska korekcija"
+            "Theil-Sen regresija + Yue-Wang Mann-Kendall test · ERA5-Land · nadmorska korekcija"
           ]
         },
         "charts": [
@@ -62233,7 +62233,7 @@
           "paragraphs": [
             "Triglavski ledenik popolnoma izgine. Visokogorski ekosistem nad gozdno mejo propade.",
             "Sto let segrevanja za +2,23 °C – pri trenutnem tempu vsaka 44,8 let doda eno stopinjo.",
-            "Theil-Sen + TFPW Mann-Kendall"
+            "Theil-Sen + Mann-Kendall"
           ],
           "stats": [
             "Izguba Triglavskega ledenika — izsušitev izvirnih vod za Slovenijo reke",
@@ -62374,11 +62374,11 @@
           "day_label": "28. feb.",
           "title": "Ljubljana 299 m · Najvišja temperatura",
           "subtitle": "28. feb.",
-          "stats_badge": "Theil-Sen + TFPW MK · τ = 0,21",
+          "stats_badge": "Theil-Sen + MK · τ = 0,21",
           "total_change": "+4,40°C",
           "total_change_color": "rgb(204, 34, 34)",
           "footer": [
-            "Theil-Sen regresija + Yue-Wang TFPW Mann-Kendall test · ERA5-Land · nadmorska korekcija"
+            "Theil-Sen regresija + Yue-Wang Mann-Kendall test · ERA5-Land · nadmorska korekcija"
           ]
         },
         "charts": [
@@ -63078,7 +63078,7 @@
           "paragraphs": [
             "Podaljšani poletni vročinski valovi presegajo hladilne zmogljivosti mesta. Hudourniške poplave iz okrepljenih alpskih padavin večkrat ogrozijo nizko ležečo kotlino.",
             "Sto let segrevanja za +5,71 °C – pri trenutnem tempu vsaka 17,5 let doda eno stopinjo.",
-            "Theil-Sen + TFPW Mann-Kendall"
+            "Theil-Sen + Mann-Kendall"
           ],
           "stats": [
             "Mestni toplotni otok — poletni vročinski stres in tveganje hudourniških poplav v Ljubljanski kotlini",
@@ -63219,11 +63219,11 @@
           "day_label": "28. feb.",
           "title": "Kredarica 2514 m · Najvišja temperatura",
           "subtitle": "28. feb.",
-          "stats_badge": "Theil-Sen + TFPW MK · τ = 0,16",
+          "stats_badge": "Theil-Sen + MK · τ = 0,16",
           "total_change": "+2,90°C",
           "total_change_color": "rgb(204, 34, 34)",
           "footer": [
-            "Theil-Sen regresija + Yue-Wang TFPW Mann-Kendall test · ERA5-Land · nadmorska korekcija"
+            "Theil-Sen regresija + Yue-Wang Mann-Kendall test · ERA5-Land · nadmorska korekcija"
           ]
         },
         "charts": [
@@ -63923,7 +63923,7 @@
           "paragraphs": [
             "Popolna izguba Triglavskega ledenika — narodni simbol in vir savinjskih rek. Propad alpskega ekosistema sproži kaskadne učinke.",
             "Sto let segrevanja za +3,76 °C – pri trenutnem tempu vsaka 26,6 let doda eno stopinjo.",
-            "Theil-Sen + TFPW Mann-Kendall"
+            "Theil-Sen + Mann-Kendall"
           ],
           "stats": [
             "Izguba Triglavskega ledenika — izsušitev izvirnih vod za Slovenijo reke",
@@ -64015,11 +64015,11 @@
           "day_label": "28. feb.",
           "title": "Ljubljana 299 m · Najvišja temperatura",
           "subtitle": "28. feb.",
-          "stats_badge": "Theil-Sen + TFPW MK · τ = 0,21",
+          "stats_badge": "Theil-Sen + MK · τ = 0,21",
           "total_change": "+4,40°C",
           "total_change_color": "rgb(204, 34, 34)",
           "footer": [
-            "Theil-Sen regresija + Yue-Wang TFPW Mann-Kendall test · ERA5-Land · nadmorska korekcija"
+            "Theil-Sen regresija + Yue-Wang Mann-Kendall test · ERA5-Land · nadmorska korekcija"
           ]
         },
         "charts": [
@@ -64719,7 +64719,7 @@
           "paragraphs": [
             "Podaljšani poletni vročinski valovi presegajo hladilne zmogljivosti mesta. Hudourniške poplave iz okrepljenih alpskih padavin večkrat ogrozijo nizko ležečo kotlino.",
             "Sto let segrevanja za +5,71 °C – pri trenutnem tempu vsaka 17,5 let doda eno stopinjo.",
-            "Theil-Sen + TFPW Mann-Kendall"
+            "Theil-Sen + Mann-Kendall"
           ],
           "stats": [
             "Mestni toplotni otok — poletni vročinski stres in tveganje hudourniških poplav v Ljubljanski kotlini",
@@ -67067,7 +67067,7 @@
         "rendered": {
           "title": "Najvišje temperature na postaji Ljubljana okoli 1. mar. · 1950–2026 · trend s projekcijo do 2050",
           "explain": "Vsaka pika je povprečna vrednost (lapsno popravljene dnevne najvišje temperature na postaji Ljubljana) v ±7-dnevnem oknu okoli tega datuma za vsako leto od 1950. Trend Theil-Sen je +0,56 °C/desetletje (p < 0,001). Po tem tempu projekcija kaže 10,5 °C do leta 2050. Zasenčeni pas je 95% interval zaupanja za nagib.",
-          "footer": "Theil-Sen + TFPW MK: +0,56 °C/desetletje · p < 0,001 · τ = 0,214 · 95% CI · 77 let",
+          "footer": "Theil-Sen + MK: +0,56 °C/desetletje · p < 0,001 · τ = 0,214 · 95% CI · 77 let",
           "current_year_plotline": {
             "value": 2026,
             "label": "2026",
@@ -67523,11 +67523,11 @@
           "day_label": "1. mar.",
           "title": "Ljubljana 299 m · Najvišja temperatura",
           "subtitle": "1. mar.",
-          "stats_badge": "Theil-Sen + TFPW MK · τ = 0,21",
+          "stats_badge": "Theil-Sen + MK · τ = 0,21",
           "total_change": "+4,29°C",
           "total_change_color": "rgb(204, 34, 34)",
           "footer": [
-            "Theil-Sen regresija + Yue-Wang TFPW Mann-Kendall test · ERA5-Land · nadmorska korekcija"
+            "Theil-Sen regresija + Yue-Wang Mann-Kendall test · ERA5-Land · nadmorska korekcija"
           ]
         },
         "charts": [
@@ -68227,7 +68227,7 @@
           "paragraphs": [
             "Podaljšani poletni vročinski valovi presegajo hladilne zmogljivosti mesta. Hudourniške poplave iz okrepljenih alpskih padavin večkrat ogrozijo nizko ležečo kotlino.",
             "Sto let segrevanja za +5,57 °C – pri trenutnem tempu vsaka 18,0 let doda eno stopinjo.",
-            "Theil-Sen + TFPW Mann-Kendall"
+            "Theil-Sen + Mann-Kendall"
           ],
           "stats": [
             "Mestni toplotni otok — poletni vročinski stres in tveganje hudourniških poplav v Ljubljanski kotlini",
@@ -70593,7 +70593,7 @@
         "rendered": {
           "title": "Najvišje temperature na postaji Ljubljana okoli 28. feb. · 1950–2026 · trend s projekcijo do 2050",
           "explain": "Vsaka pika je povprečna vrednost (lapsno popravljene dnevne najvišje temperature na postaji Ljubljana) v ±7-dnevnem oknu okoli tega datuma za vsako leto od 1950. Trend Theil-Sen je +0,57 °C/desetletje (p < 0,001). Po tem tempu projekcija kaže 10,2 °C do leta 2050. Zasenčeni pas je 95% interval zaupanja za nagib.",
-          "footer": "Theil-Sen + TFPW MK: +0,57 °C/desetletje · p < 0,001 · τ = 0,214 · 95% CI · 77 let",
+          "footer": "Theil-Sen + MK: +0,57 °C/desetletje · p < 0,001 · τ = 0,214 · 95% CI · 77 let",
           "current_year_plotline": {
             "value": 2026,
             "label": "2026",
@@ -71049,11 +71049,11 @@
           "day_label": "28. feb.",
           "title": "Ljubljana 299 m · Najvišja temperatura",
           "subtitle": "28. feb.",
-          "stats_badge": "Theil-Sen + TFPW MK · τ = 0,21",
+          "stats_badge": "Theil-Sen + MK · τ = 0,21",
           "total_change": "+4,40°C",
           "total_change_color": "rgb(204, 34, 34)",
           "footer": [
-            "Theil-Sen regresija + Yue-Wang TFPW Mann-Kendall test · ERA5-Land · nadmorska korekcija"
+            "Theil-Sen regresija + Yue-Wang Mann-Kendall test · ERA5-Land · nadmorska korekcija"
           ]
         },
         "charts": [
@@ -71753,7 +71753,7 @@
           "paragraphs": [
             "Podaljšani poletni vročinski valovi presegajo hladilne zmogljivosti mesta. Hudourniške poplave iz okrepljenih alpskih padavin večkrat ogrozijo nizko ležečo kotlino.",
             "Sto let segrevanja za +5,71 °C – pri trenutnem tempu vsaka 17,5 let doda eno stopinjo.",
-            "Theil-Sen + TFPW Mann-Kendall"
+            "Theil-Sen + Mann-Kendall"
           ],
           "stats": [
             "Mestni toplotni otok — poletni vročinski stres in tveganje hudourniških poplav v Ljubljanski kotlini",
@@ -74119,7 +74119,7 @@
         "rendered": {
           "title": "Najvišje temperature na postaji Ljubljana okoli 1. mar. · 1950–2026 · trend s projekcijo do 2050",
           "explain": "Vsaka pika je povprečna vrednost (lapsno popravljene dnevne najvišje temperature na postaji Ljubljana) v ±7-dnevnem oknu okoli tega datuma za vsako leto od 1950. Trend Theil-Sen je +0,56 °C/desetletje (p < 0,001). Po tem tempu projekcija kaže 10,5 °C do leta 2050. Zasenčeni pas je 95% interval zaupanja za nagib.",
-          "footer": "Theil-Sen + TFPW MK: +0,56 °C/desetletje · p < 0,001 · τ = 0,214 · 95% CI · 77 let",
+          "footer": "Theil-Sen + MK: +0,56 °C/desetletje · p < 0,001 · τ = 0,214 · 95% CI · 77 let",
           "current_year_plotline": {
             "value": 2026,
             "label": "2026",
@@ -74575,11 +74575,11 @@
           "day_label": "1. mar.",
           "title": "Ljubljana 299 m · Najvišja temperatura",
           "subtitle": "1. mar.",
-          "stats_badge": "Theil-Sen + TFPW MK · τ = 0,21",
+          "stats_badge": "Theil-Sen + MK · τ = 0,21",
           "total_change": "+4,29°C",
           "total_change_color": "rgb(204, 34, 34)",
           "footer": [
-            "Theil-Sen regresija + Yue-Wang TFPW Mann-Kendall test · ERA5-Land · nadmorska korekcija"
+            "Theil-Sen regresija + Yue-Wang Mann-Kendall test · ERA5-Land · nadmorska korekcija"
           ]
         },
         "charts": [
@@ -75279,7 +75279,7 @@
           "paragraphs": [
             "Podaljšani poletni vročinski valovi presegajo hladilne zmogljivosti mesta. Hudourniške poplave iz okrepljenih alpskih padavin večkrat ogrozijo nizko ležečo kotlino.",
             "Sto let segrevanja za +5,57 °C – pri trenutnem tempu vsaka 18,0 let doda eno stopinjo.",
-            "Theil-Sen + TFPW Mann-Kendall"
+            "Theil-Sen + Mann-Kendall"
           ],
           "stats": [
             "Mestni toplotni otok — poletni vročinski stres in tveganje hudourniških poplav v Ljubljanski kotlini",
@@ -77645,7 +77645,7 @@
         "rendered": {
           "title": "Najvišje temperature na postaji Ljubljana okoli 1. jan. · 1950–2026 · trend s projekcijo do 2050",
           "explain": "Vsaka pika je povprečna vrednost (lapsno popravljene dnevne najvišje temperature na postaji Ljubljana) v ±7-dnevnem oknu okoli tega datuma za vsako leto od 1950. Trend Theil-Sen je +0,48 °C/desetletje (p < 0,001). Po tem tempu projekcija kaže 6,3 °C do leta 2050. Zasenčeni pas je 95% interval zaupanja za nagib.",
-          "footer": "Theil-Sen + TFPW MK: +0,48 °C/desetletje · p < 0,001 · τ = 0,239 · 95% CI · 77 let",
+          "footer": "Theil-Sen + MK: +0,48 °C/desetletje · p < 0,001 · τ = 0,239 · 95% CI · 77 let",
           "current_year_plotline": {
             "value": 2026,
             "label": "2026",
@@ -78101,11 +78101,11 @@
           "day_label": "1. jan.",
           "title": "Ljubljana 299 m · Najvišja temperatura",
           "subtitle": "1. jan.",
-          "stats_badge": "Theil-Sen + TFPW MK · τ = 0,24",
+          "stats_badge": "Theil-Sen + MK · τ = 0,24",
           "total_change": "+3,73°C",
           "total_change_color": "rgb(204, 34, 34)",
           "footer": [
-            "Theil-Sen regresija + Yue-Wang TFPW Mann-Kendall test · ERA5-Land · nadmorska korekcija"
+            "Theil-Sen regresija + Yue-Wang Mann-Kendall test · ERA5-Land · nadmorska korekcija"
           ]
         },
         "charts": [
@@ -78805,7 +78805,7 @@
           "paragraphs": [
             "Podaljšani poletni vročinski valovi presegajo hladilne zmogljivosti mesta. Hudourniške poplave iz okrepljenih alpskih padavin večkrat ogrozijo nizko ležečo kotlino.",
             "Sto let segrevanja za +4,84 °C – pri trenutnem tempu vsaka 20,7 let doda eno stopinjo.",
-            "Theil-Sen + TFPW Mann-Kendall"
+            "Theil-Sen + Mann-Kendall"
           ],
           "stats": [
             "Mestni toplotni otok — poletni vročinski stres in tveganje hudourniških poplav v Ljubljanski kotlini",
@@ -81167,7 +81167,7 @@
         "rendered": {
           "title": "Najvišje temperature na postaji Ljubljana okoli 31. dec. · 1950–2025 · trend s projekcijo do 2050",
           "explain": "Vsaka pika je povprečna vrednost (lapsno popravljene dnevne najvišje temperature na postaji Ljubljana) v ±7-dnevnem oknu okoli tega datuma za vsako leto od 1950. Trend Theil-Sen je +0,51 °C/desetletje (p < 0,001). Po tem tempu projekcija kaže 6,4 °C do leta 2050. Zasenčeni pas je 95% interval zaupanja za nagib.",
-          "footer": "Theil-Sen + TFPW MK: +0,51 °C/desetletje · p < 0,001 · τ = 0,270 · 95% CI · 76 let",
+          "footer": "Theil-Sen + MK: +0,51 °C/desetletje · p < 0,001 · τ = 0,270 · 95% CI · 76 let",
           "current_year_plotline": {
             "value": 2026,
             "label": "2026",
@@ -81619,11 +81619,11 @@
           "day_label": "31. dec.",
           "title": "Ljubljana 299 m · Najvišja temperatura",
           "subtitle": "31. dec.",
-          "stats_badge": "Theil-Sen + TFPW MK · τ = 0,27",
+          "stats_badge": "Theil-Sen + MK · τ = 0,27",
           "total_change": "+3,90°C",
           "total_change_color": "rgb(204, 34, 34)",
           "footer": [
-            "Theil-Sen regresija + Yue-Wang TFPW Mann-Kendall test · ERA5-Land · nadmorska korekcija"
+            "Theil-Sen regresija + Yue-Wang Mann-Kendall test · ERA5-Land · nadmorska korekcija"
           ]
         },
         "charts": [
@@ -82315,7 +82315,7 @@
           "paragraphs": [
             "Podaljšani poletni vročinski valovi presegajo hladilne zmogljivosti mesta. Hudourniške poplave iz okrepljenih alpskih padavin večkrat ogrozijo nizko ležečo kotlino.",
             "Sto let segrevanja za +5,13 °C – pri trenutnem tempu vsaka 19,5 let doda eno stopinjo.",
-            "Theil-Sen + TFPW Mann-Kendall"
+            "Theil-Sen + Mann-Kendall"
           ],
           "stats": [
             "Mestni toplotni otok — poletni vročinski stres in tveganje hudourniških poplav v Ljubljanski kotlini",
@@ -84685,7 +84685,7 @@
         "rendered": {
           "title": "Najvišje temperature na postaji Ljubljana okoli 3. avg. · 1950–2025 · trend s projekcijo do 2050",
           "explain": "Vsaka pika je povprečna vrednost (lapsno popravljene dnevne najvišje temperature na postaji Ljubljana) v ±7-dnevnem oknu okoli tega datuma za vsako leto od 1950. Trend Theil-Sen je +0,41 °C/desetletje (p < 0,001). Po tem tempu projekcija kaže 27,4 °C do leta 2050. Zasenčeni pas je 95% interval zaupanja za nagib.",
-          "footer": "Theil-Sen + TFPW MK: +0,41 °C/desetletje · p < 0,001 · τ = 0,284 · 95% CI · 76 let",
+          "footer": "Theil-Sen + MK: +0,41 °C/desetletje · p < 0,001 · τ = 0,284 · 95% CI · 76 let",
           "current_year_plotline": {
             "value": 2026,
             "label": "2026",
@@ -85137,11 +85137,11 @@
           "day_label": "3. avg.",
           "title": "Ljubljana 299 m · Najvišja temperatura",
           "subtitle": "3. avg.",
-          "stats_badge": "Theil-Sen + TFPW MK · τ = 0,28",
+          "stats_badge": "Theil-Sen + MK · τ = 0,28",
           "total_change": "+3,13°C",
           "total_change_color": "rgb(204, 34, 34)",
           "footer": [
-            "Theil-Sen regresija + Yue-Wang TFPW Mann-Kendall test · ERA5-Land · nadmorska korekcija"
+            "Theil-Sen regresija + Yue-Wang Mann-Kendall test · ERA5-Land · nadmorska korekcija"
           ]
         },
         "charts": [
@@ -85833,7 +85833,7 @@
           "paragraphs": [
             "Podaljšani poletni vročinski valovi presegajo hladilne zmogljivosti mesta. Hudourniške poplave iz okrepljenih alpskih padavin večkrat ogrozijo nizko ležečo kotlino.",
             "Sto let segrevanja za +4,12 °C – pri trenutnem tempu vsaka 24,3 let doda eno stopinjo.",
-            "Theil-Sen + TFPW Mann-Kendall"
+            "Theil-Sen + Mann-Kendall"
           ],
           "stats": [
             "Mestni toplotni otok — poletni vročinski stres in tveganje hudourniških poplav v Ljubljanski kotlini",
@@ -88203,7 +88203,7 @@
         "rendered": {
           "title": "Najvišje temperature na postaji Kredarica okoli 3. avg. · 1950–2025 · trend s projekcijo do 2050",
           "explain": "Vsaka pika je povprečna vrednost (lapsno popravljene dnevne najvišje temperature na postaji Kredarica) v ±7-dnevnem oknu okoli tega datuma za vsako leto od 1950. Trend Theil-Sen je +0,27 °C/desetletje (p < 0,001). Po tem tempu projekcija kaže 13,0 °C do leta 2050. Zasenčeni pas je 95% interval zaupanja za nagib.",
-          "footer": "Theil-Sen + TFPW MK: +0,27 °C/desetletje · p < 0,001 · τ = 0,223 · 95% CI · 76 let",
+          "footer": "Theil-Sen + MK: +0,27 °C/desetletje · p < 0,001 · τ = 0,223 · 95% CI · 76 let",
           "current_year_plotline": {
             "value": 2026,
             "label": "2026",
@@ -88655,11 +88655,11 @@
           "day_label": "3. avg.",
           "title": "Kredarica 2514 m · Najvišja temperatura",
           "subtitle": "3. avg.",
-          "stats_badge": "Theil-Sen + TFPW MK · τ = 0,22",
+          "stats_badge": "Theil-Sen + MK · τ = 0,22",
           "total_change": "+2,04°C",
           "total_change_color": "rgb(204, 34, 34)",
           "footer": [
-            "Theil-Sen regresija + Yue-Wang TFPW Mann-Kendall test · ERA5-Land · nadmorska korekcija"
+            "Theil-Sen regresija + Yue-Wang Mann-Kendall test · ERA5-Land · nadmorska korekcija"
           ]
         },
         "charts": [
@@ -89351,7 +89351,7 @@
           "paragraphs": [
             "Triglavski ledenik popolnoma izgine. Visokogorski ekosistem nad gozdno mejo propade.",
             "Sto let segrevanja za +2,69 °C – pri trenutnem tempu vsaka 37,2 let doda eno stopinjo.",
-            "Theil-Sen + TFPW Mann-Kendall"
+            "Theil-Sen + Mann-Kendall"
           ],
           "stats": [
             "Izguba Triglavskega ledenika — izsušitev izvirnih vod za Slovenijo reke",
@@ -91725,7 +91725,7 @@
         "rendered": {
           "title": "Najvišje temperature na postaji Ljubljana okoli 7. feb. · 1950–2026 · trend s projekcijo do 2050",
           "explain": "Vsaka pika je povprečna vrednost (lapsno popravljene dnevne najvišje temperature na postaji Ljubljana) v ±7-dnevnem oknu okoli tega datuma za vsako leto od 1950. Trend Theil-Sen je +0,57 °C/desetletje (p < 0,001). Po tem tempu projekcija kaže 8,3 °C do leta 2050. Zasenčeni pas je 95% interval zaupanja za nagib.",
-          "footer": "Theil-Sen + TFPW MK: +0,57 °C/desetletje · p < 0,001 · τ = 0,247 · 95% CI · 77 let",
+          "footer": "Theil-Sen + MK: +0,57 °C/desetletje · p < 0,001 · τ = 0,247 · 95% CI · 77 let",
           "current_year_plotline": {
             "value": 2026,
             "label": "2026",
@@ -92181,11 +92181,11 @@
           "day_label": "7. feb.",
           "title": "Ljubljana 299 m · Najvišja temperatura",
           "subtitle": "7. feb.",
-          "stats_badge": "Theil-Sen + TFPW MK · τ = 0,25",
+          "stats_badge": "Theil-Sen + MK · τ = 0,25",
           "total_change": "+4,38°C",
           "total_change_color": "rgb(204, 34, 34)",
           "footer": [
-            "Theil-Sen regresija + Yue-Wang TFPW Mann-Kendall test · ERA5-Land · nadmorska korekcija"
+            "Theil-Sen regresija + Yue-Wang Mann-Kendall test · ERA5-Land · nadmorska korekcija"
           ]
         },
         "charts": [
@@ -92885,7 +92885,7 @@
           "paragraphs": [
             "Podaljšani poletni vročinski valovi presegajo hladilne zmogljivosti mesta. Hudourniške poplave iz okrepljenih alpskih padavin večkrat ogrozijo nizko ležečo kotlino.",
             "Sto let segrevanja za +5,69 °C – pri trenutnem tempu vsaka 17,6 let doda eno stopinjo.",
-            "Theil-Sen + TFPW Mann-Kendall"
+            "Theil-Sen + Mann-Kendall"
           ],
           "stats": [
             "Mestni toplotni otok — poletni vročinski stres in tveganje hudourniških poplav v Ljubljanski kotlini",
@@ -95264,7 +95264,7 @@
         "rendered": {
           "title": "Najvišje temperature na postaji Kredarica okoli 7. jan. · 1950–2026 · trend s projekcijo do 2050",
           "explain": "Vsaka pika je povprečna vrednost (lapsno popravljene dnevne najvišje temperature na postaji Kredarica) v ±7-dnevnem oknu okoli tega datuma za vsako leto od 1950. Trend Theil-Sen je +0,54 °C/desetletje (p < 0,001). Po tem tempu projekcija kaže −5,9 °C do leta 2050. Zasenčeni pas je 95% interval zaupanja za nagib.",
-          "footer": "Theil-Sen + TFPW MK: +0,54 °C/desetletje · p < 0,001 · τ = 0,282 · 95% CI · 77 let",
+          "footer": "Theil-Sen + MK: +0,54 °C/desetletje · p < 0,001 · τ = 0,282 · 95% CI · 77 let",
           "current_year_plotline": {
             "value": 2026,
             "label": "2026",
@@ -95720,11 +95720,11 @@
           "day_label": "7. jan.",
           "title": "Kredarica 2514 m · Najvišja temperatura",
           "subtitle": "7. jan.",
-          "stats_badge": "Theil-Sen + TFPW MK · τ = 0,28",
+          "stats_badge": "Theil-Sen + MK · τ = 0,28",
           "total_change": "+4,16°C",
           "total_change_color": "rgb(204, 34, 34)",
           "footer": [
-            "Theil-Sen regresija + Yue-Wang TFPW Mann-Kendall test · ERA5-Land · nadmorska korekcija"
+            "Theil-Sen regresija + Yue-Wang Mann-Kendall test · ERA5-Land · nadmorska korekcija"
           ]
         },
         "charts": [
@@ -96424,7 +96424,7 @@
           "paragraphs": [
             "Popolna izguba Triglavskega ledenika — narodni simbol in vir savinjskih rek. Propad alpskega ekosistema sproži kaskadne učinke.",
             "Sto let segrevanja za +5,40 °C – pri trenutnem tempu vsaka 18,5 let doda eno stopinjo.",
-            "Theil-Sen + TFPW Mann-Kendall"
+            "Theil-Sen + Mann-Kendall"
           ],
           "stats": [
             "Izguba Triglavskega ledenika — izsušitev izvirnih vod za Slovenijo reke",

--- a/tests/snapshot/harness.tsx
+++ b/tests/snapshot/harness.tsx
@@ -592,7 +592,7 @@ function captureAnalysis(unit: Unit): any {
       title: scatter.txt("[style*='font-size: 15px']"),
       subtitle: scatter.txt("[style*='margin-top: 3px']"),
       // The last panelSubStyle line in the scatter card — the footer method+fit_desc
-      // span (RegressionPanel.tsx:478), "Theil-Sen + TFPW MK · τ = …". (The field name
+      // span (RegressionPanel.tsx:478), "Theil-Sen + MK · τ = …". (The field name
       // and the old "<n> YR" comment are stale: slice(-1) lands on the footer, not the
       // years_sig badge.) T-5.60 dropped `white-space:nowrap` from panelSubStyle so the
       // subtitles wrap instead of ellipsizing; this selector keyed on that nowrap and


### PR DESCRIPTION
Removes **"TFPW"** from every method label. The page was naming a statistical method it does not run.

**The defect.** The chart footer read *"Theil-Sen regresija + Yue-Wang TFPW Mann-Kendall test"*. The code calls `pymannkendall.yue_wang_modification_test` — **Yue & Wang (2004), an effective-sample-size variance correction**. TFPW is *trend-free pre-whitening*, a different method from a different paper (Yue, Pilon, Phinney & Cavadias 2002). So the label named two things that are not the same, and asserted a method the page has never run.

**This is a published claim about method being wrong, not a wording preference.** It is the same class as T-5.51's `unit: °C/decade` on a mixed-unit column (D-42): an assertion that reads authoritatively and is false. It matters more here because T-6.8 has just given readers eleven references to check the method against — including Yue & Wang (2004) as reference [9].

**One label was reported; the sweep found six.** `reg.explain_reg`, `reg.explain_reg_nocorr`, `trend.foot`, `hero.method_theilsen`, and two hardcoded labels in `api.ts` that render as the stats badge. Fixing only the noticed one would have left five wrong claims on the page — the D-44 rule earning its keep again.

**The correct form was already shipping beside the wrong one.** `RegressionPanel.tsx:507` hardcodes *"Theil-Sen + MK"* for the year-round card, so a reader could see two different method claims on one screen. Everything now converges on that form.

**T-6.8's descriptions were already correct — confirmed, not assumed.** The glossary's Mann-Kendall entry and the new *Trend in statistična značilnost* section both describe the Yue-Wang autocorrelation correction with no mention of TFPW. **The labels moved toward them**, never the reverse.

**Only labels changed.** `yue_wang_modification_test` is untouched. No method, no threshold, no number. The code was always right; the description lied.

**Also fixed, same defect wider audience:** `README.md:216`, which asserted the wrong method in a public repo. And three stale comments quoting the old label — which is exactly how a wrong string gets restored later by someone "fixing" an inconsistency. The reference catalogue's comment now forbids reintroducing the term.

**Left alone and reported rather than silently skipped:** `docs/i18n/sl_default.json`, a dead legacy locale the page does not load; `spei.tech`, which correctly says plain *Mann-Kendall* because the SPEI path runs `original_test` with no correction; and `datapackage.yaml`, already accurate.

**A finding worth its own decision:** the two `api.ts` labels are reader-visible strings living **outside** the `i18n/` catalogue, which contradicts D-8. They were corrected in place rather than migrated — the migration is a separate call.

**Snapshot: 83 text-only leaves, verified by script.** Each `-` line with the TFPW token removed equals its `+` line — zero unexplained, zero numeric moves. Every embedded τ, p-value, trend and year figure is byte-identical (τ = 0,295, +0,45 °C/desetletje, 77 let). Every change shortens its string by five characters, so the dense mono footer only got shorter.

**Dual-commit: none triggered.** `METHODOLOGY.md:103` and `hero-content.ts:255` already carried the correct wording, are byte-identical, and were not edited — re-checked after touching neighbouring strings.

**Needs eyes on stage:** that the scatter card footer, the hero card and the year-round card now all name the same method, and that the shortened footer still sits correctly.

Gates: typecheck 0 · typecheck:gate 0 allowlisted · yarn test 79 · text-integrity 5/5 · snapshot:check identical, 0 misses · pytest 75.
