### PR TITLE
T-4.28 — compute each day's window slice once, not five times: precompute −32%

### DIFF
--- a/data/climate-si/sources/precompute_datasette.py
+++ b/data/climate-si/sources/precompute_datasette.py
@@ -403,13 +403,15 @@ VARIABLES = {
 # Precip/ET0 accumulate over the window (sum); temperatures average (mean).
 SUM_VARIABLES = {"precipitation_sum", "et0_evapotranspiration"}
 
-def _annual_trend_row(era5_name: str, station_id, loc_data: pd.DataFrame,
-                      month: int, day: int, variable: str, col: str,
-                      half: int = TREND_WINDOW) -> dict | None:
-    # `half` defaults to TREND_WINDOW so the published annual_trend build (build_annual_trend
-    # below) is byte-identical; build_annual_trend_windows passes the exploratory half-widths.
-    # The module-global TREND_WINDOW is never mutated — the window is a plain argument.
-    w       = window_filter(loc_data, month, day, half)
+def _annual_trend_row(era5_name: str, station_id, w: pd.DataFrame,
+                      month: int, day: int, variable: str, col: str) -> dict | None:
+    # T-4.28: `w` is the pre-sliced ±half day-of-year window for (station, month, day),
+    # computed ONCE by the caller and shared across all five variables. window_filter's
+    # slice depends only on (station, month, day, half) — never on the variable or column
+    # (the col selection and the >= TREND_START_YEAR filter both happen below, after the
+    # slice) — so the shared frame is byte-identical to the old per-variable window_filter
+    # call. `w` is read only, once, via .groupby here; it is never mutated, so sharing one
+    # frame across the five fits cannot let one variable's fit see another's changes.
     agg_fn  = "sum" if variable in SUM_VARIABLES else "mean"
     annual  = (
         w.groupby("_window_year")[col].agg(agg_fn).dropna()
@@ -504,20 +506,31 @@ def _annual_trend_task(args):
     task_index, half, era5_name = args
     loc = _POOL_DATA[_POOL_DATA["location"] == era5_name]
     station_id = _POOL_SID_MAP.get(era5_name)
-    rows = []
-    for variable, col in VARIABLES.items():
-        for month in range(1, 13):
-            for day in range(1, 32):
-                try:
-                    pd.Timestamp(2001, month, day)
-                except ValueError:
-                    continue
-                row = _annual_trend_row(era5_name, station_id, loc, month, day,
-                                        variable, col, half=half)
+    # T-4.28: (month, day) OUTER, variable INNER. window_filter's slice depends only on
+    # (station, month, day, half) — never on the variable — so it is computed ONCE per day
+    # and reused across all five variables (it was recomputed 5× per day, the loop's single
+    # largest cost, measured 5.00× redundant). Rows are collected per variable and emitted
+    # in VARIABLES order below, reproducing the pre-T-4.28 variable→month→day CSV layout
+    # byte-for-byte. Only one slice is held at a time (the next day's overwrites it), so the
+    # memory cost is one window, not 365.
+    buckets = {variable: [] for variable in VARIABLES}
+    for month in range(1, 13):
+        for day in range(1, 32):
+            try:
+                pd.Timestamp(2001, month, day)
+            except ValueError:
+                continue
+            w = window_filter(loc, month, day, half)
+            for variable, col in VARIABLES.items():
+                row = _annual_trend_row(era5_name, station_id, w, month, day,
+                                        variable, col)
                 if row:
                     if _POOL_ADD_WINDOW_COL:
                         row["window"] = half
-                    rows.append(row)
+                    buckets[variable].append(row)
+    rows = []
+    for variable in VARIABLES:
+        rows.extend(buckets[variable])
     return task_index, rows
 
 
@@ -549,23 +562,31 @@ def _annual_trend_serial(data, stations_df, windows, add_window_col, label):
         for era5_name in station_names:
             loc      = data[data["location"] == era5_name]
             station_id = sid_map.get(era5_name)
-            for variable, col in VARIABLES.items():
-                for month in range(1, 13):
-                    for day in range(1, 32):
-                        try:
-                            pd.Timestamp(2001, month, day)
-                        except ValueError:
-                            continue
-                        row = _annual_trend_row(era5_name, station_id, loc, month, day,
-                                                variable, col, half=half)
+            # T-4.28: (month, day) outer, variable inner — slice once per day, reuse across
+            # the five variables, emit per variable in VARIABLES order. Byte-identical row
+            # order to the old variable→month→day loop (see _annual_trend_task). This is the
+            # oracle the parallel path is proven equal to, so it must restructure identically.
+            buckets = {variable: [] for variable in VARIABLES}
+            for month in range(1, 13):
+                for day in range(1, 32):
+                    try:
+                        pd.Timestamp(2001, month, day)
+                    except ValueError:
+                        continue
+                    w = window_filter(loc, month, day, half)
+                    for variable, col in VARIABLES.items():
+                        row = _annual_trend_row(era5_name, station_id, w, month, day,
+                                                variable, col)
                         if row:
                             if add_window_col:
                                 row["window"] = half
-                            rows.append(row)
+                            buckets[variable].append(row)
                         done += 1
                         if done % 500 == 0:
                             print(f"  {label} {done}/{total} ({done/total*100:.0f}%)",
                                   end="\r", flush=True)
+            for variable in VARIABLES:
+                rows.extend(buckets[variable])
     print()
     return pd.DataFrame(rows)
 


### PR DESCRIPTION
Cuts the pipeline's largest remaining sub-cost. `window_filter` was recomputing the same day-of-year slice five times per day — once per variable — and now computes it once.

**Full precompute: 226.3 s → 154.2 s (−32%)** on arm64. CI is amd64 and roughly 2× slower on this work, so the local figure understates the benefit that lands there.

**The redundancy was 5.00× exactly — not 47.7%.** That figure from T-4.27's profiling was *time in the function*; the redundancy is five identical calls per (month, day), one per variable. The ceiling is therefore ~38% of the trend loop, and this lands at 32% because the `.copy()` and the `_window_year` assignment still happen once per day rather than never. **Both the backlog and T-4.27's entry carried the 47.7% figure as though it were the redundancy** — corrected in PROGRESS.md so the next reader is not misled.

**The cleanest proof:** trend-loop `window_filter` calls went **131,400 → 26,280**, exactly 5×.

**The approach, and why not the obvious one.** A memoise on the four-part key would hold all 365 slices per task: **624 MB per worker at half=45, ~2.5 GB across four workers**. Instead the loop order swaps from `variable→month→day` to `month→day→variable`, so one slice is computed and reused across the five variables — **~1.7 MB held at a time**. A groupby-index restructure was also rejected: it sorts, and a reordered reduction moves float bits.

**The cache key was verified, not assumed.** The slice depends on `(station, month, day, half)` and nothing else — the column selection and the `>= TREND_START_YEAR` filter both happen *downstream* in `_annual_trend_row`. Within a task, station and half are fixed, so the effective key is `(month, day)`: 365 entries.

**⚠ The gate had to change, and the reason matters for every future pipeline ticket.** This work was scoped against a fixed hash anchor from 2 August. That anchor **cannot be reproduced** — the D-29 daily refresh commits new raw every night, so even the deterministic `daily` table differs. Gating on a fixed hash is not possible once the data moves underneath.

**What replaced it is stronger.** Same-machine determinism was proved *first* — unchanged code run twice on the same pinned raw, all ten tables byte-identical including `tropical.trend_json`. Only then does a before/after comparison mean anything. Result: **all ten file hashes identical** before and after, and **row order checked directly with `cmp`** rather than inferred from a matching hash.

**A caveat now recorded:** `test_reference_manifest`'s fixture is only three years, so its `annual_trend` is **empty** and its column hashes are `sha256("")`. That gate covers slicing and shape but **not the fit values** — which is exactly why the full live-raw before/after is primary. A green reference-manifest must not be read as coverage of the numbers.

**The T-5.25 tropical invariant still flags 0**, with 11 withheld and 28 failed fits before and after, and `tropical.csv` byte-identical — so the slicing change disturbed no fit's convergence.

**Determinism argument, stated as structure rather than hope:** `window_filter` is a pure function of `(loc_data, month, day, half)`, so the single frame is byte-for-byte what the old code recomputed five times. The slice is read-only downstream, and the per-variable buckets emit in `VARIABLES` order, reproducing the variable-major CSV layout. Same rows, same order, same fit.

**For context on the build:** `generate-db` was ~10–12 min before the window table, 23m25s after T-4.26a added 98,550 rows, 12m6s after T-4.27's process pool. This should take it lower still — **faster than before the new data existed**.

**Only the CI `generate-db` timing is the real measure.** Nothing local establishes it.

Gates: typecheck 0 · typecheck:gate 0 allowlisted · yarn test 79 · snapshot:check identical · pytest 75 · validate.py exit 0 · ten-hash diff **empty**.
