### PR TITLE
T-6.20 + T-6.21 — disclose that the verdict bands are editorial; cite the ERA5 claim

### DIFF
--- a/code/ali-je-vroce-era5/components/ReferencesPanel.tsx
+++ b/code/ali-je-vroce-era5/components/ReferencesPanel.tsx
@@ -46,6 +46,9 @@ export function ReferencesPanel() {
                     <a href={entry.url} target="_blank" rel="noopener noreferrer">
                       {entry.cite}
                     </a>
+                    {entry.note ? (
+                      <span class="methodology-references-note">{" "}{entry.note}</span>
+                    ) : null}
                   </li>
                 );
               }}

--- a/code/ali-je-vroce-era5/i18n/hero-content.ts
+++ b/code/ali-je-vroce-era5/i18n/hero-content.ts
@@ -196,7 +196,7 @@ Stran uporablja **reanalizo ERA5-Land**[[ref:era5_land_dataset]][[ref:era5_land_
 
 Reanaliza ni isto kot meritev postaje. Je rekonstrukcija preteklega vremena, ki nastane tako, da model združi številne vire opazovanj — meritve postaj, satelitske posnetke, podatke z ladij in letal — v enotno, prostorsko in časovno polno mrežo vrednosti.
 
-**ERA5-Land sam ne vključuje nobenih meritev.** Opazovanja združi matična reanaliza **[ERA5](#gloss-era5)** na mreži približno 31 km. ERA5-Land te vrednosti uporabi kot vhod in z njimi na gostejši mreži (~9 km) podrobneje izračuna razmere pri tleh. Gostejša mreža torej ne pomeni več opazovanj, le podrobnejši izračun iz istega vira.
+**ERA5-Land sam ne vključuje nobenih meritev.** Opazovanja združi matična reanaliza **[ERA5](#gloss-era5)** na mreži približno 31 km.[[ref:hersbach_era5]] ERA5-Land te vrednosti uporabi kot vhod in z njimi na gostejši mreži (~9 km) podrobneje izračuna razmere pri tleh. Gostejša mreža torej ne pomeni več opazovanj, le podrobnejši izračun iz istega vira.
 
 **Dejanska ločljivost je slabša od mrežne.** Učinkovita ločljivost ERA5 je približno tri- do štirikrat slabša od nominalne — okoli **100 km**, ne 31 km. Gostejša mreža ERA5-Land tega ne popravi.
 
@@ -253,6 +253,12 @@ Za vsak dan v letu stran prikaže **[porazdelitev](#gloss-distribution)** pretek
 - Percentil je **pravi empirični percentil**, izračunan iz te krivulje (integral gostote do današnje vrednosti), ne približek iz barvnega pasu.
 
 Primerjalni vzorec za vsak koledarski dan je **združeno okno ±7 dni** čez vsa leta — tako ima vsak dan dovolj gost in stabilen vzorec. **Isto okno ±7 dni** uporablja tudi letni trend: vsaka letna točka na grafu trenda je **povprečje** vrednosti v tem oknu za posamezno leto — pri [padavinah](#gloss-precipitation) in [ET₀](#gloss-et0)[[ref:fao56]] pa **vsota**, saj sta to globini v mm in ima smisel le seštevek. **29. februar** se pri tem pridruži oknu 28. februarja (redki prestopni dnevi se ne obravnavajo kot ločen, statistično šumeč dan). Objavljena vrednost povsod uporablja okno ±7 dni; v panelu z analizo trendov lahko bralec izbere tudi ožje ali širše okno, kar velja le za tisti prikaz.
+
+## Besedna ocena trenda (kategorija)
+
+Besedo ob stoletnem trendu vsake postaje (»Izhodiščno«, »Zmerno«, »Slabo«, »Ekstremno«, »Zelo zaskrbljujoče«) določimo iz naklona trenda po mejah **0,05 · 0,10 · 0,20 · 0,30 °C na desetletje**; zgornja kategorija (≥ 0,30 °C/desetletje) je odprta navzgor. **Te meje so uredniška izbira te strani, ne standard, članek ali predhodna odločitev** — služijo le kot groba besedna oznaka relativne hitrosti segrevanja med postajami. Kako dobro so izbrane, je vprašanje za strokovni pregled.
+
+Za primerjavo: Evropa se segreva približno dvakrat hitreje od svetovnega povprečja, kar je najhitreje med celinami[[ref:wmo_c3s_esotc]].
 
 ## Trend in statistična značilnost
 

--- a/code/ali-je-vroce-era5/i18n/references.ts
+++ b/code/ali-je-vroce-era5/i18n/references.ts
@@ -39,6 +39,7 @@ export type ReferenceEntry = {
   readonly desc: string; // plain-Slovenian one-liner (a locale VALUE)
   readonly cite: string; // author/issuer, year, title/journal — the linked text
   readonly url: string; // the link a reader can actually follow
+  readonly note?: string; // optional short annotation (access status, period) — a locale VALUE
 };
 
 export const references: Record<string, ReferenceEntry> = {
@@ -51,6 +52,12 @@ export const references: Record<string, ReferenceEntry> = {
     desc: "Znanstveni članek, ki opisuje reanalizo ERA5-Land in njeno izdelavo.",
     cite: "Muñoz-Sabater in sod. (2021), Earth System Science Data 13, 4349–4383",
     url: "https://doi.org/10.5194/essd-13-4349-2021",
+  },
+  hersbach_era5: {
+    desc: "Matična reanaliza ERA5 — opis metode, asimilacije opazovanj in ločljivosti.",
+    cite: "Hersbach et al. (2020), Quarterly Journal of the Royal Meteorological Society",
+    url: "https://rmets.onlinelibrary.wiley.com/doi/10.1002/qj.3803",
+    note: "Odprt dostop.",
   },
   open_meteo: {
     desc: "Arhivski spletni vmesnik, prek katerega stran dostopa do podatkov ERA5-Land.",
@@ -86,6 +93,12 @@ export const references: Record<string, ReferenceEntry> = {
     desc: "Slovar kazalnikov z natančnimi definicijami in pragovi (vroči dnevi, tropske noči).",
     cite: "ECA&D — Indices dictionary",
     url: "https://www.ecad.eu/indicesextremes/indicesdictionary.php",
+  },
+  wmo_c3s_esotc: {
+    desc: "Evropa se segreva približno dvakrat hitreje od svetovnega povprečja.",
+    cite: "WMO & Copernicus, European State of the Climate (2022)",
+    url: "https://climate.copernicus.eu/copernicus-temperatures-europe-increase-more-twice-global-average-europe-presents-live-picture",
+    note: "Obdobje 1991–2021.",
   },
 
   // ── HELD — no marker in the prose yet (T-6.8 finding 2) ──────────────────────


### PR DESCRIPTION
Two related fixes: a factual claim that lacked a citation among cited neighbours, and five thresholds the page presented as if they were established.

## T-6.21 — the ERA5 claim is now cited

T-6.17 added paragraphs asserting that ERA5 assimilates observations at ~31 km and that ERA5-Land derives from it. Neither was supported: [1] is the ERA5-Land dataset page and [2] was Muñoz-Sabater et al. — **both about ERA5-Land**. The asymmetry was the defect, not the absence: the lapse rate, the WMO normal, ETCCDI, SPEI, FAO-56, Theil-Sen and Yue & Wang are all cited, so a reader who has just learned the page cites its sources met a new claim that did not.

**Hersbach et al. (2020)**, *The ERA5 global reanalysis*, QJRMS — operator-chosen and verified, open access.

**The marker sits on the ERA5 sentence, not the ERA5-Land one.** Attaching the ERA5 paper to a sentence about ERA5-Land would repeat the exact category error T-6.17 fixed.

## T-6.20 — the verdict thresholds are editorial, and the page now says so

`trendCategory()` assigns every station a verdict from five hardcoded constants — `≥0.30 · ≥0.20 · ≥0.10 · ≥0.05` °C/decade. **They are not from a standard, a paper or a prior decision: someone picked them.** Everything else on the page that assigns a category is either sourced or explained; these were neither, while driving the first thing a reader sees.

A new methodology subsection now states the four numbers, that they are this page's editorial choice rather than an international standard, **and that the top band is open-ended** — the fact that makes the pill judgeable, since a station at 0.52 °C/decade shows the same label as one at 0.30.

**Scope is disclosure only.** No threshold, label or band shape changed. Whether the bands are well chosen is a question for a domain reviewer (T-6.3).

**A scale sentence follows the disclosure**, citing the WMO/Copernicus figure that Europe warms roughly twice as fast as the global mean. Order matters and is deliberate: the disclosure says the bands are ours, then the yardstick gives a reader something to hold. Reversed, it would read as though a WMO figure justified thresholds it has nothing to do with — which it does not.

## Render-time numbering proved itself

Two references inserted **mid-list**, taking positions **2** and **11**. Everything after each shifted, thirteen references end to end, and **not one existing marker was edited**. This is the case that design was built for — a hand-numbered list would have needed eleven edits and would have been the obvious place to introduce an off-by-one.

**Needs eyes on stage** (`/ali-je-vroce/`): that both new links open — the QJRMS paper freely, and the WMO release; that every `[n]` marker in the prose points at the entry it names, especially the ones that moved; that the disclosure reads as a description rather than an apology; and that the scale sentence lands as context rather than as justification.

Gates: typecheck 0 · typecheck:gate 0 allowlisted · yarn test 79 · text-integrity 5/5 with a codepoint scan of every typed line · snapshot:check as predicted · pytest 77.
