### PR TITLE
T-5.25 — build-time invariant: no tropical trend from an untrustworthy fit

### DIFF
--- a/data/climate-si/sources/precompute_datasette.py
+++ b/data/climate-si/sources/precompute_datasette.py
@@ -767,10 +767,39 @@ def _streak_filter(arr: np.ndarray, streak: int) -> np.ndarray:
             i += 1
     return out
 
-def _tropical_trend(fit_years, fit_counts, years) -> dict:
+def _fit_is_trustworthy(fitted) -> bool:
+    """The tropical NB fit's OWN verdict on itself: it converged AND its parameter
+    covariance is finite and positive-definite (T-4.24's withhold criterion).
+
+    Factored into a shared helper on purpose (T-5.25). It has TWO independent call
+    sites: the gate inside `_tropical_trend` (which returns {} when the verdict is
+    False) and the value carried out in `_tropical_trend`'s return, which
+    `build_tropical` re-reads to enforce "no untrustworthy fit is ever published".
+    Because the returned verdict is an independent read of the fit — not a flag the
+    gate sets — deleting the gate's early-return does NOT silence the tripwire: a
+    non-converged fit then flows through, the return still carries verdict=False, and
+    build_tropical raises. That is what makes the tripwire an invariant rather than a
+    restatement of the gate. (A refactor could still defeat it by editing BOTH call
+    sites; that is the irreducible limit, shared with the D-16 SPEI tripwire.)"""
+    if not bool(fitted.mle_retvals.get("converged", False)):
+        return False
+    cov = np.asarray(fitted.cov_params(), dtype=float)
+    if not bool(np.all(np.isfinite(cov))):
+        return False
+    cov_sym = 0.5 * (cov + cov.T)
+    return bool(np.all(np.linalg.eigvalsh(cov_sym) > 0.0))
+
+
+def _tropical_trend(fit_years, fit_counts, years) -> tuple[dict, bool]:
+    """Return (trend, fit_ok). `trend` is {} on any withhold; `fit_ok` is the fit's
+    trustworthiness verdict (see _fit_is_trustworthy), carried out so build_tropical
+    can assert the withhold actually fired. `fit_ok` is True on the no-fit paths
+    (insufficient data — an honest, deterministic withhold) and False only when a fit
+    the optimiser could not stand behind was produced. The only combination
+    build_tropical forbids is a NON-EMPTY trend with fit_ok False (T-5.25)."""
     nonzero = sum(1 for c in fit_counts if c > 0)
     if len(fit_years) < 10 or nonzero < 10:
-        return {}
+        return {}, True
     try:
         years_arr = np.array(fit_years, dtype=float)
         year_mean = float(years_arr[0])
@@ -800,15 +829,10 @@ def _tropical_trend(fit_years, fit_counts, years) -> dict:
         # get_prediction() below (a LinAlgError caught by the except); this explicit
         # check catches the arches/paths where the inverse comes back non-finite or
         # non-PD without raising. Both routes end in the same {} withhold.
-        cov = np.asarray(fitted.cov_params(), dtype=float)
-        cov_ok = bool(np.all(np.isfinite(cov)))
-        if cov_ok:
-            cov_sym = 0.5 * (cov + cov.T)
-            cov_ok = bool(np.all(np.linalg.eigvalsh(cov_sym) > 0.0))
-        if not (bool(fitted.mle_retvals.get("converged", False)) and cov_ok):
+        if not _fit_is_trustworthy(fitted):
             reason = "did not converge" if not fitted.mle_retvals.get("converged", False) else "non-PD covariance"
             print(f"  tropical NB fit withheld ({reason})", file=sys.stderr)
-            return {}
+            return {}, False
 
         x_dense = np.linspace(years[0], years[-1], len(years))
         X_dense = sm.add_constant(x_dense - year_mean)
@@ -843,11 +867,16 @@ def _tropical_trend(fit_years, fit_counts, years) -> dict:
         if not (all(np.isfinite(v) and v >= 0 for v in yl)
                 and all(np.isfinite(v) for v in cl) and all(np.isfinite(v) for v in ch)
                 and all(cl[i] <= ch[i] for i in range(len(cl)))):
