### PR TITLE
T-6.23 — five nav items and a burger menu below 768px

### DIFF
--- a/pages/_includes/base.html
+++ b/pages/_includes/base.html
@@ -39,18 +39,70 @@
         <nav role="navigation" class="mb-(--3gap) text-white flex items-center min-h-[75px] px-3" aria-label="Main">
             <a href="/"><img class="logo" src="/assets/logo/logo-orange.svg" alt="Podnebnik"></a>
 
-            <div class="hidden sm:mr-16 sm:block w-full">
+            <!-- Inline nav: md (768px) and up. Below md it collapses to the burger below. -->
+            <div class="hidden md:mr-16 md:block w-full">
                 <div class="flex justify-end space-x-3">
                     <a class="nav-link" href="/" {% if page.url=="/" %} aria-current="page" {% endif %}>Domov</a>
                     <a class="nav-link" href="/ali-je-vroce/" {% if page.url=="/ali-je-vroce/" %} aria-current="page" {%
                         endif %}>Ali je vroče?</a>
+                    <a class="nav-link" href="/methodology/" {% if page.url=="/methodology/" %} aria-current="page" {%
+                        endif %}>Metodologija</a>
+                    <a class="nav-link" href="/glossary/" {% if page.url=="/glossary/" %} aria-current="page" {%
+                        endif %}>Slovarček pojmov</a>
                     <a class="nav-link" href="/about/" {% if page.url=="/about/" %} aria-current="page" {% endif %}>O
                         projektu</a>
                 </div>
             </div>
 
+            <!-- Burger: below md (768px). Native <details> toggle works with JavaScript disabled;
+                 the inline script below adds close-on-navigate, close-on-resize-above-md, Escape-to-close
+                 with focus return, and aria-expanded tracking. mr-14 clears the octocat corner. -->
+            <details id="nav-burger" class="md:hidden ml-auto mr-14 relative">
+                <summary class="nav-burger-toggle" aria-label="Meni">
+                    <svg width="26" height="26" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                        stroke-width="2" stroke-linecap="round" aria-hidden="true">
+                        <line x1="3" y1="6" x2="21" y2="6"></line>
+                        <line x1="3" y1="12" x2="21" y2="12"></line>
+                        <line x1="3" y1="18" x2="21" y2="18"></line>
+                    </svg>
+                </summary>
+                <ul class="nav-burger-panel">
+                    <li><a class="nav-link block" href="/" {% if page.url=="/" %} aria-current="page" {% endif %}>Domov</a></li>
+                    <li><a class="nav-link block" href="/ali-je-vroce/" {% if page.url=="/ali-je-vroce/" %} aria-current="page" {% endif %}>Ali je vroče?</a></li>
+                    <li><a class="nav-link block" href="/methodology/" {% if page.url=="/methodology/" %} aria-current="page" {% endif %}>Metodologija</a></li>
+                    <li><a class="nav-link block" href="/glossary/" {% if page.url=="/glossary/" %} aria-current="page" {% endif %}>Slovarček pojmov</a></li>
+                    <li><a class="nav-link block" href="/about/" {% if page.url=="/about/" %} aria-current="page" {% endif %}>O projektu</a></li>
+                </ul>
+            </details>
+
             {% include 'octocat.html' %}
         </nav>
+        <script>
+            (function () {
+                var d = document.getElementById('nav-burger');
+                if (!d) return;
+                var s = d.querySelector('summary');
+                // Requirement 4: aria-expanded tracks the open state (absent with JS off; native
+                // <details> semantics convey state to assistive tech in that case).
+                function sync() { s.setAttribute('aria-expanded', d.open ? 'true' : 'false'); }
+                d.addEventListener('toggle', sync);
+                sync();
+                // Close on navigate (a fresh page load renders the menu closed anyway; this covers
+                // the current-page link and keeps state clean before unload).
+                d.addEventListener('click', function (e) { if (e.target.closest('a')) d.open = false; });
+                // Requirement 2: Escape closes and returns focus to the toggle. Native <details> does
+                // NOT close on Escape, so this is required, not decorative.
+                d.addEventListener('keydown', function (e) {
+                    if (e.key === 'Escape' && d.open) { d.open = false; s.focus(); }
+                });
+                // Requirement 3: crossing to >= md while open force-closes, so a hidden panel never
+                // strands the page in an open state.
+                var mq = window.matchMedia('(min-width: 768px)');
+                var onChange = function () { if (mq.matches && d.open) d.open = false; };
+                if (mq.addEventListener) mq.addEventListener('change', onChange);
+                else if (mq.addListener) mq.addListener(onChange);
+            })();
+        </script>
     </header>
 
     <main>

