### PR TITLE
T-6.32 — 108 editorial strings become 23: description per station, explanation per band

### DIFF
--- a/code/ali-je-vroce-era5/components/HeroCards.tsx
+++ b/code/ali-je-vroce-era5/components/HeroCards.tsx
@@ -4,10 +4,11 @@ import { sectionErrorFallback } from "./SectionError.tsx";
 import { EmptyState } from "./EmptyState.tsx";
 import type { RegressionResult } from "../types.ts";
 import { t, fmtNum, fmtSigned } from "../i18n/format.ts";
-// T-5.5 — per-location content is centralised in the catalogue; read the raw
-// objects here for the `?.[cat] ?? baseline` fallback and the risk <Show> guard,
-// which a key-returning t() cannot express.
-import { climateRisks, heroContext } from "../i18n/hero-content.ts";
+// T-6.32 — per-location content is centralised in the catalogue; read the raw
+// objects here for the `<Show>` guards, which a key-returning t() cannot express.
+// The card shows ONE station description (by era5_name) plus ONE category text
+// (by trend band), replacing the former single per-band narrative + risk line.
+import { stationDescriptions, categoryTexts } from "../i18n/hero-content.ts";
 
 const CATEGORIES: Record<string, string> = {
   catastrophic: t("hero.cat_catastrophic"),
@@ -93,7 +94,7 @@ export function HeroCards(props: Props) {
 function HeroCard(props: { res: RegressionResult; unit: string; dateLabel: string; label?: string | undefined }) {
   const res = () => props.res;
   // Display name (label) for what the reader sees; res().loc stays the ASCII key for
-  // the heroContext / climateRisks lookups below.
+  // the stationDescriptions lookup below.
   const displayName = () => props.label ?? res().loc.replace(/_/g, " ");
   const st  = () => res().stats;
   const cat = () => trendCategory(st().trend10);
@@ -102,8 +103,10 @@ function HeroCard(props: { res: RegressionResult; unit: string; dateLabel: strin
 
   const nValues = () => (st() as any).n_values as number | undefined;
 
-  const ctx = () => heroContext[res().loc]?.[cat()] ?? heroContext[res().loc]?.["baseline"];
-  const risk = () => climateRisks[res().loc];
+  // Station description is band-independent (keyed by era5_name); the category
+  // text is keyed by the trend band. Both render in the right column.
+  const desc = () => stationDescriptions[res().loc];
+  const catText = () => categoryTexts[cat()];
 
   return (
     <div
@@ -142,18 +145,6 @@ function HeroCard(props: { res: RegressionResult; unit: string; dateLabel: strin
               {t("hero.unit_decade")}
             </span>
           </div>
-
-          {/* Climate risk label */}
-          <Show when={risk()}>
-            <div style={{ "margin-top": "8px" }}>
-              <div style={{ ...MONO, "font-size": "9px", "letter-spacing": "0.08em", "text-transform": "uppercase", color: "var(--color-ink-soft)", "margin-bottom": "3px" }}>
-                {t("hero.risk_label")}
-              </div>
-              <div style={{ ...SANS, "font-size": "11px", color: "var(--color-ink-soft)", "line-height": "1.45" }}>
-                {risk()}
-              </div>
-            </div>
-          </Show>
         </div>
 
         {/* Right column: verdict + category */}
@@ -175,10 +166,17 @@ function HeroCard(props: { res: RegressionResult; unit: string; dateLabel: strin
             </span>
           </div>
 
-          {/* Context text */}
-          <Show when={ctx()}>
+          {/* Station description (band-independent) */}
+          <Show when={desc()}>
             <p style={{ ...SANS, margin: "0", "font-size": "13px", color: "var(--color-ink-soft)", "line-height": "1.55" }}>
-              {ctx()}
+              {desc()}
+            </p>
+          </Show>
+
+          {/* Category text (per trend band) */}
+          <Show when={catText()}>
+            <p style={{ ...SANS, margin: "0", "font-size": "13px", color: "var(--color-ink-soft)", "line-height": "1.55" }}>
+              {catText()}
             </p>
           </Show>
 

--- a/code/ali-je-vroce-era5/i18n/hero-content.ts
+++ b/code/ali-je-vroce-era5/i18n/hero-content.ts
@@ -1,158 +1,46 @@
-// T-5.5 (D-8) — per-location HeroCards content, MOVED VERBATIM from HeroCards.tsx.
+// T-6.32 (D-8) — per-location HeroCards content.
 //
-// These two tables are single-locale editorial CONTENT (18 stations × the climate
-// risk line + 5 trend-category descriptions). They were relocated here unchanged so
-// the catalogue is the single source, WITHOUT retyping the prose — the exact bytes
-// from HeroCards.tsx were preserved to keep the rendered output byte-identical.
-// Wording is content-provider territory and is FLAGGED for review (PROGRESS T-5.5),
-// e.g. "stletni"/"stletni poplavni viški" and other typos live in the source prose.
+// Two single-locale editorial tables, keyed language-neutrally so a second
+// locale swaps VALUES only:
+//   • stationDescriptions — one physical-setting description per station, keyed
+//     by era5_name (ASCII). Shown at EVERY trend band: it says what the place IS
+//     and what the warming trend acts on there (terrain, water source, climate
+//     driver), never an outcome.
+//   • categoryTexts — one explanation per trend band, keyed by the same
+//     baseline|moderate|bad|extreme|catastrophic keys as trendCategory(). It
+//     states what the number means, not what it will cause.
+//
+// This REPLACES the former heroContext (18 stations x 5 bands = 90 narratives)
+// and climateRisks (18 impact labels). The risk labels were removed: they named
+// outcomes rather than exposures, two were factually wrong, and none was
+// sourced. Wording is the operator's (D-8); typed, not pasted (T-5.12), and
+// guarded by tests/unit/text-integrity.test.ts.
 
-export const climateRisks: Record<string, string> = {
-  Ljubljana:        "Mestni toplotni otok — poletni vročinski stres in tveganje hudourniških poplav v Ljubljanski kotlini",
-  Maribor:          "Sušni stres v vinogradništvu — zgodnejše trgatve in premik vinskih sort",
-  Celje:            "Okrepitev poplav Savinje v kombinaciji z naraščajočo poletno sušo",
-  Kranj:            "Izguba alpske snežne odeje, ki zmanjšuje poletni pretok Save",
-  Koper:            "Podaljšanje sredozemske suše — tveganje vdora slane vode in dviga morske gladine",
-  Novo_Mesto:       "Suša reke Krke ogroža pridelavo hmelja in sadja",
-  Murska_Sobota:    "Panonska vročina in suša — najtoplejše temperaturne razlike v Sloveniji",
-  Nova_Gorica:      "Sredozemsko sušenje — ekosistem hladnovodne Soče in kraško vinogradništvo v nevarnosti",
-  Postojna:         "Suša kraškega vodonosnika — jamski ekosistem in endemska favna pod toplotnim stresom",
-  Ptuj:             "Nizki vodostaji Drave — vodni stres v vinogradništvu in zmanjšanje hidroenergetskih zmogljivosti",
-  Velenje:          "Upravljanje z vodo po izkopavanju premoga ob stopnjevanju suše in poplav",
-  Trbovlje:         "Ojačanje vročine v savski soteski in naraščajoče tveganje poplav",
-  Tolmin:           "Stopnjevanje ekstremnih poplav Soče — krčenje ekosistema hladnovodnih rib",
-  Kocevje:          "Propad pragozdov pod napadom lubadarja — izguba habitata velikih zveri",
-  Ilirska_Bistrica: "Izčrpavanje kraških izvirov — motnja podzemnega rečnega sistema Pivke",
-  Domzale:          "Mestni toplotni otok v kotlini — kombinirani vročinski in sušni stres za Ljubljansko regijo",
-  Ratece:           "Izguba alpske snežne odeje — grožnja smučarskemu gospodarstvu in nestabilnost permafrost pobočij",
-  Kredarica:        "Izguba Triglavskega ledenika — izsušitev izvirnih vod za Slovenijo reke",
+export const stationDescriptions: Record<string, string> = {
+  Ljubljana:        "Leži v Ljubljanski kotlini, sklenjeni kotlini med Alpami in kraškim svetom, na jugu ob Ljubljanskem barju. Vbočena lega pozimi ujame hladen zrak, zato so pogosti temperaturni obrati in megla (v povprečju okoli 64 meglenih dni na leto). Ker je kotlina slabo prevetrena, se poletna vročina v njej kopiči in segrevanje se tu izrazi močneje. Podnebje je zmerno celinsko.",
+  Maribor:          "Leži ob Dravi tam, kjer reka zapušča alpski svet ob vznožju Pohorja in prehaja proti Panonski nižini, zato ima izrazito celinsko podnebje s toplimi poletji. Drava je alpska reka, ki jo napaja gorski sneg; take reke so občutljive na segrevanje, saj toplejše zime pomikajo taljenje bolj zgodaj in znižujejo poletni pretok. Proti vzhodu se krepi tudi sušna izpostavljenost.",
+  Celje:            "Leži v Celjski kotlini v spodnji Savinjski dolini, na nizki ravnini, kamor se v Savinjo stekajo Hudinja, Ložnica in Voglajna. Nizko ležeče sotočje v kotlini je izpostavljeno poplavam Savinje; za to porečje so izdelane karte poplavne nevarnosti, urejanje struge z nasipi pa je zmanjšalo naravne zadrževalne površine in pospešilo poplavni val. Podnebje je zmerno celinsko.",
+  Kranj:            "Leži na terasi nad sotočjem Save in Kokre, v Gorenjski ravnini, ki jo obdajajo Julijske Alpe in Karavanke na severozahodu ter Kamniško-Savinjske Alpe na vzhodu. Kokra je v teraso vrezala globoko sotesko. Savo in Kokro napaja gorski sneg, zato sta občutljivi na segrevanje: toplejše zime taljenje pomaknejo bolj zgodaj in znižajo poletni pretok.",
+  Koper:            "Leži na ozkem obalnem pasu ob Jadranskem morju, v istrskem gričevju na skrajnem jugozahodu. Morje blaži temperature, zato je podnebje submediteransko z milimi, vlažnimi zimami in vročimi, suhimi poleti. Poletja so že suha, s segrevanjem pa se sušni pritisk krepi. Obalo občasno zajame burja, hladen sunkovit severovzhodnik s kraškega zaledja.",
+  Novo_Mesto:       "Leži na terasi v okljuku reke Krke na jugovzhodu, v dolenjskem gričevju iz apnenca in dolomita. Krka je kraška reka, ki izvira iz kraških izvirov; njen poletni pretok je odvisen od zalog v krasu in dežja, suše pa so vse pogostejše. Podnebje je zmerno celinsko.",
+  Murska_Sobota:    "Leži na ravnem, odprtem delu Panonske nižine v Prekmurju, blizu reke Mure, v skrajnem severovzhodnem kotu države. Odprta lega brez morskega blaženja se hitro segreva in izsušuje; ta del države ima med najnižjimi količinami padavin in je najbolj sušno izpostavljen, pogostost kmetijskih suš pa narašča.",
+  Nova_Gorica:      "Leži tam, kjer se dolina Soče odpira proti Furlanski nižini, ob italijanski meji, v submediteranskem podnebju s toplimi, sončnimi poletji. Poletja so že suha, s segrevanjem pa se sušni pritisk krepi. Skozi Vipavsko dolino in Goriško z zaledne planote (Trnovski gozd, Nanos) pogosto piha burja, hladen sunkovit severovzhodnik. Okoliško flišno gričevje Brd je nagnjeno k zemeljskim plazovom.",
+  Postojna:         "Leži na kraški planoti Notranjske, v Postojnski kotlini, kjer reka Pivka pod hribom Sovič ponikne v podzemlje in nadaljuje pot skozi kras. Vsa voda tod je vezana na kras, na izvire in podzemne tokove, njen pretok pa je odvisen od dežja in kraških zalog; suše postajajo vse pogostejše. Dvignjena kraška lega prinaša hladnejše podnebje kot v nižinah.",
+  Ptuj:             "Leži ob Dravi na odprti Ptujski (Dravski) ravnini na severovzhodu, v zmerno celinskem podnebju s panonskim pridihom in toplimi poletji. Odprta celinska lega se hitro segreva in izsušuje, sušna izpostavljenost severovzhoda pa je med največjimi v državi. Drava je alpska reka, katere prodna ravnina hrani obsežen vodonosnik.",
+  Velenje:          "Leži v Šaleški dolini, kotlini med Kamniško-Savinjskimi Alpami in Pohorjem, ob reki Paki. V dnu kotline ležijo Šaleška jezera, ki vplivajo na lokalno podnebje doline. V slabo prevetreni kotlini se poletna vročina kopiči, zato se segrevanje tu izrazi močneje.",
+  Trbovlje:         "Leži na dnu ozke doline levega pritoka Save v Zasavju, ki jo zapirajo hribi Posavskega hribovja. Ozka, zaprta lega in temperaturni obrati zadržujejo hladen zrak pri dnu doline, poletna vročina pa se v zaprti dolini kopiči.",
+  Tolmin:           "Leži na terasi nad sotočjem Soče in Tolminke, na južnem robu Julijskih Alp. Gore silijo vlažen zrak v dvig, zato so padavine obilne; strma pobočja in obilne padavine povečujejo poplavno izpostavljenost Soče in njenih pritokov. Sočo napaja gorski sneg, zato je njen poletni pretok občutljiv na toplejše zime.",
+  Kocevje:          "Leži v gozdnati dinarski kraški kotlini ob kraški reki Rinži, pod planoto Kočevski Rog na jugu države. Dinarski svet prestreza vlažen zrak, zato so padavine obilne, voda pa ponika v kras. V kraških kotanjah se ob jasnih nočeh nabira hladen zrak. Poletni pretok kraških voda je odvisen od zalog in dežja, suše pa so vse pogostejše.",
+  Ilirska_Bistrica: "Leži v dolini reke Reke pod gozdnato planoto Snežnik, na prehodu med submediteranskim in celinskim podnebjem. Reka izvira iz kraških izvirov pod Snežnikom, teče mimo mesta in se niže ponori v podzemlje (v Škocjanske jame). Njen pretok je vezan na kraške izvire in dež, suše pa so vse pogostejše.",
+  Domzale:          "Leži v severovzhodnem delu Ljubljanske kotline ob reki Kamniški Bistrici, ki priteka iz Kamniško-Savinjskih Alp. Kotlinska lega prinaša podobne zimske temperaturne obrate in meglo kot v širši ljubljanski okolici, v slabo prevetreni kotlini pa se poletna vročina kopiči. Podnebje je zmerno celinsko.",
+  Ratece:           "Alpska vas leži na dnu široke, ravne zgornje Savske doline v Julijskih Alpah, blizu tromeje z Italijo in Avstrijo. Ravno dno pod jasnim nebom ujame hladen zrak, zato je Rateče eno najhladnejših naseljenih krajev v Sloveniji, z obilno in dolgotrajno snežno odejo (povprečno okoli 234 cm snega na leto). S toplejšimi zimami se količina in trajanje snežne odeje zmanjšujeta.",
+  Kredarica:        "Najvišja meteorološka postaja v Sloveniji stoji na 2514 m na pobočju Triglava v Julijskih Alpah, visoko nad gozdno mejo. Zaradi višine in severne lege se sneg obdrži globoko v poletje. Snežna odeja se s segrevanjem krajša, bližnji Triglavski ledenik pa se krči. To visokogorje je izvirno območje voda, ki tečejo v porečje Save.",
 };
 
-export const heroContext: Record<string, Record<string, string>> = {
-  Ljubljana: {
-    baseline:     "Glavno mesto v Ljubljanski kotlini, ki jo obkrožajo hribi in pozimi pastuje hladen zrak. Celinsko podnebje s toplimi poletji in hladnimi zimami, okrepljeno z mestnim toplotnim otokom.",
-    moderate:     "Segrevanje skrajšuje zimsko megleno sezono, a povečuje poletni toplotni stres. Mestno tkivo zadržuje toploto, ponoči postaja vse toplejše po vsej metropolitanski regiji.",
-    bad:          "Vročinski valovi presegajo 35 °C več zaporednih dni. Smrtnost starejših narašča. Kotlinska lega kopiči toploto; poraba klimatskih naprav se poveča in preobremeni omrežje.",
-    extreme:      "Podaljšane vročinske izredne razmere postanejo letni pojav. Reka Ljubljanica poleti splahni, kar ogroža vodooskrbo. Mestna zelenjava trpi pod hudim sušnim stresom.",
-    catastrophic: "Podaljšani poletni vročinski valovi presegajo hladilne zmogljivosti mesta. Hudourniške poplave iz okrepljenih alpskih padavin večkrat ogrozijo nizko ležečo kotlino.",
-  },
-  Maribor: {
-    baseline:     "Drugo največje mesto, dolina reke Drave, severovzhodna Slovenija. Celinsko podnebje z vročimi poletji. Pomembna vinorodna regija — segrevanje že pomika datume trgatve naprej.",
-    moderate:     "Podaljšana rastna sezona kratkoročno koristi vinu, a naraščajoč sušni stres in tveganje poznih zmrzali po zgodnji brstovitvi začenjata ogrožati pridelke.",
-    bad:          "Datumi trgatve se premaknejo 3–4 tedne naprej. Tradicionalne štajerske sorte trpijo pod vročinskim stresom. Fitosanitarni problemi se bistveno okrepijo.",
-    extreme:      "Tradicionalne štajerske vinogradniške sorte postanejo ekonomsko neobstojne. Povpraševanje po namakanju iz Drave se spopada z ekološkimi zahtevami pretoka.",
-    catastrophic: "Ponavljajoča se huda sušna leta sesedejo štajersko vinsko gospodarstvo. Ekstremno nizki vodostaji Drave ogrožajo vodooskrbo doline in obrečne ekosisteme.",
-  },
-  Celje: {
-    baseline:     "Dolina reke Savinje, zgodovinsko podvržena hudim poplavam. Celinsko podnebje. Zaprta dolina ustvarja temperaturne inverzije in zmrzalne žepe pozimi.",
-    moderate:     "Segrevanje zmanjšuje zmrzalne dni, a krepi konvektivne padavine, ki sprožajo poplave Savinje, po katerih je mesto že znano.",
-    bad:          "Dogodki, ki so bili prej stletni poplavni viški, se ponavljajo v desetletjih. Protipoplavna infrastruktura, zgrajena za zgodovinske povratne dobe, je sistematično prekoračena.",
-    extreme:      "Kombinirani poletni sušni in zimski poplavni ekstremi hkrati destabilizirajo kmetijstvo in infrastrukturo v dolini Savinje.",
-    catastrophic: "Pogostejši ekstremni poplavni dogodki preplavljajo staro protipoplavno infrastrukturo. Izmenjava suša–poplava destabilizira kmetijsko savinjsko ravnino.",
-  },
-  Kranj: {
-    baseline:     "Ob vznožju Kamniško-Savinjskih Alp, dolina reke Save, 387 m. Alpski vpliv ohranja razmeroma hladna poletja. Vhod v Triglavski narodni park.",
-    moderate:     "Upadanje alpske snežne odeje zmanjšuje poletni pretok Save, kar vpliva na vodooskrbo za odvodne uporabnike, vključno z Ljubljano.",
-    bad:          "Poletni nizki vodostaji Save postanejo hudi. Hidroelektrična proizvodnja na savski verigi elektrarn v sušnih letih občutno pade.",
-    extreme:      "Umikanje ledenikov v Kamniško-Savinjskih Alpah se pospeši. Kamenje iz destabilizirajočih se pobočij ogroža infrastrukturo v dolini.",
-    catastrophic: "Izguba zanesljive poletne savenice, ki jo napaja snežna odeja, ogroža hidroelektrično hrbtenico slovenskega elektroenergetskega sistema.",
-  },
-  Koper: {
-    baseline:     "Edino slovensko morsko pristanišče, Jadransko morje, 10 m nadmorske višine. Sredozemsko podnebje: mile zime, suha poletja, burjni vetrovi.",
-    moderate:     "Segrevanje morske gladine podaljšuje kopalno sezono. Tveganje suše se poleti povečuje z naraščajočim sredozemskim sušnim signalom.",
-    bad:          "Vdor slane vode v obalne vodonosnike se krepi. Mediteranske invazivne vrste se ustanavljajo v slovenskih obalnih vodah.",
-    extreme:      "Pogostost in resnost neviht s sodro narašča. Obalno kmetijsko zemljišče se sooča s slanostjo od morskih razpršilcev in vdorov podzemne vode.",
-    catastrophic: "Dvig gladine Jadranskega morja ogroža pristaniško infrastrukturo in obalno kmetijstvo. Ekstremni burjni dogodki se krepijo z naraščajočimi temperaturnimi gradienti.",
-  },
-  Novo_Mesto: {
-    baseline:     "Dolina reke Krke, jugovzhodna Slovenija, 220 m. Celinsko s ponekod panonskim vplivom. Pomembna regija za sadje — jabolka, hruške in hmelj.",
-    moderate:     "Segrevanje podaljšuje brezzmrzalno rastno sezono, a povečuje poletni sušni stres na povodju reke Krke.",
-    bad:          "Osnovni pretok reke Krke poleti občutno upade. Pridelava hmelja se sooča z vročinskim in sušnim stresom, ki zahteva drago namakanje.",
-    extreme:      "Večletne suše izčrpavajo reko Krko in podzemno vodo. Sadjarstvo in hmeljarstvo zahtevata temeljito prestrukturiranje.",
-    catastrophic: "Ponavljajoča se sušna leta izčrpavajo osnovni pretok reke Krke. Hmeljarsko in sadjarsko gospodarstvo Dolenjske se sooča s temeljitim prestrukturiranjem.",
-  },
-  Murska_Sobota: {
-    baseline:     "Severovzhodna panonska ravnina, 189 m. Najbolj celinsko postaja — najtoplejša poletja, najhladnejše zime, najmanj padavin. Intenzivno kmetijstvo: koruza, sončnice, pšenica.",
-    moderate:     "Že najbolj sušno izpostavljena regija v Sloveniji. Dni z vročinskim stresom nad 35 °C naraščajo najhitreje. Primanjkljaj kmetijske vode je že občuten.",
-    bad:          "Pridelki koruze in sončnic v sušnih letih padejo za 20–30 %. Poletni ekstremi nad 38 °C postanejo redni.",
-    extreme:      "Večletna sušna zaporedja sesedejo tradicionalno kmetijstvo brez namakanja. Povpraševanje po namakanju preseže trajnostni donos reke Mure.",
-    catastrophic: "Panonsko kmetijsko gospodarstvo se sooča s propadom pod trajnimi večletnimi sušami. Izčrpavanje podzemne vode se pospeši.",
-  },
-  Nova_Gorica: {
-    baseline:     "Zahodna Slovenija, spodnja dolina Soče, 94 m. Sredozemsko-alpski prehod. Toplo in sončno z burjnimi vetrovi. Pomembna vinorodna regija.",
-    moderate:     "Segrevanje pospešuje sredozemski trend sušenja. Burjni dogodki se morda okrepijo. Kakovost vin se preoblikuje z naraščanjem rastnih stopenj.",
-    bad:          "Poletna suša naredi tradicionalno kraško vinogradništvo vse bolj odvisno od namakanja. Nizki poletni pretoki Soče ogrožajo ekologijo.",
-    extreme:      "Hladnovodni ribolov Soče se sooča s toplotnim izumrtjem v spodnjih dosegih, ko poletne temperature presegajo toleranče.",
-    catastrophic: "Ekstremna poletna suša naredi tradiconalno kraško in brdiško vinogradništvo neobstojno brez namakanja.",
-  },
-  Postojna: {
-    baseline:     "Kraška planota, 549 m. Znana po temperaturnih inverzijah — hladen zrak se kopiči v kraški depresiji. Temperature v jamskem ekosistemu so stabilne pri 10 °C.",
-    moderate:     "Segrevanje slabi temperaturne inverzije in zmanjšuje ekstremno hlajenje. Temperature v jamskem ekosistemu se začnejo premikati.",
-    bad:          "Notranje jame začnejo izmerljivo naraščati. Pretok kraških izvirov poleti v sušah upada.",
-    extreme:      "Endemska favna Postojnske jame — človeška ribica in jamski hrošči — se sooča s toplotnim in hidrološkim stresom.",
-    catastrophic: "Napajanje kraškega vodonosnika popusti pod podaljšano sušo. Endemska favna Postojnske jame se sooča s toplotnim stresom brez poti pobega.",
-  },
-  Ptuj: {
-    baseline:     "Najstarejše stalno poseljeno mesto v Sloveniji, dolina reke Drave, 228 m. Severovzhodna celinska cona. Vino, hmelj in žitno kmetijstvo.",
-    moderate:     "Dogodki nizkih vodostajev Drave se pogostijo, kar vpliva na hladilno vodo za hidroelektrarno Formin nizvodno.",
-    bad:          "Datumi trgatve se bistveno premaknejo naprej. Kmetijsko povpraševanje po vodi vse bolj nasprotuje ekološkim zahtevam pretoka.",
-    extreme:      "Ekstremno nizki vodostaji Drave postanejo redni. Hidroelektrarna Formin se v sušnih letih sooča z obveznim omejevanjem.",
-    catastrophic: "Kombinirani sušni in vročinski ekstremi destabilizirajo kmetijsko gospodarstvo v dravski dolini.",
-  },
-  Velenje: {
-    baseline:     "Šaleška dolina, 405 m, osrednja Slovenija. Zgrajena okoli premogovništva. Gorska celinska mikroklima pod vplivom Šaleških jezer.",
-    moderate:     "Ko premogovništvo upada, podnebni vplivi vključujejo povečano tveganje poplav v posedninskih conah.",
-    bad:          "Šaleška jezera se soočajo z naraščajočim izhlapevanjem in cvetenjem alg. Upravljanje z vodo postane kompleksno.",
-    extreme:      "Prehod po premogu oteži podnebne ekstreme. Načrtovani prehod na obnovljivo energijo se sooča s konflikti rabe tal.",
-    catastrophic: "Upravljanje z vodo v posedninskih jezerih postane kritično z naraščajočim izhlapevanjem.",
-  },
-  Trbovlje: {
-    baseline:     "Zasavje, savska soteska, 230 m. Najožja poseljena dolina v Sloveniji. Kotlinska lega ustvarja značilne temperaturne inverzije.",
-    moderate:     "Segrevanje zmanjšuje zimske inverzije, ki kopičijo onesnaženost zraka, a povečuje poletni toplotni stres v zaprti dolini.",
-    bad:          "Poletni vročinski valovi v soteski so okrepljeni z njeno geometrijo in industrijskimi toplotnimi viri.",
-    extreme:      "Ekstremni padavinski dogodki nad Trbovljami povečujejo katastrofalno tveganje poplav v soteski.",
-    catastrophic: "Ekstremni vročinski valovi v soteski so okrepljeni z njeno geometrijo. Tveganje poplav Save narašča z naraščajočimi alpskimi padavinami.",
-  },
-  Tolmin: {
-    baseline:     "Dolina Soče/Isonzo, 194 m. Najtoplejša dolina v Sloveniji kljub alpski legi. Ekstremni padavinski dogodki naredijo to območje najdežnejše v Evropi.",
-    moderate:     "Segrevanje krepi že tako ekstremne padavinske dogodke. Izjemna biotska raznovrstnost doline se sooča z naraščajočim toplotnim pritiskom.",
-    bad:          "Poletni pretoki Soče občutno upadejo. Hladnovodni habitat marmornega postrva se krči navzgor po toku.",
-    extreme:      "Ekstremni poplavni dogodki na sistemu Soča–Idrijca se ponavljajo pogosteje. Smaragdna barva Soče zbledi z umikanjem ledenikov.",
-    catastrophic: "Katastrofalni poplavni dogodki na Soči postanejo pogostejši. Hladnovodni ribolov in naravni turizem sta temeljno ogrožena.",
-  },
-  Kocevje: {
-    baseline:     "Regija Kočevski Rog, 467 m, pokrita z največjim ostankom pragozdov v Srednji Evropi. Medvedi, risi in volkovi v največji gostoti v Evropi.",
-    moderate:     "Segrevanje premakne sestavo gozda k termofilnim vrstam. Izbruhi lubadarja se pospešijo v toplejših, sušnejših poletjih.",
-    bad:          "Pragozd se sooča s strukturno preobrazbo pod kombiniranim pritiskom suše in lubadarja.",
-    extreme:      "Obsežno odmiranje gozda odpre pragozd tveganju požarov, ki je bilo prej zanemarljivo.",
-    catastrophic: "Kočevski pragozd se sooča z nepopravljivo strukturno spremembo. Habitat velikih zveri se krči z upadanjem gozda.",
-  },
-  Ilirska_Bistrica: {
-    baseline:     "Pivška kotlina, 440 m. Prehodno območje med sredozemskim in celinskim podnebjem. Reka Pivka izgine pod zemljo v največji jamski sistem na svetu.",
-    moderate:     "Segrevanje zmanjšuje zimsko snežno odejo, ki napaja kraške izvire Pivke.",
-    bad:          "Površinski pretok reke Pivke izgine zgodaj v sezoni, ko upadejo kraški izviri.",
-    extreme:      "Jamski sistem Postojna–Planina se sooča z zmanjšanim pretokom in naraščajočimi temperaturami vode.",
-    catastrophic: "Kraški izviri, ki napajajo reko Pivko, poleti presahnejo. Edinstveni hidrološki sistem je moten s kaskadnimi učinki.",
-  },
-  Domzale: {
-    baseline:     "Ljubljanska kotlina, 301 m. Primestno in lahko industrijsko. Celinsko podnebje z nekoliko manjšim mestnim toplotnim otokom kot Ljubljana.",
-    moderate:     "Z razširjanjem metropolitanske regije se mestni toplotni otoški učinki krepijo.",
-    bad:          "Poletni toplotni otok po kotlini ustvarja trajen vročinski stres za 400.000 prebivalcev regije.",
-    extreme:      "Kombinirani vročinski in sušni dogodki bistveno zmanjšajo kakovost življenja in povečajo smrtnost.",
-    catastrophic: "Urbanizacija v kombinaciji s podnebnim segrevanjem ustvari trajen toplotni otok s kumulativnimi učinki na javno zdravje.",
-  },
-  Ratece: {
-    baseline:     "Tarbizijska kotlina, Julijske Alpe, 864 m. Eno najsušnejših mest v Sloveniji kljub alpski legi. Ekstremno hladne zime, obilna snežna odeja.",
-    moderate:     "Globina in trajanje snežne odeje se opazno zmanjšujeta. Čas spomladanskega odtajanja se premika naprej.",
-    bad:          "Smučarsko letovišče Kranjska Gora se sooča z ekonomsko neobstojnimi snežnimi sezonami.",
-    extreme:      "Taljenje permafrosta v Julijskih Alpah sproži naraščajoče kamenje in nestabilnost pobočij.",
-    catastrophic: "Izguba zanesljive zimske snežne odeje konča smučarsko gospodarstvo v dolini Kranjske Gore.",
-  },
-  Kredarica: {
-    baseline:     "Vrh masiva Triglava, 2514 m — najvišja meteorološka postaja v Sloveniji. Stalni sneg, ostanki ledenikov, ekstremni vetrovi.",
-    moderate:     "Triglavski ledenik — zadnji ledenik v Sloveniji — se vidno umika. Segrevanje je tukaj dvojno od nižinskega.",
-    bad:          "Triglavski ledenik izgubi več kot polovico preostalega volumna. Ikonična silhueta se sooča s trajno spremembo.",
-    extreme:      "Triglavski ledenik popolnoma izgine. Visokogorski ekosistem nad gozdno mejo propade.",
-    catastrophic: "Popolna izguba Triglavskega ledenika — narodni simbol in vir savinjskih rek. Propad alpskega ekosistema sproži kaskadne učinke.",
-  },
+export const categoryTexts: Record<string, string> = {
+  baseline:     "Trend za ta dan v letu je pod 0,05 °C na desetletje, kar pomeni, da segrevanja tako rekoč ni zaznati oziroma je znotraj statističnega šuma.",
+  moderate:     "Trend je med 0,05 in 0,10 °C na desetletje: blago, a zaznavno segrevanje, približno pol do ene stopinje na stoletje.",
+  bad:          "Trend je med 0,10 in 0,20 °C na desetletje: jasno segrevanje, približno ena do dve stopinji na stoletje.",
+  extreme:      "Trend je med 0,20 in 0,30 °C na desetletje: hitro segrevanje, približno dve do tri stopinje na stoletje.",
+  catastrophic: "Trend je 0,30 °C na desetletje ali več: zelo hitro segrevanje, tri ali več stopinj na stoletje. To je najvišja, navzgor odprta kategorija.",
 };

--- a/code/ali-je-vroce-era5/i18n/sl.ts
+++ b/code/ali-je-vroce-era5/i18n/sl.ts
@@ -1,4 +1,4 @@
-import { climateRisks, heroContext } from "./hero-content.ts";
+import { stationDescriptions, categoryTexts } from "./hero-content.ts";
 
 // T-5.5 (D-8) — Slovenian message catalogue for the "Ali je vroče" ERA5 island.
 //
@@ -339,7 +339,6 @@ export const sl = {
 
     eyebrow_var: "najvišja temperatura",
     unit_decade: "°C / desetletje",
-    risk_label: "Tveganje vpliva:",
     stat_significance: "Značilnost",
     stat_sample: "Vzorec",
     stat_autocorrelation: "Avtokorelacija",
@@ -352,11 +351,12 @@ export const sl = {
     group_a11y: "Podrobnosti lokacije {station}: stoletni temperaturni trend, kategorija tveganja in vpliv podnebne spremembe.",
   },
 
-  // Per-location content tables, moved VERBATIM from HeroCards.tsx (T-5.5) so the
-  // rendered prose stays byte-identical. Looked up as climate_risks.<Loc> and
-  // hero_context.<Loc>.<category>. Wording is content-provider territory (FLAGGED).
-  climate_risks: climateRisks,
-  hero_context: heroContext,
+  // Per-location content tables (T-6.32), surfaced through the locale catalogue.
+  // station_descriptions.<era5_name> (one per station, shown at every band) and
+  // category_texts.<band> (baseline|moderate|bad|extreme|catastrophic). A second
+  // locale swaps VALUES only. Wording is content-provider territory (D-8).
+  station_descriptions: stationDescriptions,
+  category_texts: categoryTexts,
 
   // Season heatmap
   season: {

--- a/tests/fixtures/snapshot.json
+++ b/tests/fixtures/snapshot.json
@@ -34403,12 +34403,12 @@
           "headline_color": "rgb(194, 90, 44)",
           "category": "Zelo zaskrbljujoče",
           "paragraphs": [
-            "Podaljšani poletni vročinski valovi presegajo hladilne zmogljivosti mesta. Hudourniške poplave iz okrepljenih alpskih padavin večkrat ogrozijo nizko ležečo kotlino.",
+            "Leži v Ljubljanski kotlini, sklenjeni kotlini med Alpami in kraškim svetom, na jugu ob Ljubljanskem barju. Vbočena lega pozimi ujame hladen zrak, zato so pogosti temperaturni obrati in megla (v povprečju okoli 64 meglenih dni na leto). Ker je kotlina slabo prevetrena, se poletna vročina v njej kopiči in segrevanje se tu izrazi močneje. Podnebje je zmerno celinsko.",
+            "Trend je 0,30 °C na desetletje ali več: zelo hitro segrevanje, tri ali več stopinj na stoletje. To je najvišja, navzgor odprta kategorija.",
             "Sto let segrevanja za +5,65 °C – pri trenutnem tempu vsakih 17,7 let doda eno stopinjo.",
             "Theil-Sen + Mann-Kendall"
           ],
           "stats": [
-            "Mestni toplotni otok — poletni vročinski stres in tveganje hudourniških poplav v Ljubljanski kotlini",
             "★★★ p < 0,001",
             "0,5650",
             "77 let",
@@ -37929,12 +37929,12 @@
           "headline_color": "rgb(194, 90, 44)",
           "category": "Zelo zaskrbljujoče",
           "paragraphs": [
-            "Podaljšani poletni vročinski valovi presegajo hladilne zmogljivosti mesta. Hudourniške poplave iz okrepljenih alpskih padavin večkrat ogrozijo nizko ležečo kotlino.",
+            "Leži v Ljubljanski kotlini, sklenjeni kotlini med Alpami in kraškim svetom, na jugu ob Ljubljanskem barju. Vbočena lega pozimi ujame hladen zrak, zato so pogosti temperaturni obrati in megla (v povprečju okoli 64 meglenih dni na leto). Ker je kotlina slabo prevetrena, se poletna vročina v njej kopiči in segrevanje se tu izrazi močneje. Podnebje je zmerno celinsko.",
+            "Trend je 0,30 °C na desetletje ali več: zelo hitro segrevanje, tri ali več stopinj na stoletje. To je najvišja, navzgor odprta kategorija.",
             "Sto let segrevanja za +5,65 °C – pri trenutnem tempu vsakih 17,7 let doda eno stopinjo.",
             "Theil-Sen + Mann-Kendall"
           ],
           "stats": [
-            "Mestni toplotni otok — poletni vročinski stres in tveganje hudourniških poplav v Ljubljanski kotlini",
             "★★★ p < 0,001",
             "0,5650",
             "77 let",
@@ -41455,12 +41455,12 @@
           "headline_color": "rgb(194, 90, 44)",
           "category": "Zelo zaskrbljujoče",
           "paragraphs": [
-            "Popolna izguba Triglavskega ledenika — narodni simbol in vir savinjskih rek. Propad alpskega ekosistema sproži kaskadne učinke.",
+            "Najvišja meteorološka postaja v Sloveniji stoji na 2514 m na pobočju Triglava v Julijskih Alpah, visoko nad gozdno mejo. Zaradi višine in severne lege se sneg obdrži globoko v poletje. Snežna odeja se s segrevanjem krajša, bližnji Triglavski ledenik pa se krči. To visokogorje je izvirno območje voda, ki tečejo v porečje Save.",
+            "Trend je 0,30 °C na desetletje ali več: zelo hitro segrevanje, tri ali več stopinj na stoletje. To je najvišja, navzgor odprta kategorija.",
             "Sto let segrevanja za +3,56 °C – pri trenutnem tempu vsakih 28,1 let doda eno stopinjo.",
             "Theil-Sen + Mann-Kendall"
           ],
           "stats": [
-            "Izguba Triglavskega ledenika — izsušitev izvirnih vod za Slovenijo reke",
             "★★★ p < 0,001",
             "0,3560",
             "77 let",
@@ -44790,12 +44790,12 @@
           "headline_color": "rgb(194, 90, 44)",
           "category": "Zelo zaskrbljujoče",
           "paragraphs": [
-            "Podaljšani poletni vročinski valovi presegajo hladilne zmogljivosti mesta. Hudourniške poplave iz okrepljenih alpskih padavin večkrat ogrozijo nizko ležečo kotlino.",
+            "Leži v Ljubljanski kotlini, sklenjeni kotlini med Alpami in kraškim svetom, na jugu ob Ljubljanskem barju. Vbočena lega pozimi ujame hladen zrak, zato so pogosti temperaturni obrati in megla (v povprečju okoli 64 meglenih dni na leto). Ker je kotlina slabo prevetrena, se poletna vročina v njej kopiči in segrevanje se tu izrazi močneje. Podnebje je zmerno celinsko.",
+            "Trend je 0,30 °C na desetletje ali več: zelo hitro segrevanje, tri ali več stopinj na stoletje. To je najvišja, navzgor odprta kategorija.",
             "Sto let segrevanja za +4,88 °C – pri trenutnem tempu vsakih 20,5 let doda eno stopinjo.",
             "Theil-Sen + Mann-Kendall"
           ],
           "stats": [
-            "Mestni toplotni otok — poletni vročinski stres in tveganje hudourniških poplav v Ljubljanski kotlini",
             "★★★ p < 0,001",
             "0,4880",
             "77 let",
@@ -48316,12 +48316,12 @@
           "headline_color": "rgb(194, 90, 44)",
           "category": "Zelo zaskrbljujoče",
           "paragraphs": [
-            "Podaljšani poletni vročinski valovi presegajo hladilne zmogljivosti mesta. Hudourniške poplave iz okrepljenih alpskih padavin večkrat ogrozijo nizko ležečo kotlino.",
+            "Leži v Ljubljanski kotlini, sklenjeni kotlini med Alpami in kraškim svetom, na jugu ob Ljubljanskem barju. Vbočena lega pozimi ujame hladen zrak, zato so pogosti temperaturni obrati in megla (v povprečju okoli 64 meglenih dni na leto). Ker je kotlina slabo prevetrena, se poletna vročina v njej kopiči in segrevanje se tu izrazi močneje. Podnebje je zmerno celinsko.",
+            "Trend je 0,30 °C na desetletje ali več: zelo hitro segrevanje, tri ali več stopinj na stoletje. To je najvišja, navzgor odprta kategorija.",
             "Sto let segrevanja za +4,88 °C – pri trenutnem tempu vsakih 20,5 let doda eno stopinjo.",
             "Theil-Sen + Mann-Kendall"
           ],
           "stats": [
-            "Mestni toplotni otok — poletni vročinski stres in tveganje hudourniških poplav v Ljubljanski kotlini",
             "★★★ p < 0,001",
             "0,4880",
             "77 let",
@@ -51842,12 +51842,12 @@
           "headline_color": "rgb(194, 90, 44)",
           "category": "Zelo zaskrbljujoče",
           "paragraphs": [
-            "Popolna izguba Triglavskega ledenika — narodni simbol in vir savinjskih rek. Propad alpskega ekosistema sproži kaskadne učinke.",
+            "Najvišja meteorološka postaja v Sloveniji stoji na 2514 m na pobočju Triglava v Julijskih Alpah, visoko nad gozdno mejo. Zaradi višine in severne lege se sneg obdrži globoko v poletje. Snežna odeja se s segrevanjem krajša, bližnji Triglavski ledenik pa se krči. To visokogorje je izvirno območje voda, ki tečejo v porečje Save.",
+            "Trend je 0,30 °C na desetletje ali več: zelo hitro segrevanje, tri ali več stopinj na stoletje. To je najvišja, navzgor odprta kategorija.",
             "Sto let segrevanja za +3,12 °C – pri trenutnem tempu vsakih 32,1 let doda eno stopinjo.",
             "Theil-Sen + Mann-Kendall"
           ],
           "stats": [
-            "Izguba Triglavskega ledenika — izsušitev izvirnih vod za Slovenijo reke",
             "★★★ p < 0,001",
             "0,3120",
             "77 let",
@@ -55177,12 +55177,12 @@
           "headline_color": "rgb(194, 90, 44)",
           "category": "Zelo zaskrbljujoče",
           "paragraphs": [
-            "Podaljšani poletni vročinski valovi presegajo hladilne zmogljivosti mesta. Hudourniške poplave iz okrepljenih alpskih padavin večkrat ogrozijo nizko ležečo kotlino.",
+            "Leži v Ljubljanski kotlini, sklenjeni kotlini med Alpami in kraškim svetom, na jugu ob Ljubljanskem barju. Vbočena lega pozimi ujame hladen zrak, zato so pogosti temperaturni obrati in megla (v povprečju okoli 64 meglenih dni na leto). Ker je kotlina slabo prevetrena, se poletna vročina v njej kopiči in segrevanje se tu izrazi močneje. Podnebje je zmerno celinsko.",
+            "Trend je 0,30 °C na desetletje ali več: zelo hitro segrevanje, tri ali več stopinj na stoletje. To je najvišja, navzgor odprta kategorija.",
             "Sto let segrevanja za +4,60 °C – pri trenutnem tempu vsakih 21,7 let doda eno stopinjo.",
             "Theil-Sen + Mann-Kendall"
           ],
           "stats": [
-            "Mestni toplotni otok — poletni vročinski stres in tveganje hudourniških poplav v Ljubljanski kotlini",
             "★★★ p < 0,001",
             "0,4600",
             "77 let",
@@ -58703,12 +58703,12 @@
           "headline_color": "rgb(194, 90, 44)",
           "category": "Zelo zaskrbljujoče",
           "paragraphs": [
-            "Podaljšani poletni vročinski valovi presegajo hladilne zmogljivosti mesta. Hudourniške poplave iz okrepljenih alpskih padavin večkrat ogrozijo nizko ležečo kotlino.",
+            "Leži v Ljubljanski kotlini, sklenjeni kotlini med Alpami in kraškim svetom, na jugu ob Ljubljanskem barju. Vbočena lega pozimi ujame hladen zrak, zato so pogosti temperaturni obrati in megla (v povprečju okoli 64 meglenih dni na leto). Ker je kotlina slabo prevetrena, se poletna vročina v njej kopiči in segrevanje se tu izrazi močneje. Podnebje je zmerno celinsko.",
+            "Trend je 0,30 °C na desetletje ali več: zelo hitro segrevanje, tri ali več stopinj na stoletje. To je najvišja, navzgor odprta kategorija.",
             "Sto let segrevanja za +4,60 °C – pri trenutnem tempu vsakih 21,7 let doda eno stopinjo.",
             "Theil-Sen + Mann-Kendall"
           ],
           "stats": [
-            "Mestni toplotni otok — poletni vročinski stres in tveganje hudourniških poplav v Ljubljanski kotlini",
             "★★★ p < 0,001",
             "0,4600",
             "77 let",
@@ -62229,12 +62229,12 @@
           "headline_color": "rgb(194, 90, 44)",
           "category": "Ekstremno",
           "paragraphs": [
-            "Triglavski ledenik popolnoma izgine. Visokogorski ekosistem nad gozdno mejo propade.",
+            "Najvišja meteorološka postaja v Sloveniji stoji na 2514 m na pobočju Triglava v Julijskih Alpah, visoko nad gozdno mejo. Zaradi višine in severne lege se sneg obdrži globoko v poletje. Snežna odeja se s segrevanjem krajša, bližnji Triglavski ledenik pa se krči. To visokogorje je izvirno območje voda, ki tečejo v porečje Save.",
+            "Trend je med 0,20 in 0,30 °C na desetletje: hitro segrevanje, približno dve do tri stopinje na stoletje.",
             "Sto let segrevanja za +2,23 °C – pri trenutnem tempu vsakih 44,8 let doda eno stopinjo.",
             "Theil-Sen + Mann-Kendall"
           ],
           "stats": [
-            "Izguba Triglavskega ledenika — izsušitev izvirnih vod za Slovenijo reke",
             "★★★ p < 0,001",
             "0,2230",
             "77 let",
@@ -63074,12 +63074,12 @@
           "headline_color": "rgb(194, 90, 44)",
           "category": "Zelo zaskrbljujoče",
           "paragraphs": [
-            "Podaljšani poletni vročinski valovi presegajo hladilne zmogljivosti mesta. Hudourniške poplave iz okrepljenih alpskih padavin večkrat ogrozijo nizko ležečo kotlino.",
+            "Leži v Ljubljanski kotlini, sklenjeni kotlini med Alpami in kraškim svetom, na jugu ob Ljubljanskem barju. Vbočena lega pozimi ujame hladen zrak, zato so pogosti temperaturni obrati in megla (v povprečju okoli 64 meglenih dni na leto). Ker je kotlina slabo prevetrena, se poletna vročina v njej kopiči in segrevanje se tu izrazi močneje. Podnebje je zmerno celinsko.",
+            "Trend je 0,30 °C na desetletje ali več: zelo hitro segrevanje, tri ali več stopinj na stoletje. To je najvišja, navzgor odprta kategorija.",
             "Sto let segrevanja za +5,71 °C – pri trenutnem tempu vsakih 17,5 let doda eno stopinjo.",
             "Theil-Sen + Mann-Kendall"
           ],
           "stats": [
-            "Mestni toplotni otok — poletni vročinski stres in tveganje hudourniških poplav v Ljubljanski kotlini",
             "★★★ p < 0,001",
             "0,5710",
             "77 let",
@@ -63919,12 +63919,12 @@
           "headline_color": "rgb(194, 90, 44)",
           "category": "Zelo zaskrbljujoče",
           "paragraphs": [
-            "Popolna izguba Triglavskega ledenika — narodni simbol in vir savinjskih rek. Propad alpskega ekosistema sproži kaskadne učinke.",
+            "Najvišja meteorološka postaja v Sloveniji stoji na 2514 m na pobočju Triglava v Julijskih Alpah, visoko nad gozdno mejo. Zaradi višine in severne lege se sneg obdrži globoko v poletje. Snežna odeja se s segrevanjem krajša, bližnji Triglavski ledenik pa se krči. To visokogorje je izvirno območje voda, ki tečejo v porečje Save.",
+            "Trend je 0,30 °C na desetletje ali več: zelo hitro segrevanje, tri ali več stopinj na stoletje. To je najvišja, navzgor odprta kategorija.",
             "Sto let segrevanja za +3,76 °C – pri trenutnem tempu vsakih 26,6 let doda eno stopinjo.",
             "Theil-Sen + Mann-Kendall"
           ],
           "stats": [
-            "Izguba Triglavskega ledenika — izsušitev izvirnih vod za Slovenijo reke",
             "★★★ p < 0,001",
             "0,3760",
             "77 let",
@@ -64715,12 +64715,12 @@
           "headline_color": "rgb(194, 90, 44)",
           "category": "Zelo zaskrbljujoče",
           "paragraphs": [
-            "Podaljšani poletni vročinski valovi presegajo hladilne zmogljivosti mesta. Hudourniške poplave iz okrepljenih alpskih padavin večkrat ogrozijo nizko ležečo kotlino.",
+            "Leži v Ljubljanski kotlini, sklenjeni kotlini med Alpami in kraškim svetom, na jugu ob Ljubljanskem barju. Vbočena lega pozimi ujame hladen zrak, zato so pogosti temperaturni obrati in megla (v povprečju okoli 64 meglenih dni na leto). Ker je kotlina slabo prevetrena, se poletna vročina v njej kopiči in segrevanje se tu izrazi močneje. Podnebje je zmerno celinsko.",
+            "Trend je 0,30 °C na desetletje ali več: zelo hitro segrevanje, tri ali več stopinj na stoletje. To je najvišja, navzgor odprta kategorija.",
             "Sto let segrevanja za +5,71 °C – pri trenutnem tempu vsakih 17,5 let doda eno stopinjo.",
             "Theil-Sen + Mann-Kendall"
           ],
           "stats": [
-            "Mestni toplotni otok — poletni vročinski stres in tveganje hudourniških poplav v Ljubljanski kotlini",
             "★★★ p < 0,001",
             "0,5710",
             "77 let",
@@ -68223,12 +68223,12 @@
           "headline_color": "rgb(194, 90, 44)",
           "category": "Zelo zaskrbljujoče",
           "paragraphs": [
-            "Podaljšani poletni vročinski valovi presegajo hladilne zmogljivosti mesta. Hudourniške poplave iz okrepljenih alpskih padavin večkrat ogrozijo nizko ležečo kotlino.",
+            "Leži v Ljubljanski kotlini, sklenjeni kotlini med Alpami in kraškim svetom, na jugu ob Ljubljanskem barju. Vbočena lega pozimi ujame hladen zrak, zato so pogosti temperaturni obrati in megla (v povprečju okoli 64 meglenih dni na leto). Ker je kotlina slabo prevetrena, se poletna vročina v njej kopiči in segrevanje se tu izrazi močneje. Podnebje je zmerno celinsko.",
+            "Trend je 0,30 °C na desetletje ali več: zelo hitro segrevanje, tri ali več stopinj na stoletje. To je najvišja, navzgor odprta kategorija.",
             "Sto let segrevanja za +5,57 °C – pri trenutnem tempu vsakih 18,0 let doda eno stopinjo.",
             "Theil-Sen + Mann-Kendall"
           ],
           "stats": [
-            "Mestni toplotni otok — poletni vročinski stres in tveganje hudourniških poplav v Ljubljanski kotlini",
             "★★★ p < 0,001",
             "0,5570",
             "77 let",
@@ -71749,12 +71749,12 @@
           "headline_color": "rgb(194, 90, 44)",
           "category": "Zelo zaskrbljujoče",
           "paragraphs": [
-            "Podaljšani poletni vročinski valovi presegajo hladilne zmogljivosti mesta. Hudourniške poplave iz okrepljenih alpskih padavin večkrat ogrozijo nizko ležečo kotlino.",
+            "Leži v Ljubljanski kotlini, sklenjeni kotlini med Alpami in kraškim svetom, na jugu ob Ljubljanskem barju. Vbočena lega pozimi ujame hladen zrak, zato so pogosti temperaturni obrati in megla (v povprečju okoli 64 meglenih dni na leto). Ker je kotlina slabo prevetrena, se poletna vročina v njej kopiči in segrevanje se tu izrazi močneje. Podnebje je zmerno celinsko.",
+            "Trend je 0,30 °C na desetletje ali več: zelo hitro segrevanje, tri ali več stopinj na stoletje. To je najvišja, navzgor odprta kategorija.",
             "Sto let segrevanja za +5,71 °C – pri trenutnem tempu vsakih 17,5 let doda eno stopinjo.",
             "Theil-Sen + Mann-Kendall"
           ],
           "stats": [
-            "Mestni toplotni otok — poletni vročinski stres in tveganje hudourniških poplav v Ljubljanski kotlini",
             "★★★ p < 0,001",
             "0,5710",
             "77 let",
@@ -75275,12 +75275,12 @@
           "headline_color": "rgb(194, 90, 44)",
           "category": "Zelo zaskrbljujoče",
           "paragraphs": [
-            "Podaljšani poletni vročinski valovi presegajo hladilne zmogljivosti mesta. Hudourniške poplave iz okrepljenih alpskih padavin večkrat ogrozijo nizko ležečo kotlino.",
+            "Leži v Ljubljanski kotlini, sklenjeni kotlini med Alpami in kraškim svetom, na jugu ob Ljubljanskem barju. Vbočena lega pozimi ujame hladen zrak, zato so pogosti temperaturni obrati in megla (v povprečju okoli 64 meglenih dni na leto). Ker je kotlina slabo prevetrena, se poletna vročina v njej kopiči in segrevanje se tu izrazi močneje. Podnebje je zmerno celinsko.",
+            "Trend je 0,30 °C na desetletje ali več: zelo hitro segrevanje, tri ali več stopinj na stoletje. To je najvišja, navzgor odprta kategorija.",
             "Sto let segrevanja za +5,57 °C – pri trenutnem tempu vsakih 18,0 let doda eno stopinjo.",
             "Theil-Sen + Mann-Kendall"
           ],
           "stats": [
-            "Mestni toplotni otok — poletni vročinski stres in tveganje hudourniških poplav v Ljubljanski kotlini",
             "★★★ p < 0,001",
             "0,5570",
             "77 let",
@@ -78801,12 +78801,12 @@
           "headline_color": "rgb(194, 90, 44)",
           "category": "Zelo zaskrbljujoče",
           "paragraphs": [
-            "Podaljšani poletni vročinski valovi presegajo hladilne zmogljivosti mesta. Hudourniške poplave iz okrepljenih alpskih padavin večkrat ogrozijo nizko ležečo kotlino.",
+            "Leži v Ljubljanski kotlini, sklenjeni kotlini med Alpami in kraškim svetom, na jugu ob Ljubljanskem barju. Vbočena lega pozimi ujame hladen zrak, zato so pogosti temperaturni obrati in megla (v povprečju okoli 64 meglenih dni na leto). Ker je kotlina slabo prevetrena, se poletna vročina v njej kopiči in segrevanje se tu izrazi močneje. Podnebje je zmerno celinsko.",
+            "Trend je 0,30 °C na desetletje ali več: zelo hitro segrevanje, tri ali več stopinj na stoletje. To je najvišja, navzgor odprta kategorija.",
             "Sto let segrevanja za +4,84 °C – pri trenutnem tempu vsakih 20,7 let doda eno stopinjo.",
             "Theil-Sen + Mann-Kendall"
           ],
           "stats": [
-            "Mestni toplotni otok — poletni vročinski stres in tveganje hudourniških poplav v Ljubljanski kotlini",
             "★★★ p < 0,001",
             "0,4840",
             "77 let",
@@ -82311,12 +82311,12 @@
           "headline_color": "rgb(194, 90, 44)",
           "category": "Zelo zaskrbljujoče",
           "paragraphs": [
-            "Podaljšani poletni vročinski valovi presegajo hladilne zmogljivosti mesta. Hudourniške poplave iz okrepljenih alpskih padavin večkrat ogrozijo nizko ležečo kotlino.",
+            "Leži v Ljubljanski kotlini, sklenjeni kotlini med Alpami in kraškim svetom, na jugu ob Ljubljanskem barju. Vbočena lega pozimi ujame hladen zrak, zato so pogosti temperaturni obrati in megla (v povprečju okoli 64 meglenih dni na leto). Ker je kotlina slabo prevetrena, se poletna vročina v njej kopiči in segrevanje se tu izrazi močneje. Podnebje je zmerno celinsko.",
+            "Trend je 0,30 °C na desetletje ali več: zelo hitro segrevanje, tri ali več stopinj na stoletje. To je najvišja, navzgor odprta kategorija.",
             "Sto let segrevanja za +5,13 °C – pri trenutnem tempu vsakih 19,5 let doda eno stopinjo.",
             "Theil-Sen + Mann-Kendall"
           ],
           "stats": [
-            "Mestni toplotni otok — poletni vročinski stres in tveganje hudourniških poplav v Ljubljanski kotlini",
             "★★★ p < 0,001",
             "0,5130",
             "76 let",
@@ -85829,12 +85829,12 @@
           "headline_color": "rgb(194, 90, 44)",
           "category": "Zelo zaskrbljujoče",
           "paragraphs": [
-            "Podaljšani poletni vročinski valovi presegajo hladilne zmogljivosti mesta. Hudourniške poplave iz okrepljenih alpskih padavin večkrat ogrozijo nizko ležečo kotlino.",
+            "Leži v Ljubljanski kotlini, sklenjeni kotlini med Alpami in kraškim svetom, na jugu ob Ljubljanskem barju. Vbočena lega pozimi ujame hladen zrak, zato so pogosti temperaturni obrati in megla (v povprečju okoli 64 meglenih dni na leto). Ker je kotlina slabo prevetrena, se poletna vročina v njej kopiči in segrevanje se tu izrazi močneje. Podnebje je zmerno celinsko.",
+            "Trend je 0,30 °C na desetletje ali več: zelo hitro segrevanje, tri ali več stopinj na stoletje. To je najvišja, navzgor odprta kategorija.",
             "Sto let segrevanja za +4,12 °C – pri trenutnem tempu vsakih 24,3 let doda eno stopinjo.",
             "Theil-Sen + Mann-Kendall"
           ],
           "stats": [
-            "Mestni toplotni otok — poletni vročinski stres in tveganje hudourniških poplav v Ljubljanski kotlini",
             "★★★ p < 0,001",
             "0,4120",
             "76 let",
@@ -89347,12 +89347,12 @@
           "headline_color": "rgb(194, 90, 44)",
           "category": "Ekstremno",
           "paragraphs": [
-            "Triglavski ledenik popolnoma izgine. Visokogorski ekosistem nad gozdno mejo propade.",
+            "Najvišja meteorološka postaja v Sloveniji stoji na 2514 m na pobočju Triglava v Julijskih Alpah, visoko nad gozdno mejo. Zaradi višine in severne lege se sneg obdrži globoko v poletje. Snežna odeja se s segrevanjem krajša, bližnji Triglavski ledenik pa se krči. To visokogorje je izvirno območje voda, ki tečejo v porečje Save.",
+            "Trend je med 0,20 in 0,30 °C na desetletje: hitro segrevanje, približno dve do tri stopinje na stoletje.",
             "Sto let segrevanja za +2,69 °C – pri trenutnem tempu vsakih 37,2 let doda eno stopinjo.",
             "Theil-Sen + Mann-Kendall"
           ],
           "stats": [
-            "Izguba Triglavskega ledenika — izsušitev izvirnih vod za Slovenijo reke",
             "★★★ p < 0,001",
             "0,2690",
             "76 let",
@@ -92881,12 +92881,12 @@
           "headline_color": "rgb(194, 90, 44)",
           "category": "Zelo zaskrbljujoče",
           "paragraphs": [
-            "Podaljšani poletni vročinski valovi presegajo hladilne zmogljivosti mesta. Hudourniške poplave iz okrepljenih alpskih padavin večkrat ogrozijo nizko ležečo kotlino.",
+            "Leži v Ljubljanski kotlini, sklenjeni kotlini med Alpami in kraškim svetom, na jugu ob Ljubljanskem barju. Vbočena lega pozimi ujame hladen zrak, zato so pogosti temperaturni obrati in megla (v povprečju okoli 64 meglenih dni na leto). Ker je kotlina slabo prevetrena, se poletna vročina v njej kopiči in segrevanje se tu izrazi močneje. Podnebje je zmerno celinsko.",
+            "Trend je 0,30 °C na desetletje ali več: zelo hitro segrevanje, tri ali več stopinj na stoletje. To je najvišja, navzgor odprta kategorija.",
             "Sto let segrevanja za +5,69 °C – pri trenutnem tempu vsakih 17,6 let doda eno stopinjo.",
             "Theil-Sen + Mann-Kendall"
           ],
           "stats": [
-            "Mestni toplotni otok — poletni vročinski stres in tveganje hudourniških poplav v Ljubljanski kotlini",
             "★★★ p < 0,001",
             "0,5690",
             "77 let",
@@ -96420,12 +96420,12 @@
           "headline_color": "rgb(194, 90, 44)",
           "category": "Zelo zaskrbljujoče",
           "paragraphs": [
-            "Popolna izguba Triglavskega ledenika — narodni simbol in vir savinjskih rek. Propad alpskega ekosistema sproži kaskadne učinke.",
+            "Najvišja meteorološka postaja v Sloveniji stoji na 2514 m na pobočju Triglava v Julijskih Alpah, visoko nad gozdno mejo. Zaradi višine in severne lege se sneg obdrži globoko v poletje. Snežna odeja se s segrevanjem krajša, bližnji Triglavski ledenik pa se krči. To visokogorje je izvirno območje voda, ki tečejo v porečje Save.",
+            "Trend je 0,30 °C na desetletje ali več: zelo hitro segrevanje, tri ali več stopinj na stoletje. To je najvišja, navzgor odprta kategorija.",
             "Sto let segrevanja za +5,40 °C – pri trenutnem tempu vsakih 18,5 let doda eno stopinjo.",
             "Theil-Sen + Mann-Kendall"
           ],
           "stats": [
-            "Izguba Triglavskega ledenika — izsušitev izvirnih vod za Slovenijo reke",
             "★★★ p < 0,001",
             "0,5400",
             "77 let",


### PR DESCRIPTION
Replaces the 108 editorial strings behind the location card with **23**: one description per station, one explanation per trend category.

**Why the 90 narratives went.** They entered in a single commit, were never content-edited, and read as machine-translated English. Five contained non-words (`savenice`, `stletni`, `toleranče`, `tradiconalno`, `pastuje`) that no codepoint scan could catch, being plain-Latin misspellings. Seven were factually wrong: Kranj placed at the foot of the wrong range and called the gateway to a park in the other direction, glaciers asserted in a range that has none, Triglav described as the source of the Savinja rather than the Sava, Rateče placed in a valley in **Italy**, Ilirska Bistrica put on the wrong river, and two superlatives nobody could source.

**⚠ But the deeper problem was the escalation itself.** The five bands were not variations on a theme: each asserted more than the last, ending in hydropower failing, crop yields down 20–30%, mortality rising, a ski economy ending and the national grid at risk. **All uncited, on a page whose whole argument is that its claims are checkable.**

**What replaces them.** Each station now gets one description with a three-part shape: the **physical setting**, the **variable warming acts on there**, and — only where place-specifically sourced — **flood or landslide susceptibility**. Each band gets one shared explanation stating what the trend rate means in °C per decade and per century, since the bands are a property of the trend rather than of the place.

**The discipline that made it work, and it is worth keeping:** a sentence falsifiable by a **map** is in; a sentence falsifiable by a **future event** is out. So a narrow valley concentrating heat is in, and heatwaves threatening residents is not. Snow-fed rivers being sensitive to warmer winters is in; hydropower output falling is not.

**Susceptibility was not inferred from terrain.** It is asserted for **three** stations only — Celje (Savinja flood-hazard mapping), Tolmin (torrential Soča) and Nova Gorica (Brda flysch landslides) — each sourced, and explicitly withheld for open plains and basin floors with the reason stated.

**⚠ One known gap, deliberately left.** Torrential flooding in the Ljubljana basin is a real exposure, but no place-specific source was found the way it was for the Savinja, so **it is absent rather than inferred**. Someone with a source should add it; that absence is a choice, not an oversight.

**The 18 per-station risk labels are removed entirely.** They read as correct because AI-generated prose usually does, but nearly every one named an **outcome** rather than an exposure, two were factually wrong (Novo Mesto repeating the hops error, hops being the Savinja valley rather than Dolenjska; Ilirska Bistrica naming the Pivka when the town is on the Reka), and **nobody had a source for any of them**.

**Snapshot: 21 of 21 cases move, and no number does.** After stripping the intended prose swap, every remaining data leaf is an **identical multiset** old versus new — the diff is positional (paragraphs 3→4, stats 5→4), not a change in value.

**⚠ Only 2 of 18 stations and 2 of 5 bands are snapshot-covered.** Sixteen descriptions and three category texts have never been rendered. This needs a preview and an eyeball pass.

**⚠ And a layout consequence for whoever owns the card:** removing the risk block leaves the fixed 240px left column about 60px shorter while the right column grew, so at desktop the left column now has a large empty area under the trend figure. At 390px the columns stack and it reads fine. **Flagged, not restyled.**

Gates: typecheck 0 · typecheck:gate 0 allowlisted · yarn test 100 incl. text-integrity · snapshot:check identical after re-record · pytest 77.
