### PR TITLE
T-5.68 — vsaka 21,4 let → vsakih 21,4 leta

### DIFF
--- a/code/ali-je-vroce-era5/i18n/sl.ts
+++ b/code/ali-je-vroce-era5/i18n/sl.ts
@@ -326,8 +326,8 @@ export const sl = {
 
   // HeroCards
   hero: {
-    verdict_warming: "Sto let segrevanja za <em>{t100} {unit}</em> – pri trenutnem tempu vsaka <em>{yrs} let</em> doda eno stopinjo.",
-    verdict_cooling: "Sto let ohlajanja za <em>{t100} {unit}</em> – pri trenutnem tempu vsaka <em>{yrs} let</em> odšteje eno stopinjo.",
+    verdict_warming: "Sto let segrevanja za <em>{t100} {unit}</em> – pri trenutnem tempu vsakih <em>{yrs} leta</em> doda eno stopinjo.",
+    verdict_cooling: "Sto let ohlajanja za <em>{t100} {unit}</em> – pri trenutnem tempu vsakih <em>{yrs} leta</em> odšteje eno stopinjo.",
     verdict_none: "Na ta dan v letu ni zaznati trenda.",
     method_theilsen: "Theil-Sen + Mann-Kendall",
 

--- a/tests/fixtures/snapshot.json
+++ b/tests/fixtures/snapshot.json
@@ -34405,7 +34405,7 @@
           "category": "Zelo zaskrbljujoče",
           "paragraphs": [
             "Podaljšani poletni vročinski valovi presegajo hladilne zmogljivosti mesta. Hudourniške poplave iz okrepljenih alpskih padavin večkrat ogrozijo nizko ležečo kotlino.",
-            "Sto let segrevanja za +5,65 °C – pri trenutnem tempu vsaka 17,7 let doda eno stopinjo.",
+            "Sto let segrevanja za +5,65 °C – pri trenutnem tempu vsakih 17,7 leta doda eno stopinjo.",
             "Theil-Sen + Mann-Kendall"
           ],
           "stats": [
@@ -37931,7 +37931,7 @@
           "category": "Zelo zaskrbljujoče",
           "paragraphs": [
             "Podaljšani poletni vročinski valovi presegajo hladilne zmogljivosti mesta. Hudourniške poplave iz okrepljenih alpskih padavin večkrat ogrozijo nizko ležečo kotlino.",
-            "Sto let segrevanja za +5,65 °C – pri trenutnem tempu vsaka 17,7 let doda eno stopinjo.",
+            "Sto let segrevanja za +5,65 °C – pri trenutnem tempu vsakih 17,7 leta doda eno stopinjo.",
             "Theil-Sen + Mann-Kendall"
           ],
           "stats": [
@@ -41457,7 +41457,7 @@
           "category": "Zelo zaskrbljujoče",
           "paragraphs": [
             "Popolna izguba Triglavskega ledenika — narodni simbol in vir savinjskih rek. Propad alpskega ekosistema sproži kaskadne učinke.",
-            "Sto let segrevanja za +3,56 °C – pri trenutnem tempu vsaka 28,1 let doda eno stopinjo.",
+            "Sto let segrevanja za +3,56 °C – pri trenutnem tempu vsakih 28,1 leta doda eno stopinjo.",
             "Theil-Sen + Mann-Kendall"
           ],
           "stats": [
@@ -44792,7 +44792,7 @@
           "category": "Zelo zaskrbljujoče",
           "paragraphs": [
             "Podaljšani poletni vročinski valovi presegajo hladilne zmogljivosti mesta. Hudourniške poplave iz okrepljenih alpskih padavin večkrat ogrozijo nizko ležečo kotlino.",
-            "Sto let segrevanja za +4,88 °C – pri trenutnem tempu vsaka 20,5 let doda eno stopinjo.",
+            "Sto let segrevanja za +4,88 °C – pri trenutnem tempu vsakih 20,5 leta doda eno stopinjo.",
             "Theil-Sen + Mann-Kendall"
           ],
           "stats": [
@@ -48318,7 +48318,7 @@
           "category": "Zelo zaskrbljujoče",
           "paragraphs": [
             "Podaljšani poletni vročinski valovi presegajo hladilne zmogljivosti mesta. Hudourniške poplave iz okrepljenih alpskih padavin večkrat ogrozijo nizko ležečo kotlino.",
-            "Sto let segrevanja za +4,88 °C – pri trenutnem tempu vsaka 20,5 let doda eno stopinjo.",
+            "Sto let segrevanja za +4,88 °C – pri trenutnem tempu vsakih 20,5 leta doda eno stopinjo.",
             "Theil-Sen + Mann-Kendall"
           ],
           "stats": [
@@ -51844,7 +51844,7 @@
           "category": "Zelo zaskrbljujoče",
           "paragraphs": [
             "Popolna izguba Triglavskega ledenika — narodni simbol in vir savinjskih rek. Propad alpskega ekosistema sproži kaskadne učinke.",
-            "Sto let segrevanja za +3,12 °C – pri trenutnem tempu vsaka 32,1 let doda eno stopinjo.",
+            "Sto let segrevanja za +3,12 °C – pri trenutnem tempu vsakih 32,1 leta doda eno stopinjo.",
             "Theil-Sen + Mann-Kendall"
           ],
           "stats": [
@@ -55179,7 +55179,7 @@
           "category": "Zelo zaskrbljujoče",
           "paragraphs": [
             "Podaljšani poletni vročinski valovi presegajo hladilne zmogljivosti mesta. Hudourniške poplave iz okrepljenih alpskih padavin večkrat ogrozijo nizko ležečo kotlino.",
-            "Sto let segrevanja za +4,60 °C – pri trenutnem tempu vsaka 21,7 let doda eno stopinjo.",
+            "Sto let segrevanja za +4,60 °C – pri trenutnem tempu vsakih 21,7 leta doda eno stopinjo.",
             "Theil-Sen + Mann-Kendall"
           ],
           "stats": [
@@ -58705,7 +58705,7 @@
           "category": "Zelo zaskrbljujoče",
           "paragraphs": [
             "Podaljšani poletni vročinski valovi presegajo hladilne zmogljivosti mesta. Hudourniške poplave iz okrepljenih alpskih padavin večkrat ogrozijo nizko ležečo kotlino.",
-            "Sto let segrevanja za +4,60 °C – pri trenutnem tempu vsaka 21,7 let doda eno stopinjo.",
+            "Sto let segrevanja za +4,60 °C – pri trenutnem tempu vsakih 21,7 leta doda eno stopinjo.",
             "Theil-Sen + Mann-Kendall"
           ],
           "stats": [
@@ -62231,7 +62231,7 @@
           "category": "Ekstremno",
           "paragraphs": [
             "Triglavski ledenik popolnoma izgine. Visokogorski ekosistem nad gozdno mejo propade.",
-            "Sto let segrevanja za +2,23 °C – pri trenutnem tempu vsaka 44,8 let doda eno stopinjo.",
+            "Sto let segrevanja za +2,23 °C – pri trenutnem tempu vsakih 44,8 leta doda eno stopinjo.",
             "Theil-Sen + Mann-Kendall"
           ],
           "stats": [
@@ -63076,7 +63076,7 @@
           "category": "Zelo zaskrbljujoče",
           "paragraphs": [
             "Podaljšani poletni vročinski valovi presegajo hladilne zmogljivosti mesta. Hudourniške poplave iz okrepljenih alpskih padavin večkrat ogrozijo nizko ležečo kotlino.",
-            "Sto let segrevanja za +5,71 °C – pri trenutnem tempu vsaka 17,5 let doda eno stopinjo.",
+            "Sto let segrevanja za +5,71 °C – pri trenutnem tempu vsakih 17,5 leta doda eno stopinjo.",
             "Theil-Sen + Mann-Kendall"
           ],
           "stats": [
@@ -63921,7 +63921,7 @@
           "category": "Zelo zaskrbljujoče",
           "paragraphs": [
             "Popolna izguba Triglavskega ledenika — narodni simbol in vir savinjskih rek. Propad alpskega ekosistema sproži kaskadne učinke.",
-            "Sto let segrevanja za +3,76 °C – pri trenutnem tempu vsaka 26,6 let doda eno stopinjo.",
+            "Sto let segrevanja za +3,76 °C – pri trenutnem tempu vsakih 26,6 leta doda eno stopinjo.",
             "Theil-Sen + Mann-Kendall"
           ],
           "stats": [
@@ -64717,7 +64717,7 @@
           "category": "Zelo zaskrbljujoče",
           "paragraphs": [
             "Podaljšani poletni vročinski valovi presegajo hladilne zmogljivosti mesta. Hudourniške poplave iz okrepljenih alpskih padavin večkrat ogrozijo nizko ležečo kotlino.",
-            "Sto let segrevanja za +5,71 °C – pri trenutnem tempu vsaka 17,5 let doda eno stopinjo.",
+            "Sto let segrevanja za +5,71 °C – pri trenutnem tempu vsakih 17,5 leta doda eno stopinjo.",
             "Theil-Sen + Mann-Kendall"
           ],
           "stats": [
@@ -68225,7 +68225,7 @@
           "category": "Zelo zaskrbljujoče",
           "paragraphs": [
             "Podaljšani poletni vročinski valovi presegajo hladilne zmogljivosti mesta. Hudourniške poplave iz okrepljenih alpskih padavin večkrat ogrozijo nizko ležečo kotlino.",
-            "Sto let segrevanja za +5,57 °C – pri trenutnem tempu vsaka 18,0 let doda eno stopinjo.",
+            "Sto let segrevanja za +5,57 °C – pri trenutnem tempu vsakih 18,0 leta doda eno stopinjo.",
             "Theil-Sen + Mann-Kendall"
           ],
           "stats": [
@@ -71751,7 +71751,7 @@
           "category": "Zelo zaskrbljujoče",
           "paragraphs": [
             "Podaljšani poletni vročinski valovi presegajo hladilne zmogljivosti mesta. Hudourniške poplave iz okrepljenih alpskih padavin večkrat ogrozijo nizko ležečo kotlino.",
-            "Sto let segrevanja za +5,71 °C – pri trenutnem tempu vsaka 17,5 let doda eno stopinjo.",
+            "Sto let segrevanja za +5,71 °C – pri trenutnem tempu vsakih 17,5 leta doda eno stopinjo.",
             "Theil-Sen + Mann-Kendall"
           ],
           "stats": [
@@ -75277,7 +75277,7 @@
           "category": "Zelo zaskrbljujoče",
           "paragraphs": [
             "Podaljšani poletni vročinski valovi presegajo hladilne zmogljivosti mesta. Hudourniške poplave iz okrepljenih alpskih padavin večkrat ogrozijo nizko ležečo kotlino.",
-            "Sto let segrevanja za +5,57 °C – pri trenutnem tempu vsaka 18,0 let doda eno stopinjo.",
+            "Sto let segrevanja za +5,57 °C – pri trenutnem tempu vsakih 18,0 leta doda eno stopinjo.",
             "Theil-Sen + Mann-Kendall"
           ],
           "stats": [
@@ -78803,7 +78803,7 @@
           "category": "Zelo zaskrbljujoče",
           "paragraphs": [
             "Podaljšani poletni vročinski valovi presegajo hladilne zmogljivosti mesta. Hudourniške poplave iz okrepljenih alpskih padavin večkrat ogrozijo nizko ležečo kotlino.",
-            "Sto let segrevanja za +4,84 °C – pri trenutnem tempu vsaka 20,7 let doda eno stopinjo.",
+            "Sto let segrevanja za +4,84 °C – pri trenutnem tempu vsakih 20,7 leta doda eno stopinjo.",
             "Theil-Sen + Mann-Kendall"
           ],
           "stats": [
@@ -82313,7 +82313,7 @@
           "category": "Zelo zaskrbljujoče",
           "paragraphs": [
             "Podaljšani poletni vročinski valovi presegajo hladilne zmogljivosti mesta. Hudourniške poplave iz okrepljenih alpskih padavin večkrat ogrozijo nizko ležečo kotlino.",
-            "Sto let segrevanja za +5,13 °C – pri trenutnem tempu vsaka 19,5 let doda eno stopinjo.",
+            "Sto let segrevanja za +5,13 °C – pri trenutnem tempu vsakih 19,5 leta doda eno stopinjo.",
             "Theil-Sen + Mann-Kendall"
           ],
           "stats": [
@@ -85831,7 +85831,7 @@
           "category": "Zelo zaskrbljujoče",
           "paragraphs": [
             "Podaljšani poletni vročinski valovi presegajo hladilne zmogljivosti mesta. Hudourniške poplave iz okrepljenih alpskih padavin večkrat ogrozijo nizko ležečo kotlino.",
-            "Sto let segrevanja za +4,12 °C – pri trenutnem tempu vsaka 24,3 let doda eno stopinjo.",
+            "Sto let segrevanja za +4,12 °C – pri trenutnem tempu vsakih 24,3 leta doda eno stopinjo.",
             "Theil-Sen + Mann-Kendall"
           ],
           "stats": [
@@ -89349,7 +89349,7 @@
           "category": "Ekstremno",
           "paragraphs": [
             "Triglavski ledenik popolnoma izgine. Visokogorski ekosistem nad gozdno mejo propade.",
-            "Sto let segrevanja za +2,69 °C – pri trenutnem tempu vsaka 37,2 let doda eno stopinjo.",
+            "Sto let segrevanja za +2,69 °C – pri trenutnem tempu vsakih 37,2 leta doda eno stopinjo.",
             "Theil-Sen + Mann-Kendall"
           ],
           "stats": [
@@ -92883,7 +92883,7 @@
           "category": "Zelo zaskrbljujoče",
           "paragraphs": [
             "Podaljšani poletni vročinski valovi presegajo hladilne zmogljivosti mesta. Hudourniške poplave iz okrepljenih alpskih padavin večkrat ogrozijo nizko ležečo kotlino.",
-            "Sto let segrevanja za +5,69 °C – pri trenutnem tempu vsaka 17,6 let doda eno stopinjo.",
+            "Sto let segrevanja za +5,69 °C – pri trenutnem tempu vsakih 17,6 leta doda eno stopinjo.",
             "Theil-Sen + Mann-Kendall"
           ],
           "stats": [
@@ -96422,7 +96422,7 @@
           "category": "Zelo zaskrbljujoče",
           "paragraphs": [
             "Popolna izguba Triglavskega ledenika — narodni simbol in vir savinjskih rek. Propad alpskega ekosistema sproži kaskadne učinke.",
-            "Sto let segrevanja za +5,40 °C – pri trenutnem tempu vsaka 18,5 let doda eno stopinjo.",
+            "Sto let segrevanja za +5,40 °C – pri trenutnem tempu vsakih 18,5 leta doda eno stopinjo.",
             "Theil-Sen + Mann-Kendall"
           ],
           "stats": [


### PR DESCRIPTION
Fixes Slovenian number agreement in the hero verdict. Two words in each of two strings.

**What was wrong.** The sentence rendered *"pri trenutnem tempu **vsaka 21,4 let** doda eno stopinjo"* — wrong twice over. ***Vsaka*** is feminine and agrees with nothing (*leto* is neuter), and Slovenian takes the **genitive singular** after a decimal, so it is *21,4 **leta***, not *let*.

Now: *"pri trenutnem tempu **vsakih 21,4 leta** doda eno stopinjo."*

**⚠ The shipped form was always the worst case.** `yrs` is `fmtNum(|10/trend10|, 1)` — always a decimal — so the page has never rendered a correct version of this sentence.

**A plural fix was ruled out by measurement, not by argument.** `yrs` reaches the string already `Intl`-formatted as `"21,4"`, so `Number("21,4")` is `NaN` and `PluralRules.select(NaN)` returns `"other"` → *let*. And even with the raw number, ***vsaka* → *vsakih* is gender and case, not plurality** — ICU cannot express it. Recorded in PROGRESS.md so nobody retries it.

**The audit found the catalogue is otherwise in good shape.** All number interpolation lives in `sl.ts`; `hero-content.ts`, `glossary.ts` and `references.ts` have none. Every one of the ~20 `{count, plural, …}` strings was rendered through the real runtime at 1, 2, 3, 5 and a decimal and is **correct at every reachable value** — `loc_national` gives *postaja / postaji / postaje / postaj* properly. No plural parameter ever receives a decimal in production.

**Two sites were examined and deliberately left:**
- `window_opt` / `window_cal_label` — `WINDOWS = [3, 7, 15, 45]`, so **±1 is unreachable** and a plural branch would guard a value that cannot render. *±3 dni* is not wrong in the *±N* register. **Noted for whoever adds ±1: it would need *dan*.**
- `desc_era5_freezing` — `record_years` is always ≈76, so *let* is always correct. **Verified safe**, not overlooked.

**Snapshot: 21 leaves, all `hero_cards.rendered.paragraphs[1]`**, exactly as predicted. Numbers proven unchanged rather than assumed: a script reproduced each post-image line from its pre-image via the two-word swap alone — **21/21, zero mismatches**, across values spanning +2,23…+5,71 °C and 17,5…44,8 years.

**One honest limit:** the fixture set contains no cooling case, so `verdict_cooling` is proven structurally — identical two-word swap, typecheck and text-integrity green — but never rendered in the snapshot.

Gates: typecheck 0 · typecheck:gate 0 allowlisted · yarn test 79 incl. text-integrity · snapshot:check identical after re-record · pytest 77. Codepoint scan of both edited lines clean; Slovenian typed, not pasted.