-            return {}
-        return trend
+            return {}, True
+        # Re-read the fit's verdict here (a SECOND, independent call to the shared
+        # helper) rather than returning a literal True: this is the tripwire hook
+        # (T-5.25). In normal flow the gate above already guaranteed the verdict is
+        # True; but if that gate is ever deleted, this return still carries the real
+        # verdict (False for a non-converged fit) and build_tropical raises.
+        return trend, _fit_is_trustworthy(fitted)
     except Exception as e:
         print(f"  tropical NB fit failed ({e})", file=sys.stderr)
-        return {}
+        return {}, False
 
 def build_tropical(data: pd.DataFrame, stations_df: pd.DataFrame) -> pd.DataFrame:
     sid_map = dict(zip(stations_df["era5_name"], stations_df["station_id"]))
@@ -879,7 +908,30 @@ def build_tropical(data: pd.DataFrame, stations_df: pd.DataFrame) -> pd.DataFram
                     years  = [int(y) for y in ann.index]
                     counts = [int(v) for v in ann.values]
                     fit    = [(y, c) for y, c in zip(years, counts) if y != max_year]
-                    trend  = _tropical_trend([y for y, _ in fit], [c for _, c in fit], years)
+                    trend, fit_ok = _tropical_trend(
+                        [y for y, _ in fit], [c for _, c in fit], years)
+                    # T-5.25 tripwire: assert the T-4.24 withhold actually fired.
+                    # A non-empty trend that the fit itself does NOT vouch for means
+                    # the withhold-at-source has silently stopped working — the exact
+                    # failure that once published eleven false 2050 projections.
+                    # Abort the build (validate runs before to_sql, so nothing ships)
+                    # rather than republish a false significance claim.
+                    if trend and not fit_ok:
+                        raise pipeline_validate.PipelineValidationError(
+                            f"tropical trend published from an UNTRUSTWORTHY fit: "
+                            f"station={era5_name} kind={kind} threshold={threshold} "
+                            f"streak={streak}. The NB GLM did not converge (or its "
+                            f"parameter covariance was non-finite / non-positive-"
+                            f"definite), yet a trend_json — including a 2050 "
+                            f"projection and a significance verdict — was emitted. "
+                            f"A non-converged tropical fit once published ELEVEN "
+                            f"false 2050 projections, ten with p clamped to 0.0001 "
+                            f"(T-4.24); this invariant exists so that never ships "
+                            f"again. The correct fix is to WITHHOLD this trend "
+                            f"(return an empty dict from _tropical_trend, as its "
+                            f"convergence gate does) — NOT to relax or delete this "
+                            f"check (T-5.25)."
+                        )
                     rows.append({
                         "era5_name":     era5_name,
                         "station_id":    sid_map.get(era5_name),

--- a/data/climate-si/sources/tests/test_precompute.py
+++ b/data/climate-si/sources/tests/test_precompute.py
@@ -261,8 +261,9 @@ def test_tropical_trend_withholds_when_not_converged(monkeypatch, capsys):
         pc.sm, "NegativeBinomial",
         lambda endog, exog: _StubModel(converged=False, cov=np.eye(3)),
     )
-    result = pc._tropical_trend(years[:-1], counts[:-1], years)
+    result, fit_ok = pc._tropical_trend(years[:-1], counts[:-1], years)
     assert result == {}, "a non-converged fit must be withheld, not published"
+    assert fit_ok is False, "the verdict carried out must report the fit as untrusted"
     err = capsys.readouterr().err
     assert "tropical NB fit withheld" in err and "did not converge" in err
 
@@ -274,8 +275,9 @@ def test_tropical_trend_withholds_on_nonfinite_covariance(monkeypatch, capsys):
         pc.sm, "NegativeBinomial",
         lambda endog, exog: _StubModel(converged=True, cov=bad),
     )
-    result = pc._tropical_trend(years[:-1], counts[:-1], years)
+    result, fit_ok = pc._tropical_trend(years[:-1], counts[:-1], years)
     assert result == {}, "a non-finite covariance must be withheld"
+    assert fit_ok is False
     assert "non-PD covariance" in capsys.readouterr().err
 
 
@@ -286,8 +288,9 @@ def test_tropical_trend_withholds_on_non_pd_covariance(monkeypatch, capsys):
         pc.sm, "NegativeBinomial",
         lambda endog, exog: _StubModel(converged=True, cov=non_pd),
     )
