### PR TITLE
T-6.18 — one name for the elevation correction; last hardcoded Slovenian into the catalogue

### DIFF
--- a/code/ali-je-vroce-era5/api.ts
+++ b/code/ali-je-vroce-era5/api.ts
@@ -742,7 +742,7 @@ async function buildRegressionResult(
     },
     baseline,
     stats: {
-      method: "Theil-Sen + MK", trend10: r.trend10, metric: r.trend10,
+      method: t("reg.method_short"), trend10: r.trend10, metric: r.trend10,
       metric_lbl: "trend / 10 let", p_val: r.p_val,
       direction: r.trend10 >= 0 ? "up" : "down",
       // T-5.51 M3 — unit derived per variable. NOTE: chg_str is still DEAD (nothing
@@ -900,7 +900,12 @@ export async function fetchCalendar(
   );
   // T-5.51 M2 — unit derived per variable (mm for precip/ET₀), feeds the year-round
   // tooltip "{trend} {unit}/desetletje".
-  return { loc, var: variable, unit: varUnit(variable), method_label: "Theil-Sen + MK", rows };
+  // method_label is CAPTURED by the snapshot harness (tests/snapshot/harness.tsx via
+  // CalendarData.method_label), NOT rendered by any component — that is deliberate: it
+  // is a tripwire so a change to the method label shows up in the baseline even though
+  // nothing on the page reads it (T-5.62 corrected its value for exactly this reason).
+  // Do NOT delete it as "dead code". Value moved to the catalogue (D-8, T-6.18).
+  return { loc, var: variable, unit: varUnit(variable), method_label: t("reg.method_short"), rows };
 }
 
 // ── fetchAnnualTrend ───────────────────────────────────────────────────────────

