### PR TITLE
T-5.72 — restore the six chart draw-ins; the deferral was the fix, not the animation

### DIFF
--- a/code/ali-je-vroce-era5/charts/DistributionChart.tsx
+++ b/code/ali-je-vroce-era5/charts/DistributionChart.tsx
@@ -127,12 +127,6 @@ function buildOptions(r: TodayStatus, getData: () => TodayStatus): Highcharts.Op
       tickWidth:     0,
     },
     plotOptions: {
-      // T-5.71 — the decorative ~1 s series draw-in is disabled outright (not just
-      // under reduced motion). On first load six charts + the gauge sweep animate at
-      // once; the mount storm was a 1.5–2.0 s main-thread block that janks the gauge
-      // needle on a phone. This matches YearRoundChart's long-standing plotOptions
-      // disable. `chart.animation:false` above governs redraws only.
-      series: { animation: false },
       areaspline: {
         marker:      { enabled: false },
         lineWidth:   0,

--- a/code/ali-je-vroce-era5/charts/RegressionChart.tsx
+++ b/code/ali-je-vroce-era5/charts/RegressionChart.tsx
@@ -112,10 +112,6 @@ export function RegressionChart(props: Props) {
         title: { text: d.ylabel, style: { fontFamily: "'JetBrains Mono', monospace", fontSize: "10px" } },
         gridLineColor: "rgba(0,0,0,0.06)",
       },
-      // T-5.71 — disable the decorative ~1 s series draw-in outright (see
-      // DistributionChart for the mount-storm rationale). chart.animation:false is
-      // redraw-only; this governs the initial reveal.
-      plotOptions: { series: { animation: false } },
       series: buildSeries(d.results),
     } as Highcharts.Options));
 

--- a/code/ali-je-vroce-era5/charts/SpeiTrendChart.tsx
+++ b/code/ali-je-vroce-era5/charts/SpeiTrendChart.tsx
@@ -123,10 +123,6 @@ function SpeiScatterChart(props: ChartProps) {
             label: { text: t("speitrend.threshold_wet"), style: { fontSize: "9px", color: "#1e4d78", ...MONO }, align: "right" as const } },
         ],
       },
-      // T-5.71 — disable the decorative ~1 s series draw-in outright (see
-      // DistributionChart for the mount-storm rationale). chart.animation:false is
-      // redraw-only; this governs the initial reveal.
-      plotOptions: { series: { animation: false } },
       series: [
         { type: "scatter", data: scatter, zIndex: 4 },
         ...(trendLine.length ? [{

--- a/code/ali-je-vroce-era5/charts/TropicalChart.tsx
+++ b/code/ali-je-vroce-era5/charts/TropicalChart.tsx
@@ -190,10 +190,6 @@ export function TropHighchart(props: ChartProps) {
         gridLineColor: "rgba(14,14,12,0.06)",
         labels: { style: { fontSize: "10px", color: INK_SOFT, ...MONO } },
       },
-      // T-5.71 — disable the decorative ~1 s series draw-in outright (see
-      // DistributionChart for the mount-storm rationale). chart.animation:false is
-      // redraw-only; this governs the initial reveal.
-      plotOptions: { series: { animation: false } },
       series: buildSeries(),
     } as any));
   });

--- a/code/ali-je-vroce-era5/components/TodayLast7Chart.tsx
+++ b/code/ali-je-vroce-era5/components/TodayLast7Chart.tsx
@@ -88,10 +88,6 @@ export function TodayLast7Chart(props: Props) {
           color: color + "33",
         })),
       },
