### PR TITLE
T-5.15 — honour prefers-reduced-motion; and six charts were animating unnoticed

### DIFF
--- a/code/ali-je-vroce-era5/charts/DistributionChart.tsx
+++ b/code/ali-je-vroce-era5/charts/DistributionChart.tsx
@@ -1,6 +1,7 @@
 import { onMount, onCleanup, createEffect } from "solid-js";
 import type { TodayStatus } from "../types.ts";
 import { enableChartA11y } from "./highcharts-a11y.ts";
+import { reduceChartMotion } from "../reduced-motion.ts";
 import { t, fmtNum } from "../i18n/format.ts";
 import { assertFrequencySane, distributionTooltipHtml } from "./distribution-frequency.ts";
 
@@ -155,7 +156,7 @@ export function DistributionChart(props: Props) {
     if (!r.available || !r.distribution?.length || !r.cutoffs) return;
     // The tooltip formatter reads `() => props.data` live, so it survives later data
     // changes (createEffect refreshes only the geometry, not the formatter). T-5.22 B.
-    chart = Highcharts.chart(container, buildOptions(r, () => props.data));
+    chart = Highcharts.chart(container, reduceChartMotion(buildOptions(r, () => props.data)));
   });
 
   createEffect(() => {

--- a/code/ali-je-vroce-era5/charts/RegressionChart.tsx
+++ b/code/ali-je-vroce-era5/charts/RegressionChart.tsx
@@ -1,6 +1,7 @@
 import { onMount, onCleanup, createEffect } from "solid-js";
 import type { RegressionResponse } from "../types.ts";
 import { enableChartA11y } from "./highcharts-a11y.ts";
+import { reduceChartMotion } from "../reduced-motion.ts";
 import { regressionTooltipHtml } from "./regression-tooltip.ts";
 import { t, fmtNum } from "../i18n/format.ts";
 
@@ -75,7 +76,7 @@ export function RegressionChart(props: Props) {
     await enableChartA11y(HC);
 
     const d = props.data;
-    chart = HC.chart(container, {
+    chart = HC.chart(container, reduceChartMotion({
       chart: {
         backgroundColor: "transparent",
         margin: [10, 20, 40, 60],
@@ -112,7 +113,7 @@ export function RegressionChart(props: Props) {
         gridLineColor: "rgba(0,0,0,0.06)",
       },
       series: buildSeries(d.results),
-    } as Highcharts.Options);
+    } as Highcharts.Options));
 
     // Baseline plotlines
     if (chart && d.results.length) {

--- a/code/ali-je-vroce-era5/charts/SpeiTrendChart.tsx
+++ b/code/ali-je-vroce-era5/charts/SpeiTrendChart.tsx
@@ -1,5 +1,6 @@
 import { createSignal, createMemo, For, Show, onMount, onCleanup } from "solid-js";
 import { enableChartA11y } from "./highcharts-a11y.ts";
+import { reduceChartMotion } from "../reduced-motion.ts";
 import { t, fmtNum, fmtSigned, fmtMonthShort } from "../i18n/format.ts";
 
 // ── Types ─────────────────────────────────────────────────────────────────────
@@ -135,7 +136,7 @@ function SpeiScatterChart(props: ChartProps) {
   onMount(async () => {
     const Highcharts = (await import("highcharts")).default;
     await enableChartA11y(Highcharts);
-    chart = Highcharts.chart(container, buildOpts() as any);
+    chart = Highcharts.chart(container, reduceChartMotion(buildOpts() as any));
   });
 
   // <Show keyed> in the parent remounts this component on station/period change,

--- a/code/ali-je-vroce-era5/charts/TodayGauge.tsx
+++ b/code/ali-je-vroce-era5/charts/TodayGauge.tsx
@@ -1,6 +1,7 @@
 import { onMount, onCleanup, createEffect } from "solid-js";
 import type { TodayStatus } from "../types.ts";
 import { enableChartA11y } from "./highcharts-a11y.ts";
+import { prefersReducedMotion } from "../reduced-motion.ts";
 import { t, fmtNum } from "../i18n/format.ts";
 
 interface Props {
@@ -40,13 +41,17 @@ export function TodayGauge(props: Props) {
     const catKey = r.category_key ?? "nope";
     const pct    = r.percentile ?? 0;
     const target = dialPosition(catKey, pct);
+    // T-5.15 — the needle POSITION is information; the sweep is decoration. Under
+    // prefers-reduced-motion the needle jumps to the correct value instantly (duration
+    // 0) rather than sweeping. It must still update — never withhold the position.
+    const reduced = prefersReducedMotion();
 
     chart = Highcharts.chart(container, {
       chart: {
         type:            "gauge",
         backgroundColor: "transparent",
         margin:          [0, 0, 0, 0],
-        animation:       { duration: 900, easing: "easeOutQuint" },
+        animation:       reduced ? false : { duration: 900, easing: "easeOutQuint" },
       },
       title:         { text: "" },
       credits:       { enabled: false },
@@ -92,15 +97,17 @@ export function TodayGauge(props: Props) {
       }],
     } as Highcharts.Options);
 
-    // Animate needle from 0 → actual value on first render
-    chart.series[0]?.setData([target], true, { duration: 900 });
+    // Animate needle from 0 → actual value on first render (instant under reduced motion)
+    chart.series[0]?.setData([target], true, reduced ? false : { duration: 900 });
   });
 
   createEffect(() => {
     const catKey = props.data.category_key ?? "nope";
     const pct    = props.data.percentile    ?? 0;
     if (!chart) return;
-    chart.series[0]?.setData([dialPosition(catKey, pct)], true, { duration: 500 }, false);
+    // Read the preference fresh so a rebuild after a mid-session OS toggle honours it.
+    const reduced = prefersReducedMotion();
+    chart.series[0]?.setData([dialPosition(catKey, pct)], true, reduced ? false : { duration: 500 }, false);
   });
 
   onCleanup(() => { chart?.destroy(); chart = null; });

--- a/code/ali-je-vroce-era5/charts/TropicalChart.tsx
+++ b/code/ali-je-vroce-era5/charts/TropicalChart.tsx
@@ -9,6 +9,7 @@
 import { createEffect, onMount, onCleanup } from "solid-js";
 import { todayYear } from "../clock";
 import { enableChartA11y } from "./highcharts-a11y.ts";
+import { reduceChartMotion } from "../reduced-motion.ts";
 import { t, fmtNum, fmtSigned } from "../i18n/format.ts";
 
 export interface TropTrend {
@@ -157,7 +158,7 @@ export function TropHighchart(props: ChartProps) {
     await import("highcharts/highcharts-more");
     await enableChartA11y(Highcharts);
 
-    chart = Highcharts.chart(container, {
+    chart = Highcharts.chart(container, reduceChartMotion({
       chart: { type: "column", height: 300, backgroundColor: "transparent", animation: false, style: { fontFamily: "Space Grotesk, sans-serif" } },
       title:   { text: undefined },
       credits: { enabled: false },
@@ -190,7 +191,7 @@ export function TropHighchart(props: ChartProps) {
         labels: { style: { fontSize: "10px", color: INK_SOFT, ...MONO } },
       },
       series: buildSeries(),
-    } as any);
+    } as any));
   });
 
   // ── KEY FIX: read reactive props BEFORE early return so deps are always tracked ──

--- a/code/ali-je-vroce-era5/components/TodayFlag.tsx
+++ b/code/ali-je-vroce-era5/components/TodayFlag.tsx
@@ -1,5 +1,7 @@
 // Slovenian flag with per-category weather overlay — direct port from static/js/app.js
 
+import { prefersReducedMotion } from "../reduced-motion.ts";
+
 function snowFlakePath(r: number): string {
   const f = (n: number) => n.toFixed(2);
   let d = "";
@@ -91,9 +93,23 @@ const FLAG_CONFIGS: Record<string, FlagConfig> = {
 
 const _flagCache = new Map<string, string>();
 
-function buildFlagSVG(catKey: string): string {
-  if (_flagCache.has(catKey)) return _flagCache.get(catKey)!;
+// T-5.15 — the flag's motion is SMIL (`<animate>` / `<animateTransform>`) plus the
+// CSS-driven snow. CSS `@media (prefers-reduced-motion: reduce)` freezes the snow
+// (era5.css), but it CANNOT reach SMIL, so under `reduced` this builder omits the SMIL
+// elements and renders a static scene instead:
+//   • clouds — the `<animateTransform>` drives them across the flag; dropping it alone
+//     would leave every cloud at translate(0,0), overlapping. Instead give each a fixed
+//     spread position so a static, non-overlapping cloudscape remains.
+//   • hell flame/sun — stripping their `<animate>` leaves sane static values (seed 0,
+//     r 10, opacity 0.9), so a plain `<animate …/>` removal is enough.
+// The cache key carries `reduced` so a motion SVG is never served to a reduced reader
+// (or vice-versa).
+function buildFlagSVG(catKey: string, reduced: boolean): string {
+  const cacheKey = `${catKey}:${reduced}`;
+  if (_flagCache.has(cacheKey)) return _flagCache.get(cacheKey)!;
 
+  // Snow keeps its `.tf-snowflake` class in both modes — the CSS media query stops the
+  // sparkle animation under reduced motion, leaving the flakes visible but static.
   const snow = catKey === "freezing"
     ? SNOW_POS.map(([x, y, r, dur, del]) =>
         `<g transform="translate(${x},${y})"><path class="tf-snowflake" d="${snowFlakePath(r)}" fill="none" stroke="rgba(210,235,255,0.95)" stroke-width="0.9" stroke-linecap="round" style="--dur:${dur}s;--delay:${del}s"/></g>`
@@ -101,14 +117,20 @@ function buildFlagSVG(catKey: string): string {
     : "";
 
   const clouds = catKey === "cold"
-    ? COLD_CLOUDS.map(([y, sc, op, dur, del, sh]) =>
-        `<g opacity="${op}" fill="rgba(255,248,248,0.82)"><g transform="scale(${sc})">${CLOUD_DEF[sh]}</g><animateTransform attributeName="transform" type="translate" from="-220 ${y}" to="220 ${y}" dur="${dur}s" begin="${del}s" repeatCount="indefinite"/></g>`
+    ? COLD_CLOUDS.map(([y, sc, op, dur, del, sh], i) =>
+        reduced
+          // Static: fixed, spread positions across the flag — no drift.
+          ? `<g opacity="${op}" transform="translate(${-90 + i * 34} ${y})" fill="rgba(255,248,248,0.82)"><g transform="scale(${sc})">${CLOUD_DEF[sh]}</g></g>`
+          : `<g opacity="${op}" fill="rgba(255,248,248,0.82)"><g transform="scale(${sc})">${CLOUD_DEF[sh]}</g><animateTransform attributeName="transform" type="translate" from="-220 ${y}" to="220 ${y}" dur="${dur}s" begin="${del}s" repeatCount="indefinite"/></g>`
       ).join("")
     : "";
 
   const cfg = FLAG_CONFIGS[catKey] ?? NOPE_FLAG;
-  const svg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="-140 -70 280 140"><defs>${cfg.defs}</defs><rect x="-140" y="-70" width="280" height="140" fill="${cfg.bg}"/>${cfg.body}${clouds}${snow}</svg>`;
-  _flagCache.set(catKey, svg);
+  let svg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="-140 -70 280 140"><defs>${cfg.defs}</defs><rect x="-140" y="-70" width="280" height="140" fill="${cfg.bg}"/>${cfg.body}${clouds}${snow}</svg>`;
+  // Strip the remaining SMIL <animate …/> (hell flame seed + sun pulse). The `\b`
+  // spares <animateTransform> — but the reduced cloud branch above emits none anyway.
+  if (reduced) svg = svg.replace(/<animate\b[^>]*\/>/g, "");
+  _flagCache.set(cacheKey, svg);
   return svg;
 }
 
@@ -117,7 +139,7 @@ export function TodayFlag(props: { catKey: string }) {
     <div
       class="w-16 h-8 rounded-[3px] overflow-hidden flex-shrink-0"
       style={{ "box-shadow": "0 2px 6px rgba(14,14,12,0.15)" }}
-      innerHTML={buildFlagSVG(props.catKey)}
+      innerHTML={buildFlagSVG(props.catKey, prefersReducedMotion())}
     />
   );
 }

--- a/code/ali-je-vroce-era5/components/TodayLast7Chart.tsx
+++ b/code/ali-je-vroce-era5/components/TodayLast7Chart.tsx
@@ -1,6 +1,7 @@
 import { onMount, onCleanup, createEffect } from "solid-js";
 import type { Last7 } from "../types.ts";
 import { enableChartA11y } from "../charts/highcharts-a11y.ts";
+import { reduceChartMotion } from "../reduced-motion.ts";
 import { t, fmtNum, fmtInt } from "../i18n/format.ts";
 
 const CAT_ORDER  = ["freezing", "cold", "nope", "hot", "hell"];
@@ -37,7 +38,7 @@ export function TodayLast7Chart(props: Props) {
       };
     });
 
-    chart = Highcharts.chart(container, {
+    chart = Highcharts.chart(container, reduceChartMotion({
       chart: {
         type:            "line",
         height:          190,
@@ -109,7 +110,7 @@ export function TodayLast7Chart(props: Props) {
           lineColor: INK,
         },
       }],
-    } as Highcharts.Options);
+    } as Highcharts.Options));
   });
 
   createEffect(() => {

--- a/code/ali-je-vroce-era5/components/TodayTrendChart.tsx
+++ b/code/ali-je-vroce-era5/components/TodayTrendChart.tsx
@@ -3,6 +3,7 @@ import { fetchAnnualTrend, ERA5_NATIONAL } from "../api.ts";
 import { todayYear } from "../clock.ts";
 import { sectionErrorFallback } from "./SectionError.tsx";
 import { enableChartA11y } from "../charts/highcharts-a11y.ts";
+import { reduceChartMotion } from "../reduced-motion.ts";
 import { t, fmtNum, fmtSigned, fmtMonthDay } from "../i18n/format.ts";
 import type { AnnualTrend } from "../types.ts";
 
@@ -54,7 +55,7 @@ function TrendHighchart(props: ChartProps) {
     const currentYear = todayYear();
     const { histLine, histBand, fcLine, fcBand, fcMilestones } = buildTrendSeries(d);
 
-    chart = Highcharts.chart(container, {
+    chart = Highcharts.chart(container, reduceChartMotion({
       chart: {
         type:            "line",
         height:          240,
@@ -120,7 +121,7 @@ function TrendHighchart(props: ChartProps) {
                     fillColor: "#F5F2EC", lineColor: COL, lineWidth: 1.5 },
           zIndex: 7 },
       ],
-    } as Highcharts.Options);
+    } as Highcharts.Options));
   });
 
   createEffect(() => {

--- a/code/ali-je-vroce-era5/reduced-motion.ts
+++ b/code/ali-je-vroce-era5/reduced-motion.ts
@@ -1,0 +1,41 @@
+// T-5.15 — the single prefers-reduced-motion read for the JS-driven animations that
+// CSS media queries cannot reach: Highcharts option objects and the TodayFlag SMIL.
+// CSS-driven motion is handled by the `@media (prefers-reduced-motion: reduce)` block
+// in styles/era5.css; this module exists only for what CSS cannot see.
+//
+// GUARDED, failing toward NO PREFERENCE. jsdom (the snapshot harness) and the node
+// unit-test env expose no `window.matchMedia`, so an unguarded read throws. `matches:
+// false` on absence keeps the default (animated) branch, which is exactly why adding
+// these reads moves no snapshot leaf — the harness never takes the reduce branch.
+//
+// BUILD-TIME READ, not reactive. Callers read this when a chart is built. A reader who
+// toggles the OS setting mid-session sees the CSS respond instantly, but a chart only
+// picks it up on its next rebuild (the next date or station change). Deliberate — a
+// live matchMedia listener rebuilding every chart is cost the rare case does not
+// justify (T-5.15 decision (b)).
+export function prefersReducedMotion(): boolean {
+  return (
+    typeof window !== "undefined" &&
+    typeof window.matchMedia === "function" &&
+    window.matchMedia("(prefers-reduced-motion: reduce)").matches
+  );
+}
+
+// Suppress a Highcharts chart's motion when the reader asks for it. Returns the options
+// UNCHANGED (same reference) under no preference, so the emitted option object is
+// byte-identical and no snapshot leaf moves. Under `reduce` it disables BOTH the redraw
+// animation (`chart.animation`) AND the initial series reveal
+// (`plotOptions.series.animation`) — the latter is the ~1 s draw-in that `chart.animation`
+// alone never governed (T-5.15 finding A4: chart.animation is redraw-only; the initial
+// reveal reads series.options.animation, whose Highcharts default is { duration: 1000 }).
+export function reduceChartMotion(opts: Highcharts.Options): Highcharts.Options {
+  if (!prefersReducedMotion()) return opts;
+  return {
+    ...opts,
+    chart: { ...(opts.chart ?? {}), animation: false },
+    plotOptions: {
+      ...(opts.plotOptions ?? {}),
+      series: { ...(opts.plotOptions?.series ?? {}), animation: false },
+    },
+  };
+}

--- a/styles/era5.css
+++ b/styles/era5.css
@@ -42,6 +42,33 @@
   transform-origin: center;
 }
 
+/* ── T-5.15: prefers-reduced-motion ────────────────────────────────────────────
+   A reader who sets this preference has asked for a page that does not move. This
+   blanket reset makes every CSS transition and keyframe animation on the page
+   effectively instant, so it also covers any transition a future change adds — an
+   enforceable rule beats re-auditing "is this one small enough?" each time (T-5.15
+   decision (a): B2 loading fade, B3 disclosure marker, B4/B5 heatmap hover, B1 snow
+   sparkle are all swept up here). It does NOT re-touch the two already-gated controls
+   — `.fsc` fade (:333) and `.fsc-trigger--cue::after` ripple (:359) only animate under
+   `no-preference`, so `reduce` never applies them (added by T-5.35 / T-5.27 while
+   T-5.15 sat open). Highcharts motion (the gauge sweep, the chart draw-ins) and the
+   TodayFlag SMIL are JS/SMIL, invisible to CSS — they are gated in TypeScript
+   (reduced-motion.ts, TodayFlag.tsx). 0.01ms (not `none`) preserves any animationend a
+   script might await. */
+@media (prefers-reduced-motion: reduce) {
+  #ali-je-vroce-era5 *,
+  #ali-je-vroce-era5 *::before,
+  #ali-je-vroce-era5 *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+  /* B6 — the extremes-mode heatmap highlight IS the pulse; with the animation frozen,
+     keep a static brightened highlight so extreme cells stay visibly marked. */
+  #ali-je-vroce-era5 .shm-cell--pulse { filter: brightness(1.35); }
+}
+
 /* ── CSS custom properties gap helpers ──────────────────────────────────── */
 #ali-je-vroce-era5 {
   --gap:   16px;


### PR DESCRIPTION
Honours `prefers-reduced-motion` across the ERA5 page. **Nothing changes for readers who have not set it** — every JavaScript change is behind a guarded `matchMedia` read, and the snapshot is byte-identical.

**Why this matters more than it looks.** That setting is chosen by readers with vestibular disorders, migraine triggers or motion sensitivity. For them an animation is not decoration, it is a symptom trigger. It is invisible to everyone *except* the people who explicitly asked for it — which is why it survived twenty tickets of visual work.

**⚠ The most valuable finding was one nobody was looking for.** `chart.animation: false` governs **redraw only** — the initial series reveal reads `series.options.animation`, whose Highcharts default is `{duration: 1000}`. So **six charts have been playing a ~1 second draw-in on every first load** — distribution, regression, SPEI trend, both tropical, last-7 and trend — because everyone assumed the chart-level flag covered it. Traced through the bundled Highcharts 12.6.0 source, not inferred.

**⚠ The ticket's own premise was stale, and the session flagged it rather than proceeding.** Two `prefers-reduced-motion` guards already existed — `.fsc` fade and the cue ripple, added by T-5.35 and T-5.27 while this ticket sat open. Neither was re-touched.

**What a reader with the preference set now gets:** the gauge needle jumps to its value instead of sweeping (position identical — the sweep is decoration, the position is information); the six chart draw-ins are instant; the flag stops moving, including three infinite SMIL animations for flame turbulence, sun pulse and cloud drift; the heatmap's extreme-cell pulse becomes a static highlight; and the micro-transitions on hover and loading go instant.

**Kept deliberately:** the heatmap's play button, because the reader pressed it; `scrollIntoView`, already instant; and the two already-gated controls.

**Both mechanisms were needed, and neither covers everything.** A CSS `@media` block reaches the transitions and keyframes and is reactive for free. Highcharts animation is a JavaScript option and SMIL `<animate>` elements are neither — both need a `matchMedia` read in TypeScript. Charts read the preference at build time, so a mid-session OS toggle takes effect on the next rebuild; CSS responds instantly. That limitation is recorded rather than left to be discovered.

**⚠ The `matchMedia` guard is load-bearing.** jsdom lacks `matchMedia` and the unit tests run under `environment: "node"`, so every read is `typeof window.matchMedia === "function" ? … : { matches: false }`, failing toward **no preference**. That is also why the snapshot predicted and confirmed **zero movement**: the harness takes the default branch, and the captured gauge options are unchanged.

**Honestly labelled: emulated, not OS-tested.** The session verified the CSS block is live in the served stylesheet and that the `matchMedia` branch fires when overridden, but could not drive the real media feature. **Only a human with the OS setting enabled can confirm the full path** — and above all that the gauge needle still visibly reaches its correct value.

**One finding passed on:** `.nav-burger-toggle` has a 300 ms hover fade in `main.css`, outside this island's scope and belonging to the site-chrome owner.

Gates: typecheck 0 · typecheck:gate 0 allowlisted · yarn test 100 · snapshot:check byte-identical, 0 misses · pytest 77.