--- a/styles/main.css
+++ b/styles/main.css
@@ -187,6 +187,19 @@
     @apply aria-current-page:opacity-100;
   }
 
+  /* Burger menu (below md). The panel sits at z-50 so it clears the ERA5 floating
+     station chooser (z-40). */
+  .nav-burger-toggle {
+    @apply grid place-items-center w-12 h-12 rounded-md cursor-pointer list-none;
+    @apply text-white opacity-70 hover:opacity-100 focus-visible:opacity-100 transition-opacity duration-300;
+  }
+  .nav-burger-toggle::-webkit-details-marker { display: none; }
+
+  .nav-burger-panel {
+    @apply absolute right-0 top-full mt-2 z-50 min-w-[220px] flex flex-col;
+    @apply list-none m-0 p-2 rounded-md bg-primary shadow-lg;
+  }
+
 
   .input-range {
     @apply h-[4px] w-full cursor-pointer disabled:cursor-auto appearance-none border-transparent bg-neutral-600 disabled:bg-neutral-200 accent-primary


### PR DESCRIPTION
Adds **Metodologija** and **Slovarček pojmov** to the top navigation, and a burger menu for narrow viewports — the second because the first takes the nav from three items to five.

Order: **Domov · Ali je vroče? · Metodologija · Slovarček pojmov · O projektu.** The two new items sit beside the page they serve rather than appended at the end.

**No new breakpoint was invented.** The nav already collapsed at Tailwind's `md:` (768px) into a plain stacked list; the burger simply occupies a slot that was already empty. The inline-nav gate moves `sm:` → `md:`.

**Mechanism is native `<details>`/`<summary>`** — the menu opens and closes with **no JavaScript at all**. With JS disabled it works fully; the only difference is that the panel stays open until the next page load, and clicking a link loads a fresh closed page.

**⚠ One correction to the ticket's own brief:** `<details>` does **not** close on Escape natively — the HTML spec defines no such behaviour. That listener is a necessity, not a nicety, and it lives in a ~20-line inline script alongside close-on-navigate and close-on-resize.

**Accessibility, verified on the built page rather than asserted:** the icon-only toggle has `aria-label="Meni"`; Escape closes it and focus returns to the summary (confirmed `activeElement === summary`); `aria-expanded` tracks the open state. No focus trap or scroll lock, deliberately — it is a top dropdown, not a modal.

**The floating station chooser was checked geometrically, not by z-index alone.** At 390px with the menu open on `/ali-je-vroce/`: panel at y 62–278, chooser at y 701–749, `geometricOverlap = false`, and the panel sits above it anyway (z-50 vs z-40). No collision.

**Measured five-item widths at 768–900px:** no logo overlap and no horizontal overflow anywhere ≥768. The one cosmetic effect is that longer labels **wrap to two lines between 768 and ~880px**, making links 64px tall instead of 40; they resolve to a single line above ~880px. Bar height stays 75px throughout. Natural single-line widths: Domov 74 · Ali je vroče? 110 · Metodologija 117 · Slovarček pojmov 151 · O projektu 99.

**All four layouts checked** — `/` (Domov highlighted), `/about/` (O projektu), `/ali-je-vroce/` (Ali je vroče?, burger opens with all five). Every layout chains to `base.html` and per-page highlighting works through the existing `aria-current` guards.

**⚠ Two things left deliberately, both reported rather than fixed:** the link list is now in **three** places in `base.html` — inline nav, burger panel, footer — which is a real drift risk and deserves its own dedup ticket rather than a refactor smuggled into this one. And the two new links **404 until #555 merges**.

**⚠ Nothing automated covers the nav.** Hand-verified only.

Gates: typecheck 0 · typecheck:gate 0 allowlisted · yarn test 96 · snapshot:check identical · pytest 77 · yarn build exit 0.
