### PR TITLE
promote main-a6ece7d-1786618112 to production

### DIFF
--- a/deploy/chart/values-prod.yaml
+++ b/deploy/chart/values-prod.yaml
@@ -2,5 +2,5 @@
 # proven itself on stage (see values-stage.yaml for the current one).
 host: podnebnik.org
 image:
-  tag: main-afda3ab-1786339994
+  tag: main-a6ece7d-1786618112
   repository: ghcr.io/podnebnik/website


### PR DESCRIPTION
Promote website image main-afda3ab-1786339994 -> main-a6ece7d-1786618112

Range: afda3ab..a6ece7d (17 commits, 3 days). Contents: T-6.29 domain-reviewer methodology edits, T-6.30 elevation-correction range, and four nightly data refreshes.

Website image only. Production reads the stage datasette, so the data in this range has been live since it merged.

Rollback: bin/rollback-prod.sh main-afda3ab-1786339994