-    result = pc._tropical_trend(years[:-1], counts[:-1], years)
+    result, fit_ok = pc._tropical_trend(years[:-1], counts[:-1], years)
     assert result == {}, "a non-positive-definite covariance must be withheld"
+    assert fit_ok is False
     assert "non-PD covariance" in capsys.readouterr().err
 
 
@@ -296,7 +299,12 @@ def test_tropical_trend_withholds_insufficient_data():
     # unchanged by T-4.24). No stub: it must never reach the optimiser.
     years = list(range(2000, 2021))
     counts = [0] * 16 + [1, 2, 3, 4, 5]      # only 5 non-zero
-    assert pc._tropical_trend(years[:-1], counts[:-1], years) == {}
+    result, fit_ok = pc._tropical_trend(years[:-1], counts[:-1], years)
+    assert result == {}
+    # No fit ran, so the withhold is honest/deterministic — the verdict is vacuously
+    # True (nothing was published to distrust). This keeps the tripwire's rule crisp:
+    # it forbids only a NON-EMPTY trend with fit_ok False.
+    assert fit_ok is True
 
 
 def test_tropical_trend_success_returns_nb_model():
@@ -307,6 +315,56 @@ def test_tropical_trend_success_returns_nb_model():
     years = list(range(1980, 2021))
     counts = [4, 4, 5, 0, 5, 2, 7, 3, 8, 2, 7, 8, 3, 3, 7, 5, 5, 4, 13, 6, 6,
               17, 8, 8, 4, 2, 15, 16, 18, 6, 13, 9, 12, 9, 10, 7, 9, 15, 13, 17, 31]
-    result = pc._tropical_trend(years[:-1], counts[:-1], years)
+    result, fit_ok = pc._tropical_trend(years[:-1], counts[:-1], years)
     assert result.get("model_used") == "nb"
     assert "p_value" in result and "rate_per_year" in result
+    assert fit_ok is True, "a converged, published fit must report as trusted"
+
+
+# ── T-5.25: the build-time TRIPWIRE in build_tropical ─────────────────────────
+#
+# The gate inside _tropical_trend withholds an untrustworthy fit; the tests above
+# prove it returns {}. This tripwire is the second line of defence: if that gate
+# ever stops firing (a refactor removes it, or a future estimator publishes without
+# a withhold), a non-empty trend reaches trend_json while the fit's own verdict is
+# False — the exact shape of T-4.24's eleven false projections. build_tropical must
+# ABORT the build, not publish it. We simulate the broken-gate state by stubbing
+# _tropical_trend to hand back a populated trend WITH fit_ok=False.
+
+
+def _tiny_tropical_input():
+    dates = pd.to_datetime(["2000-07-01", "2000-07-02", "2001-07-01", "2001-07-02"])
+    data = pd.DataFrame({
+        "location": ["Ljubljana"] * 4,
+        "date": dates,
+        "year": [2000, 2000, 2001, 2001],
+        "temperature_max_corr": [30.0, 31.0, 32.0, 33.0],
+        "temperature_min_corr": [16.0, 17.0, 18.0, 19.0],
+    })
+    stations_df = pd.DataFrame({"era5_name": ["Ljubljana"], "station_id": [1495]})
+    return data, stations_df
+
+
+def test_build_tropical_raises_when_untrustworthy_trend_published(monkeypatch):
+    data, stations_df = _tiny_tropical_input()
+    monkeypatch.setattr(
+        pc, "_tropical_trend",
+        lambda fy, fc, y: ({"model_used": "nb", "p_value": 0.0001}, False),
+    )
+    with pytest.raises(pc.pipeline_validate.PipelineValidationError,
+                       match="UNTRUSTWORTHY fit"):
+        pc.build_tropical(data, stations_df)
+
+
+def test_build_tropical_allows_trusted_and_honest_withholds(monkeypatch):
+    # A published trend with fit_ok True, and an empty withhold with fit_ok False
+    # (the exception path), must BOTH pass — the tripwire forbids only the one
+    # forbidden combination, so it never false-positives on legitimate output.
+    data, stations_df = _tiny_tropical_input()
+    monkeypatch.setattr(
+        pc, "_tropical_trend",
+        lambda fy, fc, y: ({"model_used": "nb", "p_value": 0.01}, True),
+    )
+    assert not pc.build_tropical(data, stations_df).empty
+    monkeypatch.setattr(pc, "_tropical_trend", lambda fy, fc, y: ({}, False))
+    assert not pc.build_tropical(data, stations_df).empty


