### PR TITLE
T-6.24 — define PI, and say which band is which

### DIFF
--- a/code/ali-je-vroce-era5/i18n/sl.ts
+++ b/code/ali-je-vroce-era5/i18n/sl.ts
@@ -486,7 +486,7 @@ export const sl = {
     nb_fit: "NB fit ({dpd} {unit}/des · {p})",
     plain_desc_days: "Vroč dan — ko dnevna temperatura preseže {th} °C — povečuje toplotni stres in zdravstvena tveganja.",
     plain_desc_nights: "Tropska noč — ko temperatura čez noč ostane nad {th} °C — preprečuje telesu okrevanje po dnevni vročini.",
-    tech: "NB GLM: {rate}%/leto · {dpd} {unit}/desetletje · 95% CI · {sigphrase} · AIC {aic} · α={alpha}.",
+    tech: "NB GLM: {rate}%/leto · {dpd} {unit}/desetletje · 95% CI (trend) · 95% PI (posamezno leto) · {sigphrase} · AIC {aic} · α={alpha}.",
     sig_yes: "statistično značilen ({p})",
     sig_no: "ni značilen ({p})",
     forward_yes: "Če trend nadaljuje, bi bilo do 2050 tipičnih okoli {proj2050} {unit} na leto.",

--- a/pages/glossary.md
+++ b/pages/glossary.md
@@ -49,7 +49,7 @@ Mednarodni strokovni skupini, ki sta poenotili definicije podnebnih kazalnikov (
 
 ## interval zaupanja (95 %) {#gloss-confidence_interval}
 
-Razpon, znotraj katerega je prava vrednost naklona z 95-odstotno zanesljivostjo. Širši razpon pomeni bolj negotovo oceno.
+Razpon, znotraj katerega je prava vrednost naklona z 95-odstotno zanesljivostjo. Širši razpon pomeni bolj negotovo oceno. Nanaša se na trendno črto, ne na posamezno leto — za to glej [napovedni interval](#gloss-prediction_interval).
 
 ## KDE {#gloss-kde}
 
@@ -94,6 +94,10 @@ Količina dežja, snega in druge vode, ki v danem obdobju pade na tla; merjena v
 ## percentil {#gloss-percentile}
 
 Pove, od kolikšnega deleža primerljivih dni v zgodovini je današnji dan toplejši. 90. percentil = topleje kot 90 % primerjalnih dni.
+
+## PI (napovedni interval) {#gloss-prediction_interval}
+
+Razpon, v katerem bi se z 95-odstotno zanesljivostjo znašla posamezna prihodnja vrednost. Je širši od intervala zaupanja, ker poleg negotovosti trenda vključuje tudi naravno nihanje med posameznimi leti.
 
 ## porazdelitev {#gloss-distribution}
 

--- a/tests/fixtures/snapshot.json
+++ b/tests/fixtures/snapshot.json
@@ -20136,7 +20136,7 @@
           "header": "Vroči dnevi · Ljubljana",
           "coverage": "77 let · 48 z vrednostjo > 0",
           "paragraphs": [
-            "NB GLM: +3,32%/leto · +1,6 dni/desetletje · 95% CI · statistično značilen (p < 0,001) · AIC 387 · α=2.059.",
+            "NB GLM: +3,32%/leto · +1,6 dni/desetletje · 95% CI (trend) · 95% PI (posamezno leto) · statistično značilen (p < 0,001) · AIC 387 · α=2.059.",
             "Vroč dan — ko dnevna temperatura preseže 30 °C — povečuje toplotni stres in zdravstvena tveganja. Postaja Ljubljana kaže statistično značilen trend: grobe 1,6 več dni na desetletje. Če trend nadaljuje, bi bilo do 2050 tipičnih okoli 34 dni na leto."
           ]
         },
@@ -22169,7 +22169,7 @@
           "header": "Tropske noči · Ljubljana",
           "coverage": "77 let · 28 z vrednostjo > 0",
           "paragraphs": [
-            "NB GLM: +3,18%/leto · +0,4 noči/desetletje · 95% CI · statistično značilen (p < 0,01) · AIC 222 · α=3.625.",
+            "NB GLM: +3,18%/leto · +0,4 noči/desetletje · 95% CI (trend) · 95% PI (posamezno leto) · statistično značilen (p < 0,01) · AIC 222 · α=3.625.",
             "Tropska noč — ko temperatura čez noč ostane nad 20 °C — preprečuje telesu okrevanje po dnevni vročini. Postaja Ljubljana kaže statistično značilen trend: grobe 0,4 več noči na desetletje. Če trend nadaljuje, bi bilo do 2050 tipičnih okoli 9 noči na leto."
           ]
         },


### PR DESCRIPTION
Defines **PI** — the prediction interval drawn on the *Vroči dnevi* and *Tropske noči* charts — and makes it distinguishable from the CI beside it.

**The gap.** Both charts draw a **95% PI** and a **95% CI**. The glossary defined *interval zaupanja* and **not** PI. That is exactly what the glossary exists to close: a statistical abbreviation on a chart with nowhere to look it up.

**⚠ And it is worse than a missing entry, because the two look alike.** A confidence interval is uncertainty about the **fitted trend line**; a prediction interval is uncertainty about a **single future observation**, and is always wider because it carries year-to-year scatter as well as the fit. A reader seeing both bands, the PI visibly wider, had no way to know why.

**What the PI actually is, read from the code rather than inferred from the label:** `precompute_datasette.py:867-870` computes `se_pred = √(μ + α·μ²)` — the negative-binomial marginal standard deviation — and takes μ ± 1.96·se_pred. The 1.96 confirms 95%, matching the wording. **Two caveats are recorded** so the entry is not later read as claiming more precision than the code delivers: it is a **normal approximation** to the NB rather than an exact quantile, and it is the **observation-scatter band around the fitted line**, without the fit's own variance added.

**A sweep confirmed PI appears only on the tropical pair.** The regression scatter and the annual-trend chart show CI only; the SPEI trend, the calendar, both heatmaps and the distribution show no such band. So the caption clause has exactly one home.

**Three parts, and the third is what makes the first two findable:**

1. **New glossary entry** at `{#gloss-prediction_interval}`, sorting between *percentil* and *porazdelitev*.
2. **A cross-reference on the existing `interval zaupanja` entry** — it refers to the trend line, not a single year, and points at the new entry. Two entries that look alike are more useful when each names the other.
3. **One clause in the tropical caption**: `· 95% CI ·` becomes `· 95% CI (trend) · 95% PI (posamezno leto) ·`. **An entry alone helps only a reader who suspects there is something to look up**, and nothing on the chart suggested there was.

**The caption width was measured, not assumed.** JetBrains Mono 10px: 106 → 140 characters, ≈636 → ≈840px on the longest line. The paragraph has no `nowrap` and no fixed height, and at 390px it already wrapped before this change — so it reflows by one line and **cannot clip**. Committed at full length rather than shortened.

**Snapshot: 2 leaves, and the prediction was corrected mid-flight.** The investigation predicted 4 — both tropical charts for both snapshot stations. The actual is 2: **Kredarica's tropical trend is withheld** (no non-zero years), so its caption is the no-trend message rather than the tech line, and it did not move. The Highcharts series names `95% PI` and `95% CI` were not touched and did not move. The glossary page is uncaptured markdown, so parts 1 and 2 moved nothing.

**⚠ Left open, deliberately:** the a11y description at `sl.ts:508` names only *"intervalom zaupanja"*, so a screen-reader user hears about one band and never learns the other exists. A clause was drafted but not committed — it needs approval as published Slovenian, and it gets its own change.

Gates: typecheck 0 · typecheck:gate 0 allowlisted · yarn test 96 · text-integrity 5/5 with a codepoint scan of every touched line · snapshot:check identical after re-record · pytest 77.
