### PR TITLE
T-6.29 — domain review corrections: the urban heat island cause, and an overstatement in two places

### DIFF
--- a/pages/glossary.md
+++ b/pages/glossary.md
@@ -74,7 +74,7 @@ Srednja vrednost: polovica vrednosti je manjših, polovica večjih. Za razliko o
 
 ## mrežna celica / mrežna ločljivost {#gloss-grid_cell}
 
-Model ozemlje razdeli na kvadrate ~9 km; vrednost velja za cel kvadrat, zato ne ujame posebnosti, manjših od tega.
+Model ozemlje razdeli na kvadrate ~9 km; vrednost velja za cel kvadrat.
 
 ## NB GLM (negativna binomska regresija) {#gloss-nb_glm}
 

--- a/pages/methodology.md
+++ b/pages/methodology.md
@@ -8,9 +8,9 @@ summary: Kako nastanejo številke na strani »Ali je vroče?«
 
 Ta stran prikazuje, kako topel je današnji dan v Sloveniji v primerjavi z zgodovino od leta 1950. Nekaj stvari, ki jih je dobro vedeti pri branju:
 
-- **Podatki niso meritve slovenskih vremenskih postaj ([ARSO](/glossary/#gloss-arso)).** Prihajajo iz **[reanalize](/glossary/#gloss-reanalysis) [ERA5-Land](/glossary/#gloss-era5_land)** (evropski podatkovni model, dostopen prek arhiva [Open-Meteo](/glossary/#gloss-open_meteo)). Reanaliza združi meritve, satelite in fizikalni model v enotno mrežo vrednosti. Zato **številke niso neposredno primerljive** z uradnimi objavami ARSO, ki temeljijo na meritvah postaj.
+- **Podatki niso meritve slovenskih vremenskih postaj ([ARSO](/glossary/#gloss-arso)).** Prihajajo iz **[reanalize](/glossary/#gloss-reanalysis) [ERA5-Land](/glossary/#gloss-era5_land)** (evropski podatkovni model, dostopen prek arhiva [Open-Meteo](/glossary/#gloss-open_meteo)). Reanaliza združi meritve, satelite in fizikalni model v enotno mrežo vrednosti. Zato **vrednosti niso neposredno primerljive** z uradnimi objavami ARSO, ki temeljijo na meritvah postaj.
 - **Stran privzeto prikazuje najvišjo dnevno temperaturo ([Tmax](/glossary/#gloss-temp_stats))** — »kako vroč je bil dan«. Povprečno in najnižjo temperaturo lahko izberete ročno, a nista privzeti (razlog je spodaj).
-- **Vsaka postaja je popravljena na nadmorsko višino.** Ker mreža modela ne leži točno na višini postaje, vrednosti prilagodimo za razliko v nadmorski višini. **Za Kredarico je ta popravek −7,85 °C** — daleč največji na strani. Podrobnosti so spodaj; navajamo jih odkrito, ker gre za velik poseg v prikazano vrednost.
+- **Vsaka postaja je popravljena na nadmorsko višino.** Ker mrežna točka modela ni točno na višini postaje, vrednosti prilagodimo za razliko v nadmorski višini. **Za Kredarico je ta popravek −7,85 °C** — daleč največji na strani. Podrobnosti so spodaj; navajamo jih odkrito, ker gre za velik poseg v prikazano vrednost.
 - **»Slovenija« pomeni povprečje 18 postaj**, ne ene same meritve na specifični postaji. Postaje segajo od morske gladine (10 m) do Kredarice (2514 m).
 - **Referenčno obdobje za [odklone](/glossary/#gloss-anomaly) je 1991–2020** (veljavna [klimatološka norma](/glossary/#gloss-climatological_normal) [WMO](/glossary/#gloss-wmo)). Ker je to razmeroma toplo obdobje, se velik del zapisov 1950–2026 prikaže kot negativni odklon.
 
@@ -26,7 +26,7 @@ Reanaliza ni enaka meritevam posameznih postaj. Je rekonstrukcija preteklega vre
 
 **ERA5-Land sam ne vključuje nobenih meritev.** Opazovanja združi matična reanaliza **[ERA5](/glossary/#gloss-era5)** na mreži približno 31 km.[^hersbach_era5] ERA5-Land te vrednosti uporabi kot vhod in z njimi na gostejši mreži (~9 km) podrobneje izračuna razmere pri tleh. Gostejša mreža torej ne pomeni več opazovanj, le podrobnejši izračun iz istega vira.
 
-**Dejanska ločljivost je slabša od mrežne.** Učinkovita ločljivost ERA5 je približno tri- do štirikrat slabša od nominalne — okoli **100 km**, ne 31 km. Gostejša mreža ERA5-Land tega ne popravi.
+**Dejanska ločljivost je slabša od mrežne.** Dejanska uporabna ločljivost ERA5 je približno tri- do štirikrat slabša od nazivne — okoli **100 km**, ne 31 km.
 
 Zadnjih ~6 dni prihaja iz predhodne različice reanalize ([ERA5T](/glossary/#gloss-era5t)), zato se te vrednosti lahko še spremenijo.
 
@@ -50,15 +50,15 @@ Odkrito navajamo njegove omejitve:
 
 ## Katera temperatura je privzeta
 
-Stran privzeto vodi z **najvišjo dnevno temperaturo (Tmax)** — na prvih karticah, ob nalaganju in v trendu, ki ga stran postavi v ospredje. Povprečna (Tmean) in najnižja (Tmin) dnevna temperatura sta na voljo za ročno izbiro, a nista privzeti.
+Stran privzeto prikazuje **najvišjo dnevno temperaturo (Tmax)** — na prvih karticah, ob nalaganju in v trendu, ki ga stran postavi v ospredje. Povprečna (Tmean) in najnižja (Tmin) dnevna temperatura sta na voljo za ročno izbiro, a nista privzeti.
 
-Razlog je kakovost podatkov. Reanaliza ERA5-Land sistematično slabše oceni **najnižjo** temperaturo v pozidanih območjih, ker mreža ne razreši mestnega toplotnega otoka. Ker se **povprečna** temperatura izračuna tudi iz najnižje, to pristranskost podeduje — ravno v naseljenih krajih, ki bralce najbolj zanimajo. Najvišja dnevna temperatura te pristranskosti ne nosi in se ujema z vprašanjem strani (»ali je vroče« — občutena dnevna vročina). Zato stran vodi s Tmax, izbira Tmean/Tmin pa ostaja bralcu, ki omejitev razume.
+Razlog je kakovost podatkov. Reanaliza ERA5-Land sistematično slabše oceni **najnižjo** temperaturo v pozidanih območjih, saj tudi matična reanaliza ERA5 v modelu eksplicitno ne upošteva učinkov mestnega toplotnega otoka. Ker se **povprečna** temperatura izračuna tudi iz najnižje, to pristranskost podeduje — ravno v naseljenih krajih, ki bralce najbolj zanimajo. Najvišja dnevna temperatura te pristranskosti ne nosi in se ujema z vprašanjem strani (»ali je vroče« — občutena dnevna vročina). Zato stran vodi s Tmax, izbira Tmean/Tmin pa ostaja bralcu, ki omejitev razume.
 
 ## Kaj pomeni »Slovenija«
 
 Vrednost predstavlja **neuteženo povprečje vseh 18 postaj**, vključno s Kredarico, popravljeno na nadmorsko višino — na strani poimenovano »povprečje 18 postaj«, s prikazanim naborom postaj in razponom višin.
 
-Uteževanje po površini ali višinskih pasovih smo pretehtali in **zavrnili**: ker je nad 1000 m le ena postaja (Kredarica), bi ta sama nosila cel višinski pas. To bi bilo videti natančno, a bi slonelo na eni sami točki. Neuteženo povprečje nad vidnim, poimenovanim naborom postaj je poštenejša konstrukcija.
+Uteževanje po površini ali višinskih pasovih smo pretehtali in **zavrnili**: ker je nad 1000 m le ena postaja (Kredarica), bi ta sama nosila cel višinski pas. To bi bilo videti natančno, a bi slonelo na eni sami točki. Neuteženo povprečje nad vidnim, poimenovanim naborom postaj je bolj poštena izbira.
 
 ## Časovni pas in dnevna meja
 
@@ -74,7 +74,7 @@ Ena posledica je pomembna za branje: ker je obdobje 1991–2020 razmeroma toplo,
 
 ## Porazdelitev in percentil
 
-Za vsak dan v letu stran prikaže **[porazdelitev](/glossary/#gloss-distribution)** preteklih vrednosti (kako pogosti so bili posamezni odkloni) in **[percentil](/glossary/#gloss-percentile)** današnje vrednosti (topleje od kolikšnega deleža primerjalnih dni).
+Za vsak dan v letu stran prikaže **[porazdelitev](/glossary/#gloss-distribution)** preteklih vrednosti (kako pogosti so bili posamezni odkloni) in v kateri **[percentil](/glossary/#gloss-percentile)** porazdelitve se uvršča današnja vrednost (topleje od kolikšnega deleža primerjalnih dni).
 
 - Porazdelitev je **empirična ocena gostote ([KDE](/glossary/#gloss-kde))** — sledi dejanski obliki podatkov — ne simetrična zvonasta (Gaussova) krivulja. Temperaturne porazdelitve so pogosto nesimetrične, zato bi Gaussova krivulja napačno prikazala repe, ravno tam, kjer se presoja »kako izjemen je današnji dan«.
 - Percentil je **pravi empirični percentil**, izračunan iz te krivulje (integral gostote do današnje vrednosti), ne približek iz barvnega pasu.
@@ -99,13 +99,13 @@ Trendno črto skozi leta ocenimo z metodo **[Theil-Sen](/glossary/#gloss-theil_s
 
 ## Trend vročih dni in tropskih noči
 
-Letni trend na grafih vročih dni in tropskih noči je **model negativne binomske regresije ([NB GLM](/glossary/#gloss-nb_glm))** čez letno število — primeren za štetne podatke z večjo razpršenostjo od Poissonove. Gre za **približek**, ne za dokončno napoved: prikazana stopnja rasti in [projekcija do leta 2050](/glossary/#gloss-projection_2050) sta odvisni od izbranega praga in dolžine zaporedja.
+Letni trend na grafih vročih dni in tropskih noči je **model negativne binomske regresije ([NB GLM](/glossary/#gloss-nb_glm))** čez letno število — primeren za številske podatke z večjo razpršenostjo od Poissonove. Gre za **približek**, ne za dokončno napoved: prikazana stopnja rasti in [projekcija do leta 2050](/glossary/#gloss-projection_2050) sta odvisni od izbranega praga in dolžine zaporedja.
 
-**Trenda ne prikažemo, kadar mu ne moremo zaupati.** Za nekatere kombinacije (redki dogodki, skoraj ravna letna vrsta) statistični model ne da zanesljivega rezultata — ne skonvergira ali pa ocena njegove negotovosti ni veljavna. V takih primerih trenda **ne objavimo** (letno štetje ostane prikazano), namesto da bi navedli navidezno natančno, a nezanesljivo številko. Enako velja, kadar je premalo let s podatki (potrebnih je vsaj 10). To je isto načelo kot pri indeksu suše SPEI: raje odklonimo objavo kot da objavimo negotovo vrednost.
+**Trenda ne prikažemo, kadar mu ne moremo zaupati.** Za nekatere kombinacije (redki dogodki, skoraj ravna časovna vrsta) statistični model ne da zanesljivega rezultata — ne skonvergira ali pa ocena njegove negotovosti ni veljavna. V takih primerih trenda **ne objavimo** (letno štetje ostane prikazano), namesto da bi navedli navidezno natančno, a nezanesljivo številko. Enako velja, kadar je premalo let s podatki (potrebnih je vsaj 10). To je isto načelo kot pri indeksu suše SPEI: raje odklonimo objavo, kot da objavimo negotovo vrednost.
 
 ## Povzetek omejitev
 
-- **Ne bazira direktno na meritvah ARSO.** Vrednosti so reanaliza ERA5-Land, ne meritve postaj, in **niso neposredno primerljive** z objavami ARSO.
+- **Ne bazira direktno na meritvah ARSO.** Vrednosti so iz reanalize ERA5-Land, ne meritev postaj, in **niso neposredno primerljive** z objavami ARSO.
 - **Korekcija na nadmorsko višino Kredarice** (−7,85 °C) je velika, preverjena, a ne validirana po mesecih, in lahko odstopa pozimi (glej zgoraj).
 - **ERA5-Land Tmin** je v mestih nezanesljiva (toplotni otok); zato stran privzeto ne prikazuje Tmean/Tmin.
 - **Ločljivost.** Mreža ERA5-Land je ~9 km, a vremenska informacija prihaja iz ERA5, katere učinkovita ločljivost je okoli 100 km. Lokalnih posebnosti pod to velikostjo vrednosti ne upoštevajo.


### PR DESCRIPTION
Applies a domain reviewer's corrections to the published methodology: twelve edits, one deletion in each of two files, and one factual correction.

**⚠ The factual correction is the substantive change.** The page said Tmin is biased in built-up areas because *the grid does not resolve* the urban heat island. That misattributes the cause: **the parent ERA5 reanalysis does not explicitly account for urban-heat-island effects in its model.** Different mechanism, and the reader is now told the right one.

**⚠ And an overstatement is removed from two places at once.** The methodology claimed *"Gostejša mreža ERA5-Land tega ne popravi"* — that the finer grid cannot recover what the effective resolution loses. The reviewer's point is that dynamic downscaling **does** partly improve on it by adapting to finer spectral orography, so the claim is too strong. It was deleted rather than softened, because softening would assert something new that would need its own source.

**The same overstatement lived in the glossary**, in `{#gloss-grid_cell}`: *"…zato ne ujame posebnosti, manjših od tega."* The session found it unprompted and stopped to ask. Deleting only the methodology sentence would have left **the page contradicting itself** — one surface saying the finer grid cannot help, the other still asserting it does not.

**A sweep confirmed there was exactly one more instance**, and it correctly distinguished the overstatement from the disclosure: `methodology.md:111` keeps the ~100 km effective-resolution framing, which the reviewer preserved, and the two glossary lines describing ERA5-Land as producing a *podrobnejšo sliko* stay, being positive about downscaling rather than dismissive of it.

**Ten further edits**, all the reviewer's: *številke* → *vrednosti* · *mreža modela ne leži* → *mrežna točka modela ni* · *učinkovita/nominalne* → *dejanska uporabna/nazivne* · *vodi z* → *prikazuje* · *poštenejša konstrukcija* → *bolj poštena izbira* · a clearer phrasing of where today's value falls in the distribution · *štetne* → *številske* · *letna vrsta* → *časovna vrsta* · a comma · *reanaliza/meritve* → *iz reanalize/meritev*.

**⚠ Two proposals were deliberately not applied.** The reviewer suggests replacing the 18-station mean with a **simple mean of all ERA5-Land grid points over Slovenia**, since 18 stations do not sample the country homogeneously — a fair point, and possible future work, but that grid is not available, it contradicts the current national definition, and it would move **every published national value**. A request for a counter-example lapse correction beside Kredarica's is likewise out of scope here.

**Left open for the operator:** the reviewer suggests citing the Copernicus Climate Data Store index as the primary archive. The prose already cites CDS via the specific dataset footnote and the glossary term, so this would be an addition rather than a fix — and citations are chosen and verified by hand, never added from a suggestion.

**One gap reported, not rewritten:** the reanalysis description lists four of the five source types the reviewer named — buoys are absent.

Snapshot unchanged, as predicted: `pages/*.md` is uncaptured markdown. Every touched line passed a codepoint scan; all Slovenian typed rather than pasted.

Gates: typecheck 0 · typecheck:gate 0 allowlisted · yarn test 100 incl. text-integrity · snapshot:check identical, 0 misses · pytest 77.
