### PR TITLE
chore(docker): pin build-only stages to BUILDPLATFORM

### DIFF
--- a/deployment/Dockerfile.datasette
+++ b/deployment/Dockerfile.datasette
@@ -4,7 +4,7 @@
 # To build only the "builder" stage, one can do:
 # docker build --target=builder --progress=plain -f deployment/Dockerfile.datasette .
 
-FROM ghcr.io/astral-sh/uv:0.9.26-python3.13-trixie-slim AS uv_setup
+FROM --platform=$BUILDPLATFORM ghcr.io/astral-sh/uv:0.9.26-python3.13-trixie-slim AS uv_setup
 
 WORKDIR /build
 

--- a/deployment/Dockerfile.dev.base
+++ b/deployment/Dockerfile.dev.base
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:10.0.301-noble@sha256:ea8bde36c11b6e7eec2656d0e59101d4462f6bd630730f2c8201ed0572b295d5 AS builder
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:10.0.301-noble@sha256:ea8bde36c11b6e7eec2656d0e59101d4462f6bd630730f2c8201ed0572b295d5 AS builder
 ARG NODE_MAJOR=24
 
 WORKDIR /build

--- a/deployment/Dockerfile.dev.website
+++ b/deployment/Dockerfile.dev.website
@@ -1,4 +1,4 @@
-FROM podnebnik/base:1.0 AS builder
+FROM --platform=$BUILDPLATFORM podnebnik/base:1.0 AS builder
 
 COPY . /build
 


### PR DESCRIPTION
## Summary
- pin build-only stage base in `deployment/Dockerfile.datasette` to `--platform=$BUILDPLATFORM`
- pin dev build base in `deployment/Dockerfile.dev.base` to `--platform=$BUILDPLATFORM`
- pin dev website build stage in `deployment/Dockerfile.dev.website` to `--platform=$BUILDPLATFORM`

## Why
This reduces multi-arch build overhead by ensuring build-only work runs on the builder platform where applicable.

## Runtime platform behavior
- final runtime stages remain native to target platform (unchanged)
- no changes to runtime stage in `deployment/Dockerfile.datasette`
- no changes to nginx runtime stage in `deployment/Dockerfile.website`

## Notes
- local/dev references for `Dockerfile.dev*` remain via `compose.yaml`
