### PR TITLE
T-6.19 — Katastrofalno → Zelo zaskrbljujoče

### DIFF
--- a/code/ali-je-vroce-era5/i18n/sl.ts
+++ b/code/ali-je-vroce-era5/i18n/sl.ts
@@ -331,7 +331,7 @@ export const sl = {
     verdict_none: "Na ta dan v letu ni zaznati trenda.",
     method_theilsen: "Theil-Sen + Mann-Kendall",
 
-    cat_catastrophic: "Katastrofalno",
+    cat_catastrophic: "Zelo zaskrbljujoče",
     cat_extreme: "Ekstremno",
     cat_bad: "Slabo",
     cat_moderate: "Zmerno",

--- a/tests/fixtures/snapshot.json
+++ b/tests/fixtures/snapshot.json
@@ -34403,7 +34403,7 @@
         "rendered": {
           "headline": "+0,565",
           "headline_color": "rgb(194, 90, 44)",
-          "category": "Katastrofalno",
+          "category": "Zelo zaskrbljujoče",
           "paragraphs": [
             "Podaljšani poletni vročinski valovi presegajo hladilne zmogljivosti mesta. Hudourniške poplave iz okrepljenih alpskih padavin večkrat ogrozijo nizko ležečo kotlino.",
             "Sto let segrevanja za +5,65 °C – pri trenutnem tempu vsaka 17,7 let doda eno stopinjo.",
@@ -37929,7 +37929,7 @@
         "rendered": {
           "headline": "+0,565",
           "headline_color": "rgb(194, 90, 44)",
-          "category": "Katastrofalno",
+          "category": "Zelo zaskrbljujoče",
           "paragraphs": [
             "Podaljšani poletni vročinski valovi presegajo hladilne zmogljivosti mesta. Hudourniške poplave iz okrepljenih alpskih padavin večkrat ogrozijo nizko ležečo kotlino.",
             "Sto let segrevanja za +5,65 °C – pri trenutnem tempu vsaka 17,7 let doda eno stopinjo.",
@@ -41455,7 +41455,7 @@
         "rendered": {
           "headline": "+0,356",
           "headline_color": "rgb(194, 90, 44)",
-          "category": "Katastrofalno",
+          "category": "Zelo zaskrbljujoče",
           "paragraphs": [
             "Popolna izguba Triglavskega ledenika — narodni simbol in vir savinjskih rek. Propad alpskega ekosistema sproži kaskadne učinke.",
             "Sto let segrevanja za +3,56 °C – pri trenutnem tempu vsaka 28,1 let doda eno stopinjo.",
@@ -44790,7 +44790,7 @@
         "rendered": {
           "headline": "+0,488",
           "headline_color": "rgb(194, 90, 44)",
-          "category": "Katastrofalno",
+          "category": "Zelo zaskrbljujoče",
           "paragraphs": [
             "Podaljšani poletni vročinski valovi presegajo hladilne zmogljivosti mesta. Hudourniške poplave iz okrepljenih alpskih padavin večkrat ogrozijo nizko ležečo kotlino.",
             "Sto let segrevanja za +4,88 °C – pri trenutnem tempu vsaka 20,5 let doda eno stopinjo.",
@@ -48316,7 +48316,7 @@
         "rendered": {
           "headline": "+0,488",
           "headline_color": "rgb(194, 90, 44)",
-          "category": "Katastrofalno",
+          "category": "Zelo zaskrbljujoče",
           "paragraphs": [
             "Podaljšani poletni vročinski valovi presegajo hladilne zmogljivosti mesta. Hudourniške poplave iz okrepljenih alpskih padavin večkrat ogrozijo nizko ležečo kotlino.",
             "Sto let segrevanja za +4,88 °C – pri trenutnem tempu vsaka 20,5 let doda eno stopinjo.",
@@ -51842,7 +51842,7 @@
         "rendered": {
           "headline": "+0,312",
           "headline_color": "rgb(194, 90, 44)",
-          "category": "Katastrofalno",
+          "category": "Zelo zaskrbljujoče",
           "paragraphs": [
             "Popolna izguba Triglavskega ledenika — narodni simbol in vir savinjskih rek. Propad alpskega ekosistema sproži kaskadne učinke.",
             "Sto let segrevanja za +3,12 °C – pri trenutnem tempu vsaka 32,1 let doda eno stopinjo.",
@@ -55177,7 +55177,7 @@
         "rendered": {
           "headline": "+0,460",
           "headline_color": "rgb(194, 90, 44)",
-          "category": "Katastrofalno",
+          "category": "Zelo zaskrbljujoče",
           "paragraphs": [
             "Podaljšani poletni vročinski valovi presegajo hladilne zmogljivosti mesta. Hudourniške poplave iz okrepljenih alpskih padavin večkrat ogrozijo nizko ležečo kotlino.",
             "Sto let segrevanja za +4,60 °C – pri trenutnem tempu vsaka 21,7 let doda eno stopinjo.",
@@ -58703,7 +58703,7 @@
         "rendered": {
           "headline": "+0,460",
           "headline_color": "rgb(194, 90, 44)",
-          "category": "Katastrofalno",
+          "category": "Zelo zaskrbljujoče",
           "paragraphs": [
             "Podaljšani poletni vročinski valovi presegajo hladilne zmogljivosti mesta. Hudourniške poplave iz okrepljenih alpskih padavin večkrat ogrozijo nizko ležečo kotlino.",
             "Sto let segrevanja za +4,60 °C – pri trenutnem tempu vsaka 21,7 let doda eno stopinjo.",
@@ -63074,7 +63074,7 @@
         "rendered": {
           "headline": "+0,571",
           "headline_color": "rgb(194, 90, 44)",
-          "category": "Katastrofalno",
+          "category": "Zelo zaskrbljujoče",
           "paragraphs": [
             "Podaljšani poletni vročinski valovi presegajo hladilne zmogljivosti mesta. Hudourniške poplave iz okrepljenih alpskih padavin večkrat ogrozijo nizko ležečo kotlino.",
             "Sto let segrevanja za +5,71 °C – pri trenutnem tempu vsaka 17,5 let doda eno stopinjo.",
@@ -63919,7 +63919,7 @@
         "rendered": {
           "headline": "+0,376",
           "headline_color": "rgb(194, 90, 44)",
-          "category": "Katastrofalno",
+          "category": "Zelo zaskrbljujoče",
           "paragraphs": [
             "Popolna izguba Triglavskega ledenika — narodni simbol in vir savinjskih rek. Propad alpskega ekosistema sproži kaskadne učinke.",
             "Sto let segrevanja za +3,76 °C – pri trenutnem tempu vsaka 26,6 let doda eno stopinjo.",
@@ -64715,7 +64715,7 @@
         "rendered": {
           "headline": "+0,571",
           "headline_color": "rgb(194, 90, 44)",
-          "category": "Katastrofalno",
+          "category": "Zelo zaskrbljujoče",
           "paragraphs": [
             "Podaljšani poletni vročinski valovi presegajo hladilne zmogljivosti mesta. Hudourniške poplave iz okrepljenih alpskih padavin večkrat ogrozijo nizko ležečo kotlino.",
             "Sto let segrevanja za +5,71 °C – pri trenutnem tempu vsaka 17,5 let doda eno stopinjo.",
@@ -68223,7 +68223,7 @@
         "rendered": {
           "headline": "+0,557",
           "headline_color": "rgb(194, 90, 44)",
-          "category": "Katastrofalno",
+          "category": "Zelo zaskrbljujoče",
           "paragraphs": [
             "Podaljšani poletni vročinski valovi presegajo hladilne zmogljivosti mesta. Hudourniške poplave iz okrepljenih alpskih padavin večkrat ogrozijo nizko ležečo kotlino.",
             "Sto let segrevanja za +5,57 °C – pri trenutnem tempu vsaka 18,0 let doda eno stopinjo.",
@@ -71749,7 +71749,7 @@
         "rendered": {
           "headline": "+0,571",
           "headline_color": "rgb(194, 90, 44)",
-          "category": "Katastrofalno",
+          "category": "Zelo zaskrbljujoče",
           "paragraphs": [
             "Podaljšani poletni vročinski valovi presegajo hladilne zmogljivosti mesta. Hudourniške poplave iz okrepljenih alpskih padavin večkrat ogrozijo nizko ležečo kotlino.",
             "Sto let segrevanja za +5,71 °C – pri trenutnem tempu vsaka 17,5 let doda eno stopinjo.",
@@ -75275,7 +75275,7 @@
         "rendered": {
           "headline": "+0,557",
           "headline_color": "rgb(194, 90, 44)",
-          "category": "Katastrofalno",
+          "category": "Zelo zaskrbljujoče",
           "paragraphs": [
             "Podaljšani poletni vročinski valovi presegajo hladilne zmogljivosti mesta. Hudourniške poplave iz okrepljenih alpskih padavin večkrat ogrozijo nizko ležečo kotlino.",
             "Sto let segrevanja za +5,57 °C – pri trenutnem tempu vsaka 18,0 let doda eno stopinjo.",
@@ -78801,7 +78801,7 @@
         "rendered": {
           "headline": "+0,484",
           "headline_color": "rgb(194, 90, 44)",
-          "category": "Katastrofalno",
+          "category": "Zelo zaskrbljujoče",
           "paragraphs": [
             "Podaljšani poletni vročinski valovi presegajo hladilne zmogljivosti mesta. Hudourniške poplave iz okrepljenih alpskih padavin večkrat ogrozijo nizko ležečo kotlino.",
             "Sto let segrevanja za +4,84 °C – pri trenutnem tempu vsaka 20,7 let doda eno stopinjo.",
@@ -82311,7 +82311,7 @@
         "rendered": {
           "headline": "+0,513",
           "headline_color": "rgb(194, 90, 44)",
-          "category": "Katastrofalno",
+          "category": "Zelo zaskrbljujoče",
           "paragraphs": [
             "Podaljšani poletni vročinski valovi presegajo hladilne zmogljivosti mesta. Hudourniške poplave iz okrepljenih alpskih padavin večkrat ogrozijo nizko ležečo kotlino.",
             "Sto let segrevanja za +5,13 °C – pri trenutnem tempu vsaka 19,5 let doda eno stopinjo.",
@@ -85829,7 +85829,7 @@
         "rendered": {
           "headline": "+0,412",
           "headline_color": "rgb(194, 90, 44)",
-          "category": "Katastrofalno",
+          "category": "Zelo zaskrbljujoče",
           "paragraphs": [
             "Podaljšani poletni vročinski valovi presegajo hladilne zmogljivosti mesta. Hudourniške poplave iz okrepljenih alpskih padavin večkrat ogrozijo nizko ležečo kotlino.",
             "Sto let segrevanja za +4,12 °C – pri trenutnem tempu vsaka 24,3 let doda eno stopinjo.",
@@ -92881,7 +92881,7 @@
         "rendered": {
           "headline": "+0,569",
           "headline_color": "rgb(194, 90, 44)",
-          "category": "Katastrofalno",
+          "category": "Zelo zaskrbljujoče",
           "paragraphs": [
             "Podaljšani poletni vročinski valovi presegajo hladilne zmogljivosti mesta. Hudourniške poplave iz okrepljenih alpskih padavin večkrat ogrozijo nizko ležečo kotlino.",
             "Sto let segrevanja za +5,69 °C – pri trenutnem tempu vsaka 17,6 let doda eno stopinjo.",
@@ -96420,7 +96420,7 @@
         "rendered": {
           "headline": "+0,540",
           "headline_color": "rgb(194, 90, 44)",
-          "category": "Katastrofalno",
+          "category": "Zelo zaskrbljujoče",
           "paragraphs": [
             "Popolna izguba Triglavskega ledenika — narodni simbol in vir savinjskih rek. Propad alpskega ekosistema sproži kaskadne učinke.",
             "Sto let segrevanja za +5,40 °C – pri trenutnem tempu vsaka 18,5 let doda eno stopinjo.",


### PR DESCRIPTION
Renames the top verdict label: **"Katastrofalno" → "Zelo zaskrbljujoče"**. One string.

**Why.** *Katastrofalno* is a verdict about **consequences the page has not measured** — it names an outcome, not a number. *Zelo zaskrbljujoče* describes a reaction to the trend, which is honest about being a judgement rather than dressing one up as a finding. Same family as **D-25**, which retired *"Peklensko"* and *"Zmrzujoče"* for judging rather than describing — this ladder survived that pass untouched.

**Deliberately minimal.** The other four levels stay: *Ekstremno*, *Slabo*, *Zmerno*, *Izhodiščno*. The ladder therefore mixes registers afterwards — concern, magnitude, evaluation, neutral — and that is accepted for now; renaming `cat_extreme` to *Zaskrbljujoče* was considered and declined. The thresholds behind the labels are a separate open question (T-6.20) and are untouched here.

**Only the Slovenian value moves.** The ASCII identifier `catastrophic` stays in `CATEGORIES`, in `CAT_STYLE` and as `trendCategory()`'s return value. So do all the `catastrophic`-keyed location narratives in `hero-content.ts` — including Trbovlje's *"katastrofalno tveganje poplav"*, which is prose about flood risk rather than the category label, and Tolmin's Soča narrative.

**The pill fits, measured rather than assumed.** `KATASTROFALNO` (13 chars) → `ZELO ZASKRBLJUJOČE` (18) is +31% width: 108.4 px → 142.4 px in JetBrains Mono. The element is `inline-flex` with no width constraint, and at 390 px its column is ~310 px — so 142 px sits on one line with ~170 px spare. No wrap, no clip, at either viewport.

**One thing worth knowing about how visible this is.** `trendCategory()` runs on the **selected day of year**, not on an annual figure. At the pinned fixture date in early August, **17 of 18 stations** fall in this band — Velenje alone (0.298) is *extreme*. That is a single-date measurement, not a property of the scale: the `extreme` band is reached at 9 of 198 fixtured points, and Ljubljana on 18 September reads +0.202 °C/decade → EKSTREMNO. Slovenian warming trends are simply steep in early August. Whether the ladder discriminates well across the whole calendar is T-6.20's question.

**Snapshot: 19 leaves, all text.** Exactly the 19 predicted `hero_cards.rendered.category` swaps, 19 deletions and 19 insertions, **no numeric leaf moved** — the label sits beside a number and the number did not shift.

**Needs eyes on stage** (`/ali-je-vroce/`): that the pill reads correctly at 390 px, and that the new word sits well beside the trend figure.

Gates: typecheck 0 · typecheck:gate 0 allowlisted · yarn test 79 · text-integrity 5/5 with a codepoint scan of the edited line · snapshot:check identical after re-record · pytest 77.