-      // T-5.71 — disable the decorative ~1 s series draw-in outright (see
-      // DistributionChart for the mount-storm rationale). chart.animation:false is
-      // redraw-only; this governs the initial reveal.
-      plotOptions: { series: { animation: false } },
       series: [{
         name: "Category",
         type: "line",

--- a/code/ali-je-vroce-era5/components/TodayTrendChart.tsx
+++ b/code/ali-je-vroce-era5/components/TodayTrendChart.tsx
@@ -104,10 +104,6 @@ function TrendHighchart(props: ChartProps) {
         labels:        { format: "{value}°C", style: { color: INK_SOFT, ...MONO } },
         gridLineColor: "rgba(14,14,12,0.06)",
       },
-      // T-5.71 — disable the decorative ~1 s series draw-in outright (see
-      // DistributionChart for the mount-storm rationale). chart.animation:false is
-      // redraw-only; this governs the initial reveal.
-      plotOptions: { series: { animation: false } },
       series: [
         { name: "CI hist",       type: "arearange", data: histBand,
           fillOpacity: 0.09, lineWidth: 0, color: COL, enableMouseTracking: false, marker: { enabled: false }, zIndex: 2 },


### PR DESCRIPTION
Restores the series draw-in on all six charts that T-5.71 turned off.

**⚠ This is a correction, not a change of mind.** T-5.71 described those draw-ins as *"decorative"* and as something *"nobody knew existed"*. **Both were wrong.** The operator knew them, liked them, and on the tropical charts the left-to-right reveal reads as year-by-year data arriving. Turning them off was folded into a jank fix without him having seen what it would remove.

**It does not undo T-5.71.** The jank came from **eight Highcharts instances constructing in one main-thread task** — 1534–1999 ms. The fix was the **deferral**, and that is untouched: the gauge still mounts alone at first paint, the rest arrive on intersection or via the idle queue. The animation was a contributing load, not the cause — and now that each chart constructs in isolation rather than competing with seven siblings, there is no storm for it to add to.

**The removal was not uniform**, and the report caught it: five charts had a whole standalone `plotOptions: { series: { animation: false } }` line; `DistributionChart` had only that property inside its existing `plotOptions` block, which keeps its areaspline and zone config. All six files now match their **exact pre-`afa83a4` git blob** — 26 deletions, nothing else — restoring Highcharts' documented `{ duration: 1000 }` default rather than a number anyone chose.

**The pre-existing `chart.animation: false` on three charts is untouched.** Those are redraw-only, predate T-5.71, and never governed the draw-in.

**⚠ Reduced motion still wins, and by design rather than by accident.** `reduceChartMotion` **constructs** `series.animation = false` itself and spreads over whatever the caller passes — so it never depended on the deleted line, and `reduced-motion.ts` needed no change. Verified with the preference **emulated**; only the operator's OS setting proves the real path.

| | T-5.71 after | this branch, animation off | **restored** |
|---|---|---|---|
| longest main-thread task | 270 / 424 ms | 309 / 356 ms | **331 / 378 ms** |
| task shape | interleaved | 7 interleaved | 7 interleaved, no monolith |
| first paint | gauge alone | gauge alone | **gauge alone** |
| steady-state | 8 | 8 | 8 containers / 8 SVG |

**331/378 ms falls inside the baseline's own run-to-run spread** (309/356), so there is no measurable regression on this proxy — and it was measured with the animation actually on, not asserted from the deferral's existence. ⚠ Every figure is a desktop/dev/fixtures proxy that **understates the phone**: unbundled dev server, fixtures resolving instantly so mounts pile up more than in production, no CPU throttling available.

**⚠ One open question, deliberately not built.** A chart mounted by the **idle queue** may begin its 1 s reveal exactly as the reader scrolls through it, which could read as a glitch rather than as data arriving. Off-screen idle mounts finish before arrival; intersection mounts animate on arrival, which is the intended effect. Only a real device settles it — and if it reads badly, the likely answer is to skip the animation for idle-queue mounts while keeping it for intersection mounts.

Snapshot byte-identical, as predicted — animation config is not a captured leaf.

Gates: typecheck 0 · typecheck:gate 0 allowlisted · yarn test 100 · snapshot:check identical · pytest 77.
