### PR TITLE
T-6.17 — ERA5-Land assimilates nothing, and 9 km is not the effective resolution

### DIFF
--- a/code/ali-je-vroce-era5/i18n/glossary.ts
+++ b/code/ali-je-vroce-era5/i18n/glossary.ts
@@ -31,9 +31,13 @@ export type GlossaryEntry = { readonly term: string; readonly def: string };
 
 export const glossary: Record<string, GlossaryEntry> = {
   // ── Acronyms / named identifiers ──────────────────────────────────────────
+  era5: {
+    term: "ERA5",
+    def: "Matična reanaliza ECMWF na mreži približno 31 km, ki združuje meritve, satelitske posnetke in fizikalni model. ERA5-Land iz nje izpelje podrobnejšo sliko razmer pri tleh.",
+  },
   era5_land: {
     term: "ERA5-Land",
-    def: "Podatkovni niz, ki za vsak košček ozemlja in vsak dan oceni vreme z računalniškim modelom; izdeluje ga ECMWF, prostorska gostota je približno 9 km.",
+    def: "Podatkovni niz ECMWF na mreži ~9 km, ki podrobneje izračuna razmere pri tleh. Vremenske podatke dobi iz reanalize ERA5 in sam ne vključuje nobenih meritev.",
   },
   era5t: {
     term: "ERA5T",

--- a/code/ali-je-vroce-era5/i18n/hero-content.ts
+++ b/code/ali-je-vroce-era5/i18n/hero-content.ts
@@ -194,7 +194,11 @@ Podroben tehnični opis sledi spodaj.
 
 Stran uporablja **reanalizo ERA5-Land**[[ref:era5_land_dataset]][[ref:era5_land_paper]], dostopano prek **arhivskega API-ja Open-Meteo**[[ref:open_meteo]] (ne neposredno prek [ECMWF](#gloss-ecmwf)/[CDS](#gloss-cds)). ERA5-Land je globalni reanalizni niz Evropskega centra za srednjeročne vremenske napovedi (ECMWF) z [mrežno ločljivostjo](#gloss-grid_cell) približno 9 km.
 
-Reanaliza ni isto kot meritev postaje. Je rekonstrukcija preteklega vremena, ki jo model ustvari z asimilacijo številnih virov opazovanj. Prednost je enotna, prostorsko in časovno polna pokritost brez vrzeli; slabost je, da posamezna mrežna celica ne ujame lokalnih posebnosti (npr. mestnega toplotnega otoka ali natančne mikrolokacije postaje).
+Reanaliza ni isto kot meritev postaje. Je rekonstrukcija preteklega vremena, ki nastane tako, da model združi številne vire opazovanj — meritve postaj, satelitske posnetke, podatke z ladij in letal — v enotno, prostorsko in časovno polno mrežo vrednosti.
+
+**ERA5-Land sam ne vključuje nobenih meritev.** Opazovanja združi matična reanaliza **[ERA5](#gloss-era5)** na mreži približno 31 km. ERA5-Land te vrednosti uporabi kot vhod in z njimi na gostejši mreži (~9 km) podrobneje izračuna razmere pri tleh. Gostejša mreža torej ne pomeni več opazovanj, le podrobnejši izračun iz istega vira.
+
+**Dejanska ločljivost je slabša od mrežne.** Učinkovita ločljivost ERA5 je približno tri- do štirikrat slabša od nominalne — okoli **100 km**, ne 31 km. Gostejša mreža ERA5-Land tega ne popravi.
 
 Zadnjih ~6 dni prihaja iz predhodne različice reanalize ([ERA5T](#gloss-era5t)), zato se te vrednosti lahko še spremenijo.
 
@@ -269,7 +273,7 @@ Letni trend na grafih vročih dni in tropskih noči je **model negativne binomsk
 - **Ni ARSO.** Vrednosti so reanaliza ERA5-Land, ne meritve postaj, in **niso neposredno primerljive** z objavami ARSO.
 - **Višinski popravek Kredarice** (−7,85 °C) je velik, preverjen a ne validiran po mesecih, in lahko odstopa pozimi (glej zgoraj).
 - **ERA5-Land Tmin** je v mestih nezanesljiv (toplotni otok); zato stran privzeto ne vodi s Tmean/Tmin.
-- **Mrežna ločljivost** (~9 km) ne ujame lokalnih posebnosti pod to velikostjo.
+- **Ločljivost.** Mreža ERA5-Land je ~9 km, a vremenska informacija prihaja iz ERA5, katere učinkovita ločljivost je okoli 100 km. Lokalnih posebnosti pod to velikostjo vrednosti ne ujamejo.
 - **Najnovejše vrednosti** so lahko napoved (označene z »napoved«), dokler reanaliza ni na voljo.
 - **Trend vročih dni/tropskih noči je približek** in ni na voljo za vse kombinacije praga in zaporedja: kjer se model ne ustali, trenda ne prikažemo (glej zgoraj).
 


### PR DESCRIPTION
Corrects two factual errors in the methodology, found by an ECMWF professional reviewing the page.

**(a) The page attributed observation assimilation to the wrong dataset.** It said of ERA5-Land: *"Je rekonstrukcija preteklega vremena, ki jo model ustvari z asimilacijo številnih virov opazovanj"*. **ERA5-Land assimilates nothing** — ERA5 does, and ERA5-Land derives from it.

**(b) The page implied ~9 km of real detail.** *Znane omejitve* said *"Mrežna ločljivost (~9 km) ne ujame lokalnih posebnosti pod to velikostjo"*. But the atmospheric information comes from ERA5 at an **effective resolution near 100 km** — three to four times worse than its nominal 31 km, from numerical diffusion. The finer 9 km grid **redistributes** that information rather than adding to it.

For a page whose entire claim is about station-level values, (b) is the more consequential: it is a limitation the methodology did not disclose, and it now sits beside the Kredarica correction where it belongs.

**And it exposed a gap:** the page names ERA5-Land constantly, cites ECMWF, has glossary entries for ERA5-Land and ERA5T — and **never defined ERA5 itself**. It does now.

*Vir podatkov* gains three paragraphs distinguishing what each dataset does; the `era5_land` glossary entry is revised to say it derives from ERA5 and includes no measurements; a new `era5` entry defines the parent reanalysis. The terms *downscaling*, *surface model* and *asimilacija* were deliberately avoided as jargon a lay reader cannot parse.

**Two things were deliberately left alone**, and the distinction matters. The *Na kratko* summary says *"Reanaliza združi meritve, satelite in fizikalni model"* — that attributes assimilation to **reanalysis as a concept**, linked to its glossary entry, not to ERA5-Land by name. It is correct as written. And `:195`'s *"z mrežno ločljivostjo približno 9 km"* states the grid spacing as a plain fact, which it is; the new paragraphs distinguish grid spacing from effective resolution and explicitly reconcile the two.

**⚠ A gap this ticket does not close.** The new paragraphs make a factual claim about ERA5 that the reference list **does not support**: [1] and [2] are both about ERA5-Land, and the natural citation — Hersbach et al. 2020, or the C3S ERA5 dataset page — is not in the catalogue. Under D-49 no citation is added from memory, so this ships unreferenced while the surrounding text is referenced. That asymmetry deserves a follow-up with an operator-verified source rather than being invisible.

`[ERA5](#gloss-era5)` links the true first standalone use in *Vir podatkov*, nested in bold as `:183` already does. The entry sorts between ECMWF and ERA5-Land under `Intl.Collator("sl-SI")`, verified rather than assumed.

**Dual-commit under D-23:** both wrong lines were byte-identical twins in `METHODOLOGY.md`, and the shared body is byte-identical again after the edit.

Snapshot unchanged and the structural section guard did not fire — methodology prose and glossary text are both uncaptured, and adding an entry to an existing object introduces no new capitalised tag.

**Needs eyes on stage** (the page is now at `/ali-je-vroce/`, routes swapped in `a2bde60`): that the three new paragraphs read correctly, and that the ERA5 link opens its entry.

Gates: typecheck 0 · typecheck:gate 0 allowlisted · yarn test 79 · text-integrity 5/5 · snapshot:check byte-identical, 0 misses · pytest 77.