### PR DESCRIPTION
Adds a build-time invariant that no tropical trend is published from a fit the optimiser could not stand behind.

**The gap this closes.** The snapshot fixture grid holds the full threshold×streak matrix for **Ljubljana and Kredarica only** — 66 fixtures each — while the other sixteen stations carry **two** apiece, just their default combination. So every non-default combination at those sixteen is invisible to `snapshot:check`. That is exactly why T-4.24's **eleven false 2050 projections** shipped, and why removing them left the snapshot byte-identical: the gate could not see them.

**The eleven were reconstructed from real raw data, not from a description.** Running `build_tropical` with and without T-4.24's convergence gate yields exactly 11 withheld series, names matching. All eleven have `converged=False`; on this architecture all eleven also have finite, positive-definite covariance, so the convergence flag alone is the discriminator.

**Six cheaper invariants were tested against real data and all fail.** The output table cannot support one:

| candidate | catches of 11 | false positives / 760 legitimate |
|---|---|---|
| `p_value` at floor (0.0001) | 10 | **559** |
| `p_value` at ceiling | 0 | 0 |
| `\|rate_per_year\| ≥ 5%` | 6 | 15 |
| `alpha ≥ 2` / `≥ 5` | 0 | 231 / 98 |
| projection CI width ≥ 50 | 0 | 3 |
| `y_line[-1] > 60` | 2 | 85 |

No published field separates the eleven from legitimate trends — the one non-clamped case (Celje days 35/1, p = 0.006) is output-indistinguishable from a benign fit. That is what proves the check must live at **fit time**, not in `validate.py` or a Pandera schema, which see only the output table.

**The shape: share a helper, not a line.** `_fit_is_trustworthy(fitted)` computes T-4.24's exact criterion and is called at **two independent sites** — the gate's early return inside `_tropical_trend`, and the returned verdict, which deliberately re-reads the fit rather than returning a literal `True`. `build_tropical` then raises `PipelineValidationError` on any published trend whose verdict is false, across all 1,188 series, before `to_sql`.

**That independence was verified, not asserted.** Removing *only* the gate's early return leaves the returned verdict intact, and the tripwire catches exactly the eleven. Had gate and verdict shared one line, deleting it would have killed both. The irreducible limit — a refactor editing both call sites — is documented in the helper's docstring, the same limit the D-16 SPEI tripwire has.

**Zero false positives by construction**, and the reason matters: the verdict *is* the gate criterion, so publish and verdict can only disagree on a **code regression**, never on data. A genuinely flat series converges and publishes an honest large p; a sparse-event series is withheld before any fit. That is also why aborting the build is safe under the unattended D-29 nightly refresh — data cannot trip it; only a human code change can, and that surfaces in CI.

**The failure message explains itself to someone who has never heard of T-4.24** — it names the station, variable, threshold and streak, states that the NB GLM did not converge, records that this once published eleven false 2050 projections, and says the correct response is to **withhold the trend, not to relax the check**. An assertion that fires without explaining itself gets deleted by whoever it blocks.

**A new test proves the invariant fires.** The pre-existing tests only proved the gate returns `{}`; this one stubs the broken-gate state — a populated trend with `fit_ok=False` — and asserts `build_tropical` raises.

**Flags 0 of 1,188 today.** Snapshot byte-identical, as predicted: a pipeline assertion moves no rendered value.

**The other half of the deliverable is a note in CLAUDE.md's gates section** stating what a green `snapshot:check` actually covers, with the measured counts, and ending with this ticket's honest scope: the grid is still two stations, and the invariant covers **tropical trend convergence only** — not `counts_json`, not `annual_trend`, not season or SPEI content at non-fixtured stations, not chart options. A note that overstated its own coverage would repeat the error it exists to prevent.

Gates: typecheck 0 · typecheck:gate 0 allowlisted · yarn test 79 · snapshot:check identical, 0 misses · pytest 77 · validate.py all 10 tables valid on a full local rebuild.