--- a/code/ali-je-vroce-era5/charts/Era5TropicalChart.tsx
+++ b/code/ali-je-vroce-era5/charts/Era5TropicalChart.tsx
@@ -16,11 +16,6 @@ const ERA5_CONFIGS: Record<string, Config> = {
     unitLabel:        t("tropical.unit_days"),
     defaultThreshold: 30,
     minT: 25, maxT: 35,
-    // NB: subLabel is currently unreferenced (the section subtitle is rendered from
-    // sections.tropical_days_sub in AliJeVroceERA5). Left as-is — see PROGRESS T-5.5.
-    subLabel:         (th, st) => `Število dni z najvišjo temperaturo nad ${th} °C` +
-      (st > 1 ? `, v nizih ${st}+ zaporednih dni` : "") +
-      ` na leto · lapsna korekcija nadmorske višine · ERA5-Land`,
     tooltipNoun:      t("tropical.noun_days"),
     plainDesc:        (th) => t("tropical.plain_desc_days", { th: fmtInt(th) }),
     plainNounInstr:   t("tropical.instr_days"),
@@ -30,9 +25,6 @@ const ERA5_CONFIGS: Record<string, Config> = {
     unitLabel:        t("tropical.unit_nights"),
     defaultThreshold: 20,
     minT: 15, maxT: 25,
-    subLabel:         (th, st) => `Število noči z najnižjo temperaturo nad ${th} °C` +
-      (st > 1 ? `, v nizih ${st}+ zaporednih noči` : "") +
-      ` na leto · lapsna korekcija nadmorske višine · ERA5-Land`,
     tooltipNoun:      t("tropical.noun_nights"),
     plainDesc:        (th) => t("tropical.plain_desc_nights", { th: fmtInt(th) }),
     plainNounInstr:   t("tropical.instr_nights"),

--- a/code/ali-je-vroce-era5/charts/TropicalChart.tsx
+++ b/code/ali-je-vroce-era5/charts/TropicalChart.tsx
@@ -40,7 +40,6 @@ export interface Config {
   defaultThreshold: number;
   minT:             number;
   maxT:             number;
-  subLabel:         (th: number, st: number) => string;
   tooltipNoun:      string;
   plainDesc:        (th: number) => string;
   plainNounInstr:   string;  // instrumental-plural noun for no_trend ("z {instr}")

--- a/code/ali-je-vroce-era5/i18n/glossary.ts
+++ b/code/ali-je-vroce-era5/i18n/glossary.ts
@@ -114,7 +114,7 @@ export const glossary: Record<string, GlossaryEntry> = {
     def: "Model ozemlje razdeli na kvadrate ~9 km; vrednost velja za cel kvadrat, zato ne ujame posebnosti, manjših od tega.",
   },
   lapse_rate: {
-    term: "višinski popravek (lapse-rate)",
+    term: "korekcija na nadmorsko višino postaje (lapse-rate)",
     def: "Ker mreža ne leži točno na višini postaje, vrednost prilagodimo za razliko v nadmorski višini po pravilu 6,5 °C na kilometer.",
   },
   distribution: {
@@ -167,7 +167,7 @@ export const glossary: Record<string, GlossaryEntry> = {
   },
   temperature_inversion: {
     term: "temperaturna inverzija",
-    def: "Ko je zrak v višini toplejši od zraka pri tleh — pogosto pozimi v kotlinah. Takrat višinski popravek slabše deluje.",
+    def: "Ko je zrak v višini toplejši od zraka pri tleh — pogosto pozimi v kotlinah. Takrat korekcija na nadmorsko višino slabše deluje.",
   },
   water_balance: {
     term: "vodna bilanca",

--- a/code/ali-je-vroce-era5/i18n/hero-content.ts
+++ b/code/ali-je-vroce-era5/i18n/hero-content.ts
@@ -182,7 +182,7 @@ Ta stran prikazuje, kako topel je današnji dan v Sloveniji v primerjavi z zgodo
 
 - **Podatki niso meritve slovenskih vremenskih postaj ([ARSO](#gloss-arso)).** Prihajajo iz **[reanalize](#gloss-reanalysis) [ERA5-Land](#gloss-era5_land)** (evropski podatkovni model, dostopen prek arhiva [Open-Meteo](#gloss-open_meteo)). Reanaliza združi meritve, satelite in fizikalni model v enotno mrežo vrednosti. Zato **številke niso neposredno primerljive** z uradnimi objavami ARSO, ki temeljijo na meritvah postaj.
 - **Stran privzeto prikazuje najvišjo dnevno temperaturo ([Tmax](#gloss-temp_stats))** — »kako vroč je bil dan«. Povprečno in najnižjo temperaturo lahko izberete ročno, a nista privzeti (razlog je spodaj).
-- **Vsaka postaja je višinsko popravljena.** Ker mreža modela ne leži točno na višini postaje, vrednosti prilagodimo za razliko v nadmorski višini. **Za Kredarico je ta popravek −7,85 °C** — daleč največji na strani. Podrobnosti so spodaj; navajamo jih odkrito, ker gre za velik poseg v prikazano vrednost.
+- **Vsaka postaja je popravljena na nadmorsko višino.** Ker mreža modela ne leži točno na višini postaje, vrednosti prilagodimo za razliko v nadmorski višini. **Za Kredarico je ta popravek −7,85 °C** — daleč največji na strani. Podrobnosti so spodaj; navajamo jih odkrito, ker gre za velik poseg v prikazano vrednost.
 - **»Slovenija« pomeni povprečje 18 postaj**, ne ene same nacionalne meritve. Postaje segajo od morske gladine (10 m) do Kredarice (2514 m).
 - **Referenčno obdobje za [odklone](#gloss-anomaly) je 1991–2020** (veljavna [klimatološka norma](#gloss-climatological_normal) [WMO](#gloss-wmo)). Ker je to razmeroma toplo obdobje, se velik del zapisov 1950–2026 prikaže kot negativni odklon.
 
@@ -208,7 +208,7 @@ Za današnje in najnovejše vrednosti, kjer reanaliza še ni na voljo, stran upo
 
 Stran zajema **18 lokacij** po Sloveniji. Za vsako je vrednost vzeta iz mrežne celice ERA5-Land nad njo. Nabor postaj sega od nižin do visokogorja — med drugim Koper (blizu morske gladine, ~10 m), Postojna (549 m), Rateče (864 m) in Kredarica (2514 m). Celoten razpon nadmorskih višin je **10–2514 m**.
 
-## [Višinski popravek](#gloss-lapse_rate) (lapse-rate)
+## [Korekcija na nadmorsko višino postaje](#gloss-lapse_rate)
 
 Mrežna celica ERA5-Land redko leži točno na nadmorski višini postaje. Da bi vrednosti ustrezale višini postaje in ne višini mrežne celice, vsako popravimo s **fiksno stopnjo 6,5 °C na kilometer** razlike med višino postaje in višino mrežne celice. To je standardna vrednost povprečne stopnje ohlajanja ozračja z višino.[[ref:lapse_rate]]
 
@@ -228,7 +228,7 @@ Razlog je kakovost podatkov. Reanaliza ERA5-Land sistematično slabše oceni **n
 
 ## Kaj pomeni »Slovenija«
 
-Nacionalna vrednost je **neuteženo povprečje vseh 18 postaj**, vključno z višinsko popravljeno Kredarico — na strani poimenovano »povprečje 18 postaj«, s prikazanim naborom postaj in razponom višin.
+Nacionalna vrednost je **neuteženo povprečje vseh 18 postaj**, vključno s Kredarico, popravljeno na nadmorsko višino — na strani poimenovano »povprečje 18 postaj«, s prikazanim naborom postaj in razponom višin.
 
 Uteževanje po površini ali višinskih pasovih smo pretehtali in **zavrnili**: ker je nad 1000 m le ena postaja (Kredarica), bi ta sama nosila cel višinski pas. To bi bilo videti natančno, a bi slonelo na eni sami točki. Neuteženo povprečje nad vidnim, poimenovanim naborom postaj je poštenejša konstrukcija.
 
@@ -271,7 +271,7 @@ Letni trend na grafih vročih dni in tropskih noči je **model negativne binomsk
 ## Znane omejitve
 
 - **Ni ARSO.** Vrednosti so reanaliza ERA5-Land, ne meritve postaj, in **niso neposredno primerljive** z objavami ARSO.
-- **Višinski popravek Kredarice** (−7,85 °C) je velik, preverjen a ne validiran po mesecih, in lahko odstopa pozimi (glej zgoraj).
+- **Korekcija na nadmorsko višino Kredarice** (−7,85 °C) je velik, preverjen a ne validiran po mesecih, in lahko odstopa pozimi (glej zgoraj).
 - **ERA5-Land Tmin** je v mestih nezanesljiv (toplotni otok); zato stran privzeto ne vodi s Tmean/Tmin.
 - **Ločljivost.** Mreža ERA5-Land je ~9 km, a vremenska informacija prihaja iz ERA5, katere učinkovita ločljivost je okoli 100 km. Lokalnih posebnosti pod to velikostjo vrednosti ne ujamejo.
 - **Najnovejše vrednosti** so lahko napoved (označene z »napoved«), dokler reanaliza ni na voljo.

--- a/code/ali-je-vroce-era5/i18n/sl.ts
+++ b/code/ali-je-vroce-era5/i18n/sl.ts
@@ -95,9 +95,9 @@ export const sl = {
     spei_trend: "Sušni trend po postaji — SPEI",
     spei_trend_sub: "Sezonski (SPEI-3) in mesečni (SPEI-30) indeks vodne bilance · Theil-Sen · ERA5-Land",
     tropical_days: "Vroči dnevi",
-    tropical_days_sub: "Število dni z najvišjo temperaturo nad pragom · ERA5-Land · lapsna korekcija nadmorske višine",
+    tropical_days_sub: "Število dni z najvišjo temperaturo nad pragom · ERA5-Land · korekcija na nadmorsko višino",
     tropical_nights: "Tropske noči",
-    tropical_nights_sub: "Število noči z najnižjo temperaturo nad pragom · ERA5-Land · lapsna korekcija nadmorske višine",
+    tropical_nights_sub: "Število noči z najnižjo temperaturo nad pragom · ERA5-Land · korekcija na nadmorsko višino",
     sea_level: "Dvig morske gladine — Koper",
     sea_level_sub: "Projekcije dviga morske gladine po scenarijih IPCC AR6 z viharnimi nalivi · severni Jadran",
   },
@@ -228,7 +228,7 @@ export const sl = {
     title_station: "Najvišje temperature na postaji {station} okoli {day} · {yearMin}–{yearMax} · trend s projekcijo do 2050",
     title_nat: "Najvišje temperature v Sloveniji okoli {day} · {yearMin}–{yearMax} · trend s projekcijo do 2050",
     explain: "Vsaka pika je povprečna vrednost ({source}) v ±7-dnevnem oknu okoli tega datuma za vsako leto od {yearMin}. Trend Theil-Sen je {trend} °C/desetletje ({sig}). Po tem tempu projekcija kaže {proj2050} °C do leta 2050. Zasenčeni pas je 95% interval zaupanja za nagib.",
-    explain_source_station: "lapsno popravljene dnevne najvišje temperature na postaji {station}",
+    explain_source_station: "dnevne najvišje temperature na postaji {station}, popravljene na nadmorsko višino",
     explain_source_nat: "nacionalne povprečne dnevne najvišje temperature vseh {count, plural, one{# postaje} two{# postaj} few{# postaj} other{# postaj}}",
     foot: "Theil-Sen + MK: {trend} °C/desetletje · {sig} · τ = {tau} · 95% CI · {count, plural, one{# leto} two{# leti} few{# leta} other{# let}}",
     tooltip_annual: "<b>{x}</b>: {y} °C",
@@ -275,9 +275,13 @@ export const sl = {
     year_round_footer: "prosojnost = značilnost · p < 0,001 povsem neprosojno",
 
     // T-5.51 (E3) — precip/ET₀ read raw columns with NO elevation correction, so the
-    // "· nadmorska korekcija" clause is dropped for them (it is simply false there).
-    explain_reg: "Theil-Sen regresija + Yue-Wang Mann-Kendall test · ERA5-Land · nadmorska korekcija",
+    // "· korekcija na nadmorsko višino" clause is dropped for them (it is simply false there).
+    explain_reg: "Theil-Sen regresija + Yue-Wang Mann-Kendall test · ERA5-Land · korekcija na nadmorsko višino",
     explain_reg_nocorr: "Theil-Sen regresija + Yue-Wang Mann-Kendall test · ERA5-Land",
+    // T-6.18 — the stats-badge method label, moved out of api.ts (D-8). Rendered at
+    // RegressionPanel.tsx:478 as `{method} · {fit_desc}`, and captured by the snapshot
+    // harness via CalendarData.method_label. Value byte-identical to the old literal.
+    method_short: "Theil-Sen + MK",
     // T-5.51 (E2) — the calendar colour legend, three-way; only the colour clause
     // varies. "segrevanje" (was "ogrevanje") unifies with the reg.warming legend word.
     explain_cal: "Trend na desetletje za vsak dan v letu · rdeča = segrevanje · modra = ohlajanje · prosojnost = statistična značilnost",

--- a/tests/fixtures/snapshot.json
+++ b/tests/fixtures/snapshot.json
@@ -33707,7 +33707,7 @@
           "total_change": "+4,35°C",
           "total_change_color": "rgb(204, 34, 34)",
           "footer": [
-            "Theil-Sen regresija + Yue-Wang Mann-Kendall test · ERA5-Land · nadmorska korekcija"
+            "Theil-Sen regresija + Yue-Wang Mann-Kendall test · ERA5-Land · korekcija na nadmorsko višino"
           ]
         },
         "charts": [
@@ -36772,7 +36772,7 @@
         },
         "rendered": {
           "title": "Najvišje temperature na postaji Ljubljana okoli 21. jul. · 1950–2026 · trend s projekcijo do 2050",
-          "explain": "Vsaka pika je povprečna vrednost (lapsno popravljene dnevne najvišje temperature na postaji Ljubljana) v ±7-dnevnem oknu okoli tega datuma za vsako leto od 1950. Trend Theil-Sen je +0,56 °C/desetletje (p < 0,001). Po tem tempu projekcija kaže 28,4 °C do leta 2050. Zasenčeni pas je 95% interval zaupanja za nagib.",
+          "explain": "Vsaka pika je povprečna vrednost (dnevne najvišje temperature na postaji Ljubljana, popravljene na nadmorsko višino) v ±7-dnevnem oknu okoli tega datuma za vsako leto od 1950. Trend Theil-Sen je +0,56 °C/desetletje (p < 0,001). Po tem tempu projekcija kaže 28,4 °C do leta 2050. Zasenčeni pas je 95% interval zaupanja za nagib.",
           "footer": "Theil-Sen + MK: +0,56 °C/desetletje · p < 0,001 · τ = 0,335 · 95% CI · 77 let",
           "current_year_plotline": {
             "value": 2026,
@@ -37233,7 +37233,7 @@
           "total_change": "+4,35°C",
           "total_change_color": "rgb(204, 34, 34)",
           "footer": [
-            "Theil-Sen regresija + Yue-Wang Mann-Kendall test · ERA5-Land · nadmorska korekcija"
+            "Theil-Sen regresija + Yue-Wang Mann-Kendall test · ERA5-Land · korekcija na nadmorsko višino"
           ]
         },
         "charts": [
@@ -40298,7 +40298,7 @@
         },
         "rendered": {
           "title": "Najvišje temperature na postaji Kredarica okoli 21. jul. · 1950–2026 · trend s projekcijo do 2050",
-          "explain": "Vsaka pika je povprečna vrednost (lapsno popravljene dnevne najvišje temperature na postaji Kredarica) v ±7-dnevnem oknu okoli tega datuma za vsako leto od 1950. Trend Theil-Sen je +0,36 °C/desetletje (p < 0,001). Po tem tempu projekcija kaže 13,4 °C do leta 2050. Zasenčeni pas je 95% interval zaupanja za nagib.",
+          "explain": "Vsaka pika je povprečna vrednost (dnevne najvišje temperature na postaji Kredarica, popravljene na nadmorsko višino) v ±7-dnevnem oknu okoli tega datuma za vsako leto od 1950. Trend Theil-Sen je +0,36 °C/desetletje (p < 0,001). Po tem tempu projekcija kaže 13,4 °C do leta 2050. Zasenčeni pas je 95% interval zaupanja za nagib.",
           "footer": "Theil-Sen + MK: +0,36 °C/desetletje · p < 0,001 · τ = 0,254 · 95% CI · 77 let",
           "current_year_plotline": {
             "value": 2026,
@@ -40759,7 +40759,7 @@
           "total_change": "+2,74°C",
           "total_change_color": "rgb(204, 34, 34)",
           "footer": [
-            "Theil-Sen regresija + Yue-Wang Mann-Kendall test · ERA5-Land · nadmorska korekcija"
+            "Theil-Sen regresija + Yue-Wang Mann-Kendall test · ERA5-Land · korekcija na nadmorsko višino"
           ]
         },
         "charts": [
@@ -44094,7 +44094,7 @@
           "total_change": "+3,76°C",
           "total_change_color": "rgb(204, 34, 34)",
           "footer": [
-            "Theil-Sen regresija + Yue-Wang Mann-Kendall test · ERA5-Land · nadmorska korekcija"
+            "Theil-Sen regresija + Yue-Wang Mann-Kendall test · ERA5-Land · korekcija na nadmorsko višino"
           ]
         },
         "charts": [
@@ -47159,7 +47159,7 @@
         },
         "rendered": {
           "title": "Najvišje temperature na postaji Ljubljana okoli 29. jul. · 1950–2026 · trend s projekcijo do 2050",
-          "explain": "Vsaka pika je povprečna vrednost (lapsno popravljene dnevne najvišje temperature na postaji Ljubljana) v ±7-dnevnem oknu okoli tega datuma za vsako leto od 1950. Trend Theil-Sen je +0,49 °C/desetletje (p < 0,001). Po tem tempu projekcija kaže 28,0 °C do leta 2050. Zasenčeni pas je 95% interval zaupanja za nagib.",
+          "explain": "Vsaka pika je povprečna vrednost (dnevne najvišje temperature na postaji Ljubljana, popravljene na nadmorsko višino) v ±7-dnevnem oknu okoli tega datuma za vsako leto od 1950. Trend Theil-Sen je +0,49 °C/desetletje (p < 0,001). Po tem tempu projekcija kaže 28,0 °C do leta 2050. Zasenčeni pas je 95% interval zaupanja za nagib.",
           "footer": "Theil-Sen + MK: +0,49 °C/desetletje · p < 0,001 · τ = 0,327 · 95% CI · 77 let",
           "current_year_plotline": {
             "value": 2026,
@@ -47620,7 +47620,7 @@
           "total_change": "+3,76°C",
           "total_change_color": "rgb(204, 34, 34)",
           "footer": [
-            "Theil-Sen regresija + Yue-Wang Mann-Kendall test · ERA5-Land · nadmorska korekcija"
+            "Theil-Sen regresija + Yue-Wang Mann-Kendall test · ERA5-Land · korekcija na nadmorsko višino"
           ]
         },
         "charts": [
@@ -50685,7 +50685,7 @@
         },
         "rendered": {
           "title": "Najvišje temperature na postaji Kredarica okoli 29. jul. · 1950–2026 · trend s projekcijo do 2050",
-          "explain": "Vsaka pika je povprečna vrednost (lapsno popravljene dnevne najvišje temperature na postaji Kredarica) v ±7-dnevnem oknu okoli tega datuma za vsako leto od 1950. Trend Theil-Sen je +0,31 °C/desetletje (p < 0,001). Po tem tempu projekcija kaže 13,3 °C do leta 2050. Zasenčeni pas je 95% interval zaupanja za nagib.",
+          "explain": "Vsaka pika je povprečna vrednost (dnevne najvišje temperature na postaji Kredarica, popravljene na nadmorsko višino) v ±7-dnevnem oknu okoli tega datuma za vsako leto od 1950. Trend Theil-Sen je +0,31 °C/desetletje (p < 0,001). Po tem tempu projekcija kaže 13,3 °C do leta 2050. Zasenčeni pas je 95% interval zaupanja za nagib.",
           "footer": "Theil-Sen + MK: +0,31 °C/desetletje · p < 0,001 · τ = 0,258 · 95% CI · 77 let",
           "current_year_plotline": {
             "value": 2026,
@@ -51146,7 +51146,7 @@
           "total_change": "+2,40°C",
           "total_change_color": "rgb(204, 34, 34)",
           "footer": [
-            "Theil-Sen regresija + Yue-Wang Mann-Kendall test · ERA5-Land · nadmorska korekcija"
+            "Theil-Sen regresija + Yue-Wang Mann-Kendall test · ERA5-Land · korekcija na nadmorsko višino"
           ]
         },
         "charts": [
@@ -54481,7 +54481,7 @@
           "total_change": "+3,54°C",
           "total_change_color": "rgb(204, 34, 34)",
           "footer": [
-            "Theil-Sen regresija + Yue-Wang Mann-Kendall test · ERA5-Land · nadmorska korekcija"
+            "Theil-Sen regresija + Yue-Wang Mann-Kendall test · ERA5-Land · korekcija na nadmorsko višino"
           ]
         },
         "charts": [
@@ -57546,7 +57546,7 @@
         },
         "rendered": {
           "title": "Najvišje temperature na postaji Ljubljana okoli 15. jul. · 1950–2026 · trend s projekcijo do 2050",
-          "explain": "Vsaka pika je povprečna vrednost (lapsno popravljene dnevne najvišje temperature na postaji Ljubljana) v ±7-dnevnem oknu okoli tega datuma za vsako leto od 1950. Trend Theil-Sen je +0,46 °C/desetletje (p < 0,001). Po tem tempu projekcija kaže 27,2 °C do leta 2050. Zasenčeni pas je 95% interval zaupanja za nagib.",
+          "explain": "Vsaka pika je povprečna vrednost (dnevne najvišje temperature na postaji Ljubljana, popravljene na nadmorsko višino) v ±7-dnevnem oknu okoli tega datuma za vsako leto od 1950. Trend Theil-Sen je +0,46 °C/desetletje (p < 0,001). Po tem tempu projekcija kaže 27,2 °C do leta 2050. Zasenčeni pas je 95% interval zaupanja za nagib.",
           "footer": "Theil-Sen + MK: +0,46 °C/desetletje · p < 0,001 · τ = 0,305 · 95% CI · 77 let",
           "current_year_plotline": {
             "value": 2026,
@@ -58007,7 +58007,7 @@
           "total_change": "+3,54°C",
           "total_change_color": "rgb(204, 34, 34)",
           "footer": [
-            "Theil-Sen regresija + Yue-Wang Mann-Kendall test · ERA5-Land · nadmorska korekcija"
+            "Theil-Sen regresija + Yue-Wang Mann-Kendall test · ERA5-Land · korekcija na nadmorsko višino"
           ]
         },
         "charts": [
@@ -61072,7 +61072,7 @@
         },
         "rendered": {
           "title": "Najvišje temperature na postaji Kredarica okoli 15. jul. · 1950–2026 · trend s projekcijo do 2050",
-          "explain": "Vsaka pika je povprečna vrednost (lapsno popravljene dnevne najvišje temperature na postaji Kredarica) v ±7-dnevnem oknu okoli tega datuma za vsako leto od 1950. Trend Theil-Sen je +0,22 °C/desetletje (p < 0,001). Po tem tempu projekcija kaže 12,1 °C do leta 2050. Zasenčeni pas je 95% interval zaupanja za nagib.",
+          "explain": "Vsaka pika je povprečna vrednost (dnevne najvišje temperature na postaji Kredarica, popravljene na nadmorsko višino) v ±7-dnevnem oknu okoli tega datuma za vsako leto od 1950. Trend Theil-Sen je +0,22 °C/desetletje (p < 0,001). Po tem tempu projekcija kaže 12,1 °C do leta 2050. Zasenčeni pas je 95% interval zaupanja za nagib.",
           "footer": "Theil-Sen + MK: +0,22 °C/desetletje · p < 0,001 · τ = 0,189 · 95% CI · 77 let",
           "current_year_plotline": {
             "value": 2026,
@@ -61533,7 +61533,7 @@
           "total_change": "+1,72°C",
           "total_change_color": "rgb(204, 34, 34)",
           "footer": [
-            "Theil-Sen regresija + Yue-Wang Mann-Kendall test · ERA5-Land · nadmorska korekcija"
+            "Theil-Sen regresija + Yue-Wang Mann-Kendall test · ERA5-Land · korekcija na nadmorsko višino"
           ]
         },
         "charts": [
@@ -62378,7 +62378,7 @@
           "total_change": "+4,40°C",
           "total_change_color": "rgb(204, 34, 34)",
           "footer": [
-            "Theil-Sen regresija + Yue-Wang Mann-Kendall test · ERA5-Land · nadmorska korekcija"
+            "Theil-Sen regresija + Yue-Wang Mann-Kendall test · ERA5-Land · korekcija na nadmorsko višino"
           ]
         },
         "charts": [
@@ -63223,7 +63223,7 @@
           "total_change": "+2,90°C",
           "total_change_color": "rgb(204, 34, 34)",
           "footer": [
-            "Theil-Sen regresija + Yue-Wang Mann-Kendall test · ERA5-Land · nadmorska korekcija"
+            "Theil-Sen regresija + Yue-Wang Mann-Kendall test · ERA5-Land · korekcija na nadmorsko višino"
           ]
         },
         "charts": [
@@ -64019,7 +64019,7 @@
           "total_change": "+4,40°C",
           "total_change_color": "rgb(204, 34, 34)",
           "footer": [
-            "Theil-Sen regresija + Yue-Wang Mann-Kendall test · ERA5-Land · nadmorska korekcija"
+            "Theil-Sen regresija + Yue-Wang Mann-Kendall test · ERA5-Land · korekcija na nadmorsko višino"
           ]
         },
         "charts": [
@@ -67066,7 +67066,7 @@
         },
         "rendered": {
           "title": "Najvišje temperature na postaji Ljubljana okoli 1. mar. · 1950–2026 · trend s projekcijo do 2050",
-          "explain": "Vsaka pika je povprečna vrednost (lapsno popravljene dnevne najvišje temperature na postaji Ljubljana) v ±7-dnevnem oknu okoli tega datuma za vsako leto od 1950. Trend Theil-Sen je +0,56 °C/desetletje (p < 0,001). Po tem tempu projekcija kaže 10,5 °C do leta 2050. Zasenčeni pas je 95% interval zaupanja za nagib.",
+          "explain": "Vsaka pika je povprečna vrednost (dnevne najvišje temperature na postaji Ljubljana, popravljene na nadmorsko višino) v ±7-dnevnem oknu okoli tega datuma za vsako leto od 1950. Trend Theil-Sen je +0,56 °C/desetletje (p < 0,001). Po tem tempu projekcija kaže 10,5 °C do leta 2050. Zasenčeni pas je 95% interval zaupanja za nagib.",
           "footer": "Theil-Sen + MK: +0,56 °C/desetletje · p < 0,001 · τ = 0,214 · 95% CI · 77 let",
           "current_year_plotline": {
             "value": 2026,
@@ -67527,7 +67527,7 @@
           "total_change": "+4,29°C",
           "total_change_color": "rgb(204, 34, 34)",
           "footer": [
-            "Theil-Sen regresija + Yue-Wang Mann-Kendall test · ERA5-Land · nadmorska korekcija"
+            "Theil-Sen regresija + Yue-Wang Mann-Kendall test · ERA5-Land · korekcija na nadmorsko višino"
           ]
         },
         "charts": [
@@ -70592,7 +70592,7 @@
         },
         "rendered": {
           "title": "Najvišje temperature na postaji Ljubljana okoli 28. feb. · 1950–2026 · trend s projekcijo do 2050",
-          "explain": "Vsaka pika je povprečna vrednost (lapsno popravljene dnevne najvišje temperature na postaji Ljubljana) v ±7-dnevnem oknu okoli tega datuma za vsako leto od 1950. Trend Theil-Sen je +0,57 °C/desetletje (p < 0,001). Po tem tempu projekcija kaže 10,2 °C do leta 2050. Zasenčeni pas je 95% interval zaupanja za nagib.",
+          "explain": "Vsaka pika je povprečna vrednost (dnevne najvišje temperature na postaji Ljubljana, popravljene na nadmorsko višino) v ±7-dnevnem oknu okoli tega datuma za vsako leto od 1950. Trend Theil-Sen je +0,57 °C/desetletje (p < 0,001). Po tem tempu projekcija kaže 10,2 °C do leta 2050. Zasenčeni pas je 95% interval zaupanja za nagib.",
           "footer": "Theil-Sen + MK: +0,57 °C/desetletje · p < 0,001 · τ = 0,214 · 95% CI · 77 let",
           "current_year_plotline": {
             "value": 2026,
@@ -71053,7 +71053,7 @@
           "total_change": "+4,40°C",
           "total_change_color": "rgb(204, 34, 34)",
           "footer": [
-            "Theil-Sen regresija + Yue-Wang Mann-Kendall test · ERA5-Land · nadmorska korekcija"
+            "Theil-Sen regresija + Yue-Wang Mann-Kendall test · ERA5-Land · korekcija na nadmorsko višino"
           ]
         },
         "charts": [
@@ -74118,7 +74118,7 @@
         },
         "rendered": {
           "title": "Najvišje temperature na postaji Ljubljana okoli 1. mar. · 1950–2026 · trend s projekcijo do 2050",
-          "explain": "Vsaka pika je povprečna vrednost (lapsno popravljene dnevne najvišje temperature na postaji Ljubljana) v ±7-dnevnem oknu okoli tega datuma za vsako leto od 1950. Trend Theil-Sen je +0,56 °C/desetletje (p < 0,001). Po tem tempu projekcija kaže 10,5 °C do leta 2050. Zasenčeni pas je 95% interval zaupanja za nagib.",
+          "explain": "Vsaka pika je povprečna vrednost (dnevne najvišje temperature na postaji Ljubljana, popravljene na nadmorsko višino) v ±7-dnevnem oknu okoli tega datuma za vsako leto od 1950. Trend Theil-Sen je +0,56 °C/desetletje (p < 0,001). Po tem tempu projekcija kaže 10,5 °C do leta 2050. Zasenčeni pas je 95% interval zaupanja za nagib.",
           "footer": "Theil-Sen + MK: +0,56 °C/desetletje · p < 0,001 · τ = 0,214 · 95% CI · 77 let",
           "current_year_plotline": {
             "value": 2026,
@@ -74579,7 +74579,7 @@
           "total_change": "+4,29°C",
           "total_change_color": "rgb(204, 34, 34)",
           "footer": [
-            "Theil-Sen regresija + Yue-Wang Mann-Kendall test · ERA5-Land · nadmorska korekcija"
+            "Theil-Sen regresija + Yue-Wang Mann-Kendall test · ERA5-Land · korekcija na nadmorsko višino"
           ]
         },
         "charts": [
@@ -77644,7 +77644,7 @@
         },
         "rendered": {
           "title": "Najvišje temperature na postaji Ljubljana okoli 1. jan. · 1950–2026 · trend s projekcijo do 2050",
-          "explain": "Vsaka pika je povprečna vrednost (lapsno popravljene dnevne najvišje temperature na postaji Ljubljana) v ±7-dnevnem oknu okoli tega datuma za vsako leto od 1950. Trend Theil-Sen je +0,48 °C/desetletje (p < 0,001). Po tem tempu projekcija kaže 6,3 °C do leta 2050. Zasenčeni pas je 95% interval zaupanja za nagib.",
+          "explain": "Vsaka pika je povprečna vrednost (dnevne najvišje temperature na postaji Ljubljana, popravljene na nadmorsko višino) v ±7-dnevnem oknu okoli tega datuma za vsako leto od 1950. Trend Theil-Sen je +0,48 °C/desetletje (p < 0,001). Po tem tempu projekcija kaže 6,3 °C do leta 2050. Zasenčeni pas je 95% interval zaupanja za nagib.",
           "footer": "Theil-Sen + MK: +0,48 °C/desetletje · p < 0,001 · τ = 0,239 · 95% CI · 77 let",
           "current_year_plotline": {
             "value": 2026,
@@ -78105,7 +78105,7 @@
           "total_change": "+3,73°C",
           "total_change_color": "rgb(204, 34, 34)",
           "footer": [
-            "Theil-Sen regresija + Yue-Wang Mann-Kendall test · ERA5-Land · nadmorska korekcija"
+            "Theil-Sen regresija + Yue-Wang Mann-Kendall test · ERA5-Land · korekcija na nadmorsko višino"
           ]
         },
         "charts": [
@@ -81166,7 +81166,7 @@
         },
         "rendered": {
           "title": "Najvišje temperature na postaji Ljubljana okoli 31. dec. · 1950–2025 · trend s projekcijo do 2050",
-          "explain": "Vsaka pika je povprečna vrednost (lapsno popravljene dnevne najvišje temperature na postaji Ljubljana) v ±7-dnevnem oknu okoli tega datuma za vsako leto od 1950. Trend Theil-Sen je +0,51 °C/desetletje (p < 0,001). Po tem tempu projekcija kaže 6,4 °C do leta 2050. Zasenčeni pas je 95% interval zaupanja za nagib.",
+          "explain": "Vsaka pika je povprečna vrednost (dnevne najvišje temperature na postaji Ljubljana, popravljene na nadmorsko višino) v ±7-dnevnem oknu okoli tega datuma za vsako leto od 1950. Trend Theil-Sen je +0,51 °C/desetletje (p < 0,001). Po tem tempu projekcija kaže 6,4 °C do leta 2050. Zasenčeni pas je 95% interval zaupanja za nagib.",
           "footer": "Theil-Sen + MK: +0,51 °C/desetletje · p < 0,001 · τ = 0,270 · 95% CI · 76 let",
           "current_year_plotline": {
             "value": 2026,
@@ -81623,7 +81623,7 @@
           "total_change": "+3,90°C",
           "total_change_color": "rgb(204, 34, 34)",
           "footer": [
-            "Theil-Sen regresija + Yue-Wang Mann-Kendall test · ERA5-Land · nadmorska korekcija"
+            "Theil-Sen regresija + Yue-Wang Mann-Kendall test · ERA5-Land · korekcija na nadmorsko višino"
           ]
         },
         "charts": [
@@ -84684,7 +84684,7 @@
         },
         "rendered": {
           "title": "Najvišje temperature na postaji Ljubljana okoli 3. avg. · 1950–2025 · trend s projekcijo do 2050",
-          "explain": "Vsaka pika je povprečna vrednost (lapsno popravljene dnevne najvišje temperature na postaji Ljubljana) v ±7-dnevnem oknu okoli tega datuma za vsako leto od 1950. Trend Theil-Sen je +0,41 °C/desetletje (p < 0,001). Po tem tempu projekcija kaže 27,4 °C do leta 2050. Zasenčeni pas je 95% interval zaupanja za nagib.",
+          "explain": "Vsaka pika je povprečna vrednost (dnevne najvišje temperature na postaji Ljubljana, popravljene na nadmorsko višino) v ±7-dnevnem oknu okoli tega datuma za vsako leto od 1950. Trend Theil-Sen je +0,41 °C/desetletje (p < 0,001). Po tem tempu projekcija kaže 27,4 °C do leta 2050. Zasenčeni pas je 95% interval zaupanja za nagib.",
           "footer": "Theil-Sen + MK: +0,41 °C/desetletje · p < 0,001 · τ = 0,284 · 95% CI · 76 let",
           "current_year_plotline": {
             "value": 2026,
@@ -85141,7 +85141,7 @@
           "total_change": "+3,13°C",
           "total_change_color": "rgb(204, 34, 34)",
           "footer": [
-            "Theil-Sen regresija + Yue-Wang Mann-Kendall test · ERA5-Land · nadmorska korekcija"
+            "Theil-Sen regresija + Yue-Wang Mann-Kendall test · ERA5-Land · korekcija na nadmorsko višino"
           ]
         },
         "charts": [
@@ -88202,7 +88202,7 @@
         },
         "rendered": {
           "title": "Najvišje temperature na postaji Kredarica okoli 3. avg. · 1950–2025 · trend s projekcijo do 2050",
-          "explain": "Vsaka pika je povprečna vrednost (lapsno popravljene dnevne najvišje temperature na postaji Kredarica) v ±7-dnevnem oknu okoli tega datuma za vsako leto od 1950. Trend Theil-Sen je +0,27 °C/desetletje (p < 0,001). Po tem tempu projekcija kaže 13,0 °C do leta 2050. Zasenčeni pas je 95% interval zaupanja za nagib.",
+          "explain": "Vsaka pika je povprečna vrednost (dnevne najvišje temperature na postaji Kredarica, popravljene na nadmorsko višino) v ±7-dnevnem oknu okoli tega datuma za vsako leto od 1950. Trend Theil-Sen je +0,27 °C/desetletje (p < 0,001). Po tem tempu projekcija kaže 13,0 °C do leta 2050. Zasenčeni pas je 95% interval zaupanja za nagib.",
           "footer": "Theil-Sen + MK: +0,27 °C/desetletje · p < 0,001 · τ = 0,223 · 95% CI · 76 let",
           "current_year_plotline": {
             "value": 2026,
@@ -88659,7 +88659,7 @@
           "total_change": "+2,04°C",
           "total_change_color": "rgb(204, 34, 34)",
           "footer": [
-            "Theil-Sen regresija + Yue-Wang Mann-Kendall test · ERA5-Land · nadmorska korekcija"
+            "Theil-Sen regresija + Yue-Wang Mann-Kendall test · ERA5-Land · korekcija na nadmorsko višino"
           ]
         },
         "charts": [
@@ -91724,7 +91724,7 @@
         },
         "rendered": {
           "title": "Najvišje temperature na postaji Ljubljana okoli 7. feb. · 1950–2026 · trend s projekcijo do 2050",
-          "explain": "Vsaka pika je povprečna vrednost (lapsno popravljene dnevne najvišje temperature na postaji Ljubljana) v ±7-dnevnem oknu okoli tega datuma za vsako leto od 1950. Trend Theil-Sen je +0,57 °C/desetletje (p < 0,001). Po tem tempu projekcija kaže 8,3 °C do leta 2050. Zasenčeni pas je 95% interval zaupanja za nagib.",
+          "explain": "Vsaka pika je povprečna vrednost (dnevne najvišje temperature na postaji Ljubljana, popravljene na nadmorsko višino) v ±7-dnevnem oknu okoli tega datuma za vsako leto od 1950. Trend Theil-Sen je +0,57 °C/desetletje (p < 0,001). Po tem tempu projekcija kaže 8,3 °C do leta 2050. Zasenčeni pas je 95% interval zaupanja za nagib.",
           "footer": "Theil-Sen + MK: +0,57 °C/desetletje · p < 0,001 · τ = 0,247 · 95% CI · 77 let",
           "current_year_plotline": {
             "value": 2026,
@@ -92185,7 +92185,7 @@
           "total_change": "+4,38°C",
           "total_change_color": "rgb(204, 34, 34)",
           "footer": [
-            "Theil-Sen regresija + Yue-Wang Mann-Kendall test · ERA5-Land · nadmorska korekcija"
+            "Theil-Sen regresija + Yue-Wang Mann-Kendall test · ERA5-Land · korekcija na nadmorsko višino"
           ]
         },
         "charts": [
@@ -95263,7 +95263,7 @@
         },
         "rendered": {
           "title": "Najvišje temperature na postaji Kredarica okoli 7. jan. · 1950–2026 · trend s projekcijo do 2050",
-          "explain": "Vsaka pika je povprečna vrednost (lapsno popravljene dnevne najvišje temperature na postaji Kredarica) v ±7-dnevnem oknu okoli tega datuma za vsako leto od 1950. Trend Theil-Sen je +0,54 °C/desetletje (p < 0,001). Po tem tempu projekcija kaže −5,9 °C do leta 2050. Zasenčeni pas je 95% interval zaupanja za nagib.",
+          "explain": "Vsaka pika je povprečna vrednost (dnevne najvišje temperature na postaji Kredarica, popravljene na nadmorsko višino) v ±7-dnevnem oknu okoli tega datuma za vsako leto od 1950. Trend Theil-Sen je +0,54 °C/desetletje (p < 0,001). Po tem tempu projekcija kaže −5,9 °C do leta 2050. Zasenčeni pas je 95% interval zaupanja za nagib.",
           "footer": "Theil-Sen + MK: +0,54 °C/desetletje · p < 0,001 · τ = 0,282 · 95% CI · 77 let",
           "current_year_plotline": {
             "value": 2026,
@@ -95724,7 +95724,7 @@
           "total_change": "+4,16°C",
           "total_change_color": "rgb(204, 34, 34)",
           "footer": [
-            "Theil-Sen regresija + Yue-Wang Mann-Kendall test · ERA5-Land · nadmorska korekcija"
+            "Theil-Sen regresija + Yue-Wang Mann-Kendall test · ERA5-Land · korekcija na nadmorsko višino"
           ]
         },
         "charts": [


### PR DESCRIPTION
Gives the elevation correction **one name** across the page, and moves the last reader-visible Slovenian out of code files into the catalogue.

**The page used three unrelated names for the same thing:** *"lapsna korekcija nadmorske višine"* in the tropical subtitles, *"Višinski popravek (lapse-rate)"* in the methodology, and *"nadmorska korekcija"* in the regression footer. An ECMWF professional reviewing the page proposed the clearer **"korekcija na nadmorsko višino postaje"**, and that is now the name — full form in prose and the glossary, short form in the dense subtitles and footers.

*(lapse-rate)* stays in the **glossary term only**, deliberately: a reader who meets the English term elsewhere must still be able to find it. It is dropped from the methodology heading, which the glossary now defines.

**The sweep found four more sites than the ticket listed, and a fifth after that** — three swept, one comment-only.

**⚠ And the fifth is the finding worth keeping.** `hero-content.ts:231` says *"vključno z **višinsko popravljeno** Kredarico"* — the same concept as an **adjective**, sharing no substring with any search token (`nadmorsk`, `lapsn`, `lapse`, `višinski`). `:185` was caught only because it happens to sit near *"nadmorski"*. **A term-based grep cannot find a concept expressed as a different part of speech.** The next rename on this page should search word stems (`poprav`, `višin`) rather than exact terms. It also needed a real phrasing decision rather than a swap: `z` → `s` before the voiceless *k* in *Kredarico*.

**Two "dead code" claims proved wrong, both caught before deletion.**

`method_label` (`api.ts:903`) looked dead — no component renders it. It is read by `tests/snapshot/harness.tsx:990` and captured twice in the baseline: it is a **deliberate snapshot tripwire**, so a change to the method label surfaces even though nothing draws it. T-5.62 corrected its value for exactly that reason. Deleting it would have failed typecheck (the allowlist is zero) and moved two leaves — both declared stop conditions in the same instruction that called it dead. It is now relocated to the catalogue with a comment recording why it exists, in the spirit of `panelSubStyle`'s "do NOT re-add nowrap", which survived a 67-line rewrite by someone who had never read the ticket behind it (D-52).

`subLabel` (`Era5TropicalChart.tsx`) **is** genuinely dead — a whole-repo grep including `tests/` and `scripts/` found the type declaration, two assignments and a comment, and no caller. Deleted with its type field.

**The general lesson: both dead-code claims came from greps over `code/` alone, and the harness is precisely where a reader with no on-page consumer lives.**

**Two snapshot traces, kept separate.** Part 1 moved **36 string leaves, zero numbers** — 21 `explain_reg` and 15 `explain_source_station`, with the digit multiset identical before and after. The extra swept prose is uncaptured, so the count stayed 36 rather than growing. Part 2 moved **zero**: `stats.method` and `method_label` keep byte-identical values while their home changes.

**Dual-commit under D-23** across five paired lines in `METHODOLOGY.md`.

The glossary term's re-sort (position 31 → 14, under `Intl.Collator("sl-SI")`) does **not** change its anchor: the ASCII key `lapse_rate` is untouched, so T-6.15's `#gloss-lapse_rate` link still resolves.

**Needs eyes on stage** (the page is now at `/ali-je-vroce/`): that one name reads everywhere — searching for *"lapsn"* or *"višinski popravek"* should return nothing; that the footer's extra 10 characters wrap rather than clip at 390 px, since T-5.60 already had to unclip that element; and that the glossary link still opens its re-sorted entry.

Gates: typecheck 0 · typecheck:gate 0 allowlisted · yarn test 79 incl. text-integrity 5/5 · snapshot:check clean after re-record · pytest 77.